### PR TITLE
Implement const generics take 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,10 @@ on:
 
 jobs:
   rust-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Run cargo test

--- a/crates/formality-check/src/lib.rs
+++ b/crates/formality-check/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::collections::VecDeque;
+use std::{collections::VecDeque, fmt::Debug};
 
 use anyhow::bail;
 use formality_prove::{Decls, Env};
@@ -86,7 +86,12 @@ impl Check<'_> {
         }
     }
 
-    fn prove_goal(&self, env: &Env, assumptions: impl ToWcs, goal: impl ToWcs) -> Fallible<()> {
+    fn prove_goal(
+        &self,
+        env: &Env,
+        assumptions: impl ToWcs,
+        goal: impl ToWcs + Debug,
+    ) -> Fallible<()> {
         let goal: Wcs = goal.to_wcs();
         let assumptions: Wcs = assumptions.to_wcs();
 
@@ -101,7 +106,12 @@ impl Check<'_> {
         bail!("failed to prove {goal:?} given {assumptions:?}, got {cs:?}")
     }
 
-    fn prove_not_goal(&self, env: &Env, assumptions: impl ToWcs, goal: impl ToWcs) -> Fallible<()> {
+    fn prove_not_goal(
+        &self,
+        env: &Env,
+        assumptions: impl ToWcs,
+        goal: impl ToWcs + Debug,
+    ) -> Fallible<()> {
         let goal: Wcs = goal.to_wcs();
         let assumptions: Wcs = assumptions.to_wcs();
 

--- a/crates/formality-check/src/where_clauses.rs
+++ b/crates/formality-check/src/where_clauses.rs
@@ -1,3 +1,4 @@
+use fn_error_context::context;
 use formality_prove::Env;
 use formality_rust::{
     grammar::{WhereClause, WhereClauseData},
@@ -21,6 +22,7 @@ impl super::Check<'_> {
         Ok(())
     }
 
+    #[context("prove_where_clauses_well_formed({where_clause:?})")]
     fn prove_where_clause_well_formed(
         &self,
         in_env: &Env,

--- a/crates/formality-check/src/where_clauses.rs
+++ b/crates/formality-check/src/where_clauses.rs
@@ -22,7 +22,7 @@ impl super::Check<'_> {
         Ok(())
     }
 
-    #[context("prove_where_clauses_well_formed({where_clause:?})")]
+    #[context("prove_where_clause_well_formed({where_clause:?})")]
     fn prove_where_clause_well_formed(
         &self,
         in_env: &Env,
@@ -44,6 +44,10 @@ impl super::Check<'_> {
                 let mut e = in_env.clone();
                 let wc = e.instantiate_universally(binder);
                 self.prove_where_clause_well_formed(&e, assumptions, &wc)
+            }
+            WhereClauseData::TypeOfConst(ct, ty) => {
+                self.prove_parameter_well_formed(in_env, &assumptions, ct.clone())?;
+                self.prove_parameter_well_formed(in_env, assumptions, ty.clone())
             }
         }
     }

--- a/crates/formality-macros/src/test.rs
+++ b/crates/formality-macros/src/test.rs
@@ -1,15 +1,11 @@
 use proc_macro::TokenStream;
-use quote::quote;
 
 pub(crate) fn test(_args: TokenStream, mut item_fn: syn::ItemFn) -> syn::Result<syn::ItemFn> {
     let original_fn_body = item_fn.block.clone();
-    item_fn.block = syn::parse2(quote! {
-        {
-            formality_core::with_tracing_logs(move || {
-                #original_fn_body
-            })
-        }
-    })
-    .unwrap();
+    item_fn.block = syn::parse_quote!({
+        formality_core::with_tracing_logs(move || {
+            #original_fn_body
+        })
+    });
     Ok(item_fn)
 }

--- a/crates/formality-prove/src/prove/prove_wc.rs
+++ b/crates/formality-prove/src/prove/prove_wc.rs
@@ -116,8 +116,8 @@ judgment_fn! {
         )
 
         (
-            (if ct.as_value().is_some())
-            (prove(decls, env, assumptions, Wcs::all_eq(vec![ct.as_value().unwrap().1], vec![ty])) => c)
+            (if let Some((_, const_ty)) = ct.as_value())
+            (prove(decls, env, assumptions, Wcs::all_eq(vec![const_ty], vec![ty])) => c)
             ----------------------------- ("const has ty")
             (prove_wc(decls, env, assumptions, Predicate::ConstHasType(ct, ty)) => c)
         )

--- a/crates/formality-prove/src/prove/prove_wc.rs
+++ b/crates/formality-prove/src/prove/prove_wc.rs
@@ -114,5 +114,12 @@ judgment_fn! {
             ----------------------------- ("trait ref is local")
             (prove_wc(decls, env, assumptions, Relation::WellFormed(p)) => c)
         )
+
+        (
+            (if ct.as_value().is_some())
+            (prove(decls, env, assumptions, Wcs::all_eq(vec![ct.as_value().unwrap().1], vec![ty])) => c)
+            ----------------------------- ("const has ty")
+            (prove_wc(decls, env, assumptions, Predicate::ConstHasType(ct, ty)) => c)
+        )
     }
 }

--- a/crates/formality-prove/src/prove/prove_wf.rs
+++ b/crates/formality-prove/src/prove/prove_wf.rs
@@ -1,5 +1,5 @@
 use formality_types::{
-    grammar::{Parameter, RigidName, RigidTy, UniversalVar, Wcs},
+    grammar::{ConstData, Parameter, RigidName, RigidTy, UniversalVar, Wcs},
     judgment_fn,
 };
 
@@ -37,6 +37,12 @@ judgment_fn! {
             (for_all(&decls, &env, &assumptions, &parameters, &prove_wf) => c)
             --- ("integers and booleans")
             (prove_wf(decls, env, assumptions, RigidTy { name: RigidName::ScalarId(_), parameters }) => c)
+        )
+
+        (
+            (prove_wf(&decls, &env, &assumptions, ty) => c)
+            --- ("rigid constants")
+            (prove_wf(decls, env, assumptions, ConstData::Value(_, ty)) => c)
         )
     }
 }

--- a/crates/formality-prove/src/prove/prove_wf.rs
+++ b/crates/formality-prove/src/prove/prove_wf.rs
@@ -32,5 +32,11 @@ judgment_fn! {
             --- ("tuples")
             (prove_wf(decls, env, assumptions, RigidTy { name: RigidName::Tuple(_), parameters }) => c)
         )
+
+        (
+            (for_all(&decls, &env, &assumptions, &parameters, &prove_wf) => c)
+            --- ("integers and booleans")
+            (prove_wf(decls, env, assumptions, RigidTy { name: RigidName::ScalarId(_), parameters }) => c)
+        )
     }
 }

--- a/crates/formality-rust/src/grammar.rs
+++ b/crates/formality-rust/src/grammar.rs
@@ -4,8 +4,8 @@ use formality_macros::term;
 use formality_types::{
     cast::Upcast,
     grammar::{
-        AdtId, AssociatedItemId, Binder, CrateId, Fallible, FieldId, FnId, Lt, Parameter, TraitId,
-        TraitRef, Ty, Wc,
+        AdtId, AssociatedItemId, Binder, Const, CrateId, Fallible, FieldId, FnId, Lt, Parameter,
+        TraitId, TraitRef, Ty, Wc,
     },
     term::Term,
 };
@@ -331,6 +331,7 @@ impl WhereClause {
                 let wc = where_clause.invert()?;
                 Some(Wc::for_all(&vars, wc))
             }
+            WhereClauseData::TypeOfConst(_, _) => None,
         }
     }
 }
@@ -345,6 +346,9 @@ pub enum WhereClauseData {
 
     #[grammar(for $v0)]
     ForAll(Binder<WhereClause>),
+
+    #[grammar(type_of_const $v0 is $v1)]
+    TypeOfConst(Const, Ty),
 }
 
 #[term($data)]

--- a/crates/formality-rust/src/prove.rs
+++ b/crates/formality-rust/src/prove.rs
@@ -9,8 +9,8 @@ use formality_types::{
     cast::{To, Upcast, Upcasted},
     collections::Set,
     grammar::{
-        fresh_bound_var, AdtId, AliasTy, Binder, ConstData, ParameterKind, Predicate, Relation,
-        TraitId, Ty, Wc, Wcs, PR,
+        fresh_bound_var, AdtId, AliasTy, Binder, ParameterKind, Predicate, Relation, TraitId, Ty,
+        Wc, Wcs, PR,
     },
     seq,
 };
@@ -386,12 +386,9 @@ impl ToWcs for WhereClause {
                     .map(|wc| Wc::for_all(&vars, wc))
                     .collect()
             }
-            WhereClauseData::TypeOfConst(ct, ty) => match ct.data() {
-                // Concrete constants must have equal types
-                ConstData::Value(_, t) => Relation::eq(ty, t).upcast(),
-                // Generic constants must have where bounds constraining their type
-                ConstData::Variable(_) => Predicate::ConstHasType(ct.clone(), ty.clone()).upcast(),
-            },
+            WhereClauseData::TypeOfConst(ct, ty) => {
+                Predicate::ConstHasType(ct.clone(), ty.clone()).upcast()
+            }
         }
     }
 }

--- a/crates/formality-rust/src/prove.rs
+++ b/crates/formality-rust/src/prove.rs
@@ -386,6 +386,9 @@ impl ToWcs for WhereClause {
                     .map(|wc| Wc::for_all(&vars, wc))
                     .collect()
             }
+            WhereClauseData::TypeOfConst(ct, ty) => {
+                Predicate::ConstHasType(ct.clone(), ty.clone()).upcast()
+            }
         }
     }
 }

--- a/crates/formality-rust/src/prove.rs
+++ b/crates/formality-rust/src/prove.rs
@@ -9,8 +9,8 @@ use formality_types::{
     cast::{To, Upcast, Upcasted},
     collections::Set,
     grammar::{
-        fresh_bound_var, AdtId, AliasTy, Binder, ParameterKind, Predicate, Relation, TraitId, Ty,
-        Wc, Wcs, PR,
+        fresh_bound_var, AdtId, AliasTy, Binder, ConstData, ParameterKind, Predicate, Relation,
+        TraitId, Ty, Wc, Wcs, PR,
     },
     seq,
 };
@@ -386,9 +386,12 @@ impl ToWcs for WhereClause {
                     .map(|wc| Wc::for_all(&vars, wc))
                     .collect()
             }
-            WhereClauseData::TypeOfConst(ct, ty) => {
-                Predicate::ConstHasType(ct.clone(), ty.clone()).upcast()
-            }
+            WhereClauseData::TypeOfConst(ct, ty) => match ct.data() {
+                // Concrete constants must have equal types
+                ConstData::Value(_, t) => Relation::eq(ty, t).upcast(),
+                // Generic constants must have where bounds constraining their type
+                ConstData::Variable(_) => Predicate::ConstHasType(ct.clone(), ty.clone()).upcast(),
+            },
         }
     }
 }

--- a/crates/formality-types/src/fold.rs
+++ b/crates/formality-types/src/fold.rs
@@ -76,7 +76,10 @@ impl Fold for Ty {
 impl Fold for Const {
     fn substitute(&self, substitution_fn: SubstitutionFn<'_>) -> Self {
         match self.data() {
-            ConstData::Value(v) => Self::new(v.substitute(substitution_fn)),
+            ConstData::Value(v, ty) => Self::valtree(
+                v.substitute(substitution_fn),
+                ty.substitute(substitution_fn),
+            ),
             ConstData::Variable(v) => match substitution_fn(v.clone()) {
                 None => self.clone(),
                 Some(Parameter::Const(c)) => c,

--- a/crates/formality-types/src/fold.rs
+++ b/crates/formality-types/src/fold.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::{
     cast::Upcast,
     collections::Set,
-    grammar::{Lt, LtData, Parameter, Ty, TyData, Variable},
+    grammar::{Const, ConstData, Lt, LtData, Parameter, Ty, TyData, ValTree, Variable},
     visit::Visit,
 };
 
@@ -70,6 +70,25 @@ impl Fold for Ty {
                 Some(param) => panic!("ill-kinded substitute: expected type, got {param:?}"),
             },
         }
+    }
+}
+
+impl Fold for Const {
+    fn substitute(&self, substitution_fn: SubstitutionFn<'_>) -> Self {
+        match self.data() {
+            ConstData::Value(v) => Self::new(v.substitute(substitution_fn)),
+            ConstData::Variable(v) => match substitution_fn(v.clone()) {
+                None => self.clone(),
+                Some(Parameter::Const(c)) => c,
+                Some(param) => panic!("ill-kinded substitute: expected const, got {param:?}"),
+            },
+        }
+    }
+}
+
+impl Fold for ValTree {
+    fn substitute(&self, _substitution_fn: SubstitutionFn<'_>) -> Self {
+        self.clone()
     }
 }
 

--- a/crates/formality-types/src/grammar.rs
+++ b/crates/formality-types/src/grammar.rs
@@ -1,4 +1,5 @@
 mod binder;
+mod consts;
 mod formulas;
 mod ids;
 mod kinded;
@@ -6,6 +7,7 @@ mod ty;
 mod wc;
 
 pub use binder::*;
+pub use consts::*;
 pub use formulas::*;
 pub use ids::*;
 pub use kinded::*;

--- a/crates/formality-types/src/grammar/consts.rs
+++ b/crates/formality-types/src/grammar/consts.rs
@@ -1,0 +1,68 @@
+mod valtree;
+
+use crate::cast::{Upcast, UpcastFrom};
+
+use super::{Parameter, Variable};
+use formality_macros::{term, Visit};
+use std::sync::Arc;
+pub use valtree::*;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Visit)]
+pub struct Const {
+    data: Arc<ConstData>,
+}
+impl Const {
+    pub fn data(&self) -> &ConstData {
+        &self.data
+    }
+
+    pub fn new(data: impl Upcast<ConstData>) -> Self {
+        Self {
+            data: Arc::new(data.upcast()),
+        }
+    }
+    pub fn as_variable(&self) -> Option<Variable> {
+        match self.data() {
+            ConstData::Value(_) => None,
+            ConstData::Variable(var) => Some(var.clone()),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Visit)]
+pub enum ConstData {
+    Value(ValTree),
+    Variable(Variable),
+}
+
+#[term]
+pub enum Bool {
+    #[grammar(true)]
+    True,
+    #[grammar(false)]
+    False,
+}
+
+impl UpcastFrom<Bool> for Const {
+    fn upcast_from(term: Bool) -> Self {
+        Self::new(ValTree::upcast_from(term))
+    }
+}
+
+impl UpcastFrom<ValTree> for ConstData {
+    fn upcast_from(v: ValTree) -> Self {
+        Self::Value(v)
+    }
+}
+
+impl UpcastFrom<Variable> for ConstData {
+    fn upcast_from(v: Variable) -> Self {
+        Self::Variable(v)
+    }
+}
+
+impl UpcastFrom<Const> for Parameter {
+    fn upcast_from(term: Const) -> Self {
+        Self::Const(term)
+    }
+}

--- a/crates/formality-types/src/grammar/consts.rs
+++ b/crates/formality-types/src/grammar/consts.rs
@@ -1,6 +1,6 @@
 mod valtree;
 
-use crate::cast::{Upcast, UpcastFrom};
+use crate::cast::{DowncastTo, Upcast, UpcastFrom};
 
 use super::{Parameter, Ty, Variable};
 use formality_macros::{term, Visit};
@@ -50,6 +50,28 @@ pub enum ConstData {
 impl UpcastFrom<Self> for ConstData {
     fn upcast_from(term: Self) -> Self {
         term
+    }
+}
+
+impl DowncastTo<ConstData> for Const {
+    fn downcast_to(&self) -> Option<ConstData> {
+        Some(self.data().clone())
+    }
+}
+
+impl DowncastTo<Const> for Parameter {
+    fn downcast_to(&self) -> Option<Const> {
+        match self {
+            Parameter::Ty(_) | Parameter::Lt(_) => None,
+            Parameter::Const(c) => Some(c.clone()),
+        }
+    }
+}
+
+impl DowncastTo<ConstData> for Parameter {
+    fn downcast_to(&self) -> Option<ConstData> {
+        let c: Const = self.downcast_to()?;
+        c.downcast_to()
     }
 }
 

--- a/crates/formality-types/src/grammar/consts.rs
+++ b/crates/formality-types/src/grammar/consts.rs
@@ -32,6 +32,13 @@ impl Const {
             ConstData::Variable(var) => Some(var.clone()),
         }
     }
+
+    pub fn as_value(&self) -> Option<(ValTree, Ty)> {
+        match self.data() {
+            ConstData::Value(v, t) => Some((v.clone(), t.clone())),
+            ConstData::Variable(_) => None,
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Visit)]

--- a/crates/formality-types/src/grammar/consts.rs
+++ b/crates/formality-types/src/grammar/consts.rs
@@ -2,7 +2,7 @@ mod valtree;
 
 use crate::cast::{Upcast, UpcastFrom};
 
-use super::{Parameter, Variable};
+use super::{Parameter, Ty, Variable};
 use formality_macros::{term, Visit};
 use std::sync::Arc;
 pub use valtree::*;
@@ -21,9 +21,14 @@ impl Const {
             data: Arc::new(data.upcast()),
         }
     }
+
+    pub fn valtree(vt: impl Upcast<ValTree>, ty: impl Upcast<Ty>) -> Self {
+        Self::new(ConstData::Value(vt.upcast(), ty.upcast()))
+    }
+
     pub fn as_variable(&self) -> Option<Variable> {
         match self.data() {
-            ConstData::Value(_) => None,
+            ConstData::Value(_, _) => None,
             ConstData::Variable(var) => Some(var.clone()),
         }
     }
@@ -31,8 +36,14 @@ impl Const {
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Visit)]
 pub enum ConstData {
-    Value(ValTree),
+    Value(ValTree, Ty),
     Variable(Variable),
+}
+
+impl UpcastFrom<Self> for ConstData {
+    fn upcast_from(term: Self) -> Self {
+        term
+    }
 }
 
 #[term]
@@ -45,13 +56,7 @@ pub enum Bool {
 
 impl UpcastFrom<Bool> for Const {
     fn upcast_from(term: Bool) -> Self {
-        Self::new(ValTree::upcast_from(term))
-    }
-}
-
-impl UpcastFrom<ValTree> for ConstData {
-    fn upcast_from(v: ValTree) -> Self {
-        Self::Value(v)
+        Self::new(ConstData::Value(term.upcast(), Ty::bool()))
     }
 }
 

--- a/crates/formality-types/src/grammar/consts/valtree.rs
+++ b/crates/formality-types/src/grammar/consts/valtree.rs
@@ -2,7 +2,7 @@ use formality_macros::Visit;
 
 use crate::cast::{Upcast, UpcastFrom};
 
-use super::{Bool, ConstData};
+use super::Bool;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Visit)]
 pub enum ValTree {
@@ -48,9 +48,9 @@ impl UpcastFrom<Scalar> for ValTree {
     }
 }
 
-impl UpcastFrom<Scalar> for ConstData {
-    fn upcast_from(s: Scalar) -> Self {
-        ValTree::upcast_from(s).upcast()
+impl UpcastFrom<Self> for ValTree {
+    fn upcast_from(s: Self) -> Self {
+        s
     }
 }
 

--- a/crates/formality-types/src/grammar/consts/valtree.rs
+++ b/crates/formality-types/src/grammar/consts/valtree.rs
@@ -1,0 +1,61 @@
+use formality_macros::Visit;
+
+use crate::cast::{Upcast, UpcastFrom};
+
+use super::{Bool, ConstData};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Visit)]
+pub enum ValTree {
+    Leaf(Scalar),
+    Branches(Vec<ValTree>),
+}
+
+impl std::fmt::Debug for ValTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Leaf(s) => s.fmt(f),
+            Self::Branches(branches) => branches.fmt(f),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Visit)]
+pub struct Scalar {
+    bits: u128,
+}
+
+impl std::fmt::Debug for Scalar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.bits.fmt(f)
+    }
+}
+
+impl Scalar {
+    pub fn new(bits: u128) -> Self {
+        Self { bits }
+    }
+}
+
+impl UpcastFrom<Bool> for ValTree {
+    fn upcast_from(term: Bool) -> Self {
+        Scalar::upcast_from(term).upcast()
+    }
+}
+
+impl UpcastFrom<Scalar> for ValTree {
+    fn upcast_from(s: Scalar) -> Self {
+        Self::Leaf(s)
+    }
+}
+
+impl UpcastFrom<Scalar> for ConstData {
+    fn upcast_from(s: Scalar) -> Self {
+        ValTree::upcast_from(s).upcast()
+    }
+}
+
+impl UpcastFrom<Bool> for Scalar {
+    fn upcast_from(term: Bool) -> Self {
+        Scalar { bits: term as u128 }
+    }
+}

--- a/crates/formality-types/src/grammar/formulas.rs
+++ b/crates/formality-types/src/grammar/formulas.rs
@@ -93,6 +93,7 @@ pub enum Skeleton {
 impl Predicate {
     /// Separate an atomic predicate into the "skeleton" (which can be compared for equality using `==`)
     /// and the parameters (which must be related).
+    #[tracing::instrument(level = "trace", ret)]
     pub fn debone(&self) -> (Skeleton, Vec<Parameter>) {
         match self {
             Predicate::IsImplemented(TraitRef {
@@ -171,6 +172,7 @@ impl Relation {
         Self::Sub(p1.upcast(), p2.upcast())
     }
 
+    #[tracing::instrument(level = "trace", ret)]
     pub fn debone(&self) -> (Skeleton, Vec<Parameter>) {
         match self {
             Relation::Equals(a, b) => (Skeleton::Equals, vec![a.clone(), b.clone()]),

--- a/crates/formality-types/src/grammar/formulas.rs
+++ b/crates/formality-types/src/grammar/formulas.rs
@@ -4,6 +4,7 @@ use crate::cast::To;
 use crate::cast::Upcast;
 use crate::cast_impl;
 
+use super::Const;
 use super::Parameter;
 use super::Parameters;
 use super::TraitId;
@@ -27,6 +28,9 @@ pub enum Predicate {
 
     #[grammar(@IsLocal($v0))]
     IsLocal(TraitRef),
+
+    #[grammar(@ConstHasType($v0, $v1))]
+    ConstHasType(Const, Ty),
 }
 
 /// A coinductive predicate is one that can be proven via a cycle.
@@ -79,6 +83,7 @@ pub enum Skeleton {
     WellFormed,
     WellFormedTraitRef(TraitId),
     IsLocal(TraitId),
+    ConstHasType,
 
     Equals,
     Sub,
@@ -115,6 +120,10 @@ impl Predicate {
                 trait_id,
                 parameters,
             }) => (Skeleton::IsLocal(trait_id.clone()), parameters.clone()),
+            Predicate::ConstHasType(ct, ty) => (
+                Skeleton::ConstHasType,
+                vec![ct.clone().upcast(), ty.clone().upcast()],
+            ),
         }
     }
 }

--- a/crates/formality-types/src/grammar/ty.rs
+++ b/crates/formality-types/src/grammar/ty.rs
@@ -13,7 +13,10 @@ use crate::{
     fold::Fold,
 };
 
-use super::{AdtId, AssociatedItemId, Binder, FnId, TraitId};
+use super::{
+    consts::{Const, ConstData},
+    AdtId, AssociatedItemId, Binder, FnId, TraitId,
+};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Ty {
@@ -263,6 +266,8 @@ pub enum Parameter {
     Ty(Ty),
     #[cast]
     Lt(Lt),
+    #[grammar(const $v0)]
+    Const(Const),
 }
 
 impl Parameter {
@@ -270,6 +275,7 @@ impl Parameter {
         match self {
             Parameter::Ty(_) => ParameterKind::Ty,
             Parameter::Lt(_) => ParameterKind::Lt,
+            Parameter::Const(_) => ParameterKind::Const,
         }
     }
 
@@ -281,6 +287,7 @@ impl Parameter {
         match self {
             Parameter::Ty(v) => v.as_variable(),
             Parameter::Lt(v) => v.as_variable(),
+            Parameter::Const(v) => v.as_variable(),
         }
     }
 
@@ -288,6 +295,7 @@ impl Parameter {
         match self {
             Parameter::Ty(v) => ParameterData::Ty(v.data()),
             Parameter::Lt(v) => ParameterData::Lt(v.data()),
+            Parameter::Const(v) => ParameterData::Const(v.data()),
         }
     }
 }
@@ -297,6 +305,7 @@ pub type Parameters = Vec<Parameter>;
 pub enum ParameterData<'me> {
     Ty(&'me TyData),
     Lt(&'me LtData),
+    Const(&'me ConstData),
 }
 
 #[term]
@@ -304,6 +313,7 @@ pub enum ParameterData<'me> {
 pub enum ParameterKind {
     Ty,
     Lt,
+    Const,
 }
 
 #[term]
@@ -517,6 +527,7 @@ impl UpcastFrom<Variable> for Parameter {
         match v.kind() {
             ParameterKind::Lt => Lt::new(v).upcast(),
             ParameterKind::Ty => Ty::new(v).upcast(),
+            ParameterKind::Const => Const::new(v).upcast(),
         }
     }
 }

--- a/crates/formality-types/src/grammar/ty.rs
+++ b/crates/formality-types/src/grammar/ty.rs
@@ -80,6 +80,14 @@ impl Ty {
             vec![l.to::<Parameter>(), self.to::<Parameter>()],
         )
     }
+
+    pub fn bool() -> Ty {
+        RigidTy {
+            name: RigidName::ScalarId(ScalarId::Bool),
+            parameters: vec![],
+        }
+        .upcast()
+    }
 }
 
 impl UpcastFrom<TyData> for Ty {

--- a/crates/formality-types/src/grammar/ty.rs
+++ b/crates/formality-types/src/grammar/ty.rs
@@ -13,10 +13,7 @@ use crate::{
     fold::Fold,
 };
 
-use super::{
-    consts::{Const, ConstData},
-    AdtId, AssociatedItemId, Binder, FnId, TraitId,
-};
+use super::{consts::Const, AdtId, AssociatedItemId, Binder, FnId, TraitId};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Ty {
@@ -298,23 +295,9 @@ impl Parameter {
             Parameter::Const(v) => v.as_variable(),
         }
     }
-
-    pub fn data(&self) -> ParameterData<'_> {
-        match self {
-            Parameter::Ty(v) => ParameterData::Ty(v.data()),
-            Parameter::Lt(v) => ParameterData::Lt(v.data()),
-            Parameter::Const(v) => ParameterData::Const(v.data()),
-        }
-    }
 }
 
 pub type Parameters = Vec<Parameter>;
-
-pub enum ParameterData<'me> {
-    Ty(&'me TyData),
-    Lt(&'me LtData),
-    Const(&'me ConstData),
-}
 
 #[term]
 #[derive(Copy)]

--- a/crates/formality-types/src/grammar/ty/debug_impls.rs
+++ b/crates/formality-types/src/grammar/ty/debug_impls.rs
@@ -14,7 +14,7 @@ impl std::fmt::Debug for super::Ty {
 impl std::fmt::Debug for Const {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.data() {
-            crate::grammar::ConstData::Value(valtree) => write!(f, "{valtree:?}"),
+            crate::grammar::ConstData::Value(valtree, ty) => write!(f, "{valtree:?}_{ty:?}"),
             crate::grammar::ConstData::Variable(r) => write!(f, "{r:?}"),
         }
     }

--- a/crates/formality-types/src/grammar/ty/debug_impls.rs
+++ b/crates/formality-types/src/grammar/ty/debug_impls.rs
@@ -1,3 +1,5 @@
+use crate::grammar::Const;
+
 impl std::fmt::Debug for super::Ty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.data() {
@@ -5,6 +7,15 @@ impl std::fmt::Debug for super::Ty {
             super::TyData::AliasTy(r) => write!(f, "{r:?}"),
             super::TyData::PredicateTy(r) => write!(f, "{r:?}"),
             super::TyData::Variable(r) => write!(f, "{r:?}"),
+        }
+    }
+}
+
+impl std::fmt::Debug for Const {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.data() {
+            crate::grammar::ConstData::Value(valtree) => write!(f, "{valtree:?}"),
+            crate::grammar::ConstData::Variable(r) => write!(f, "{r:?}"),
         }
     }
 }

--- a/crates/formality-types/src/visit.rs
+++ b/crates/formality-types/src/visit.rs
@@ -149,6 +149,18 @@ impl Visit for u32 {
     fn assert_valid(&self) {}
 }
 
+impl Visit for u128 {
+    fn free_variables(&self) -> Vec<Variable> {
+        vec![]
+    }
+
+    fn size(&self) -> usize {
+        std::mem::size_of::<Self>()
+    }
+
+    fn assert_valid(&self) {}
+}
+
 impl Visit for () {
     fn free_variables(&self) -> Vec<Variable> {
         vec![]

--- a/tests/consts.rs
+++ b/tests/consts.rs
@@ -81,6 +81,8 @@ fn test_generic_mismatch() {
 }
 
 #[test]
+/// This test is the short version of `test_holds`, skipping
+/// substituting and directly going to a rigid constant.
 fn test_rigid_const_bound() {
     expect_test::expect![[r#"
         Ok(
@@ -97,6 +99,8 @@ fn test_rigid_const_bound() {
 }
 
 #[test]
+/// This test is the short version of `test_generic_mismatch`, skipping
+/// substituting and directly going to a wrong constant.
 fn test_nonsense_rigid_const_bound() {
     expect_test::expect![[r#"
         Err(
@@ -119,6 +123,8 @@ fn test_nonsense_rigid_const_bound() {
 }
 
 #[test]
+/// This test is wrong, but it's also not something rustc ever generates.
+/// Types on const generics only get exactly one `type_of_const` bound.
 fn test_multiple_type_of_const() {
     expect_test::expect![[r#"
         Ok(

--- a/tests/consts.rs
+++ b/tests/consts.rs
@@ -23,11 +23,8 @@ fn test_ok() {
 #[test]
 fn test_holds() {
     expect_test::expect![[r#"
-        Err(
-            Error {
-                context: "check_trait_impl(impl <> Foo < const 0_(rigid (scalar bool)) > for (rigid (scalar u32)) where [] { })",
-                source: "failed to prove {Foo((rigid (scalar u32)), const 0_(rigid (scalar bool)))} given {}, got {}",
-            },
+        Ok(
+            (),
         )
     "#]]
     .assert_debug_eq(&test_program_ok(
@@ -57,6 +54,27 @@ fn test_mismatch() {
                 trait Foo<const C> where [type_of_const C is bool] {}
 
                 impl<> Foo<const 42_u32> for u32 where [] {}
+            }
+        ]",
+    ));
+}
+
+#[test]
+fn test_generic_mismatch() {
+    expect_test::expect![[r#"
+        Err(
+            Error {
+                context: "check_trait_impl(impl <const> Foo < const ^const0_0 > for (rigid (scalar u32)) where [type_of_const ^const0_0 is (rigid (scalar u32))] { })",
+                source: "failed to prove {Foo((rigid (scalar u32)), const !const_1)} given {@ ConstHasType(!const_1 , (rigid (scalar u32)))}, got {}",
+            },
+        )
+    "#]]
+    .assert_debug_eq(&test_program_ok(
+        "[
+            crate Foo {
+                trait Foo<const C> where [type_of_const C is bool] {}
+
+                impl<const C> Foo<const C> for u32 where [type_of_const C is u32] {}
             }
         ]",
     ));

--- a/tests/consts.rs
+++ b/tests/consts.rs
@@ -1,0 +1,63 @@
+use formality::test_program_ok;
+use formality_macros::test;
+
+#[test]
+fn test_ok() {
+    expect_test::expect![[r#"
+        Ok(
+            (),
+        )
+    "#]]
+    .assert_debug_eq(&test_program_ok(
+        "[
+            crate Foo {
+                trait Foo<const C> where [type_of_const C is bool] {}
+                trait Bar<const C> where [type_of_const C is u32] {}
+
+                impl<const C> Foo<const C> for u32 where [type_of_const C is bool] {}
+            }
+        ]",
+    ));
+}
+
+#[test]
+fn test_holds() {
+    expect_test::expect![[r#"
+        Err(
+            Error {
+                context: "check_trait_impl(impl <> Foo < const 0 > for (rigid (scalar u32)) where [] { })",
+                source: "failed to prove {Foo((rigid (scalar u32)), const 0)} given {}, got {}",
+            },
+        )
+    "#]]
+    .assert_debug_eq(&test_program_ok(
+        "[
+            crate Foo {
+                trait Foo<const C> where [type_of_const C is bool] {}
+
+                impl<> Foo<const true> for u32 where [] {}
+            }
+        ]",
+    ));
+}
+
+#[test]
+fn test_mismatch() {
+    expect_test::expect![[r#"
+        Err(
+            Error {
+                context: "check_trait_impl(impl <> Foo < const 42 > for (rigid (scalar u32)) where [] { })",
+                source: "failed to prove {Foo((rigid (scalar u32)), const 42)} given {}, got {}",
+            },
+        )
+    "#]]
+    .assert_debug_eq(&test_program_ok(
+        "[
+            crate Foo {
+                trait Foo<const C> where [type_of_const C is bool] {}
+
+                impl<> Foo<const 42> for u32 where [] {}
+            }
+        ]",
+    ));
+}

--- a/tests/consts.rs
+++ b/tests/consts.rs
@@ -79,3 +79,57 @@ fn test_generic_mismatch() {
         ]",
     ));
 }
+
+#[test]
+fn test_rigid_const_bound() {
+    expect_test::expect![[r#"
+        Ok(
+            (),
+        )
+    "#]]
+    .assert_debug_eq(&test_program_ok(
+        "[
+            crate Foo {
+                trait Foo<> where [type_of_const true is bool] {}
+            }
+        ]",
+    ));
+}
+
+#[test]
+fn test_nonsense_rigid_const_bound() {
+    expect_test::expect![[r#"
+        Err(
+            Error {
+                context: "check_trait(Foo)",
+                source: Error {
+                    context: "prove_where_clause_well_formed(type_of_const 0_(rigid (scalar bool)) is (rigid (scalar u32)))",
+                    source: "failed to prove {(rigid (scalar u32)) = (rigid (scalar bool))} given {@ ConstHasType(0_(rigid (scalar bool)) , (rigid (scalar u32)))}, got {}",
+                },
+            },
+        )
+    "#]]
+    .assert_debug_eq(&test_program_ok(
+        "[
+            crate Foo {
+                trait Foo<> where [type_of_const true is u32] {}
+            }
+        ]",
+    ));
+}
+
+#[test]
+fn test_multiple_type_of_const() {
+    expect_test::expect![[r#"
+        Ok(
+            (),
+        )
+    "#]]
+    .assert_debug_eq(&test_program_ok(
+        "[
+            crate Foo {
+                trait Foo<const C> where [type_of_const C is bool, type_of_const C is u32] {}
+            }
+        ]",
+    ));
+}

--- a/tests/consts.rs
+++ b/tests/consts.rs
@@ -25,8 +25,8 @@ fn test_holds() {
     expect_test::expect![[r#"
         Err(
             Error {
-                context: "check_trait_impl(impl <> Foo < const 0 > for (rigid (scalar u32)) where [] { })",
-                source: "failed to prove {Foo((rigid (scalar u32)), const 0)} given {}, got {}",
+                context: "check_trait_impl(impl <> Foo < const 0_(rigid (scalar bool)) > for (rigid (scalar u32)) where [] { })",
+                source: "failed to prove {Foo((rigid (scalar u32)), const 0_(rigid (scalar bool)))} given {}, got {}",
             },
         )
     "#]]
@@ -46,8 +46,8 @@ fn test_mismatch() {
     expect_test::expect![[r#"
         Err(
             Error {
-                context: "check_trait_impl(impl <> Foo < const 42 > for (rigid (scalar u32)) where [] { })",
-                source: "failed to prove {Foo((rigid (scalar u32)), const 42)} given {}, got {}",
+                context: "check_trait_impl(impl <> Foo < const 42_(rigid (scalar u32)) > for (rigid (scalar u32)) where [] { })",
+                source: "failed to prove {Foo((rigid (scalar u32)), const 42_(rigid (scalar u32)))} given {}, got {}",
             },
         )
     "#]]
@@ -56,7 +56,7 @@ fn test_mismatch() {
             crate Foo {
                 trait Foo<const C> where [type_of_const C is bool] {}
 
-                impl<> Foo<const 42> for u32 where [] {}
+                impl<> Foo<const 42_u32> for u32 where [] {}
             }
         ]",
     ));

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -37,6 +37,11 @@ fn test_ok() {
                 trait Bar<ty T> where [T: Baz<>] {}
                 
                 trait Baz<> where [] {}
+
+                impl<> Baz<> for u32 where [] {}
+
+                impl<> Bar<u32> for u32 where [] {}
+                impl<ty T> Bar<T> for () where [T: Baz<>] {}
             }
         ]",
     ));

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -6,7 +6,10 @@ fn test_broken() {
         Err(
             Error {
                 context: "check_trait(Foo)",
-                source: "failed to prove {@ WellFormedTraitRef(Bar(!ty_2, !ty_1))} given {Bar(!ty_2, !ty_1)}, got {}",
+                source: Error {
+                    context: "prove_where_clause_well_formed(!ty_2 : Bar < !ty_1 >)",
+                    source: "failed to prove {@ WellFormedTraitRef(Bar(!ty_2, !ty_1))} given {Bar(!ty_2, !ty_1)}, got {}",
+                },
             },
         )
     "#]].assert_debug_eq(&test_program_ok(


### PR DESCRIPTION
In contrast to #127, this PR does not attach types to const generic params, but introduces a `type_of_const` where bound, that constrains that generic const parameter to have a specific type.

At present you can create incoherent where bounds where a single const param ends up having two different types at the same time. I should fix that. This is not really an issue, as rustc will never generate such wrong `type_of_const` bounds.