### PR TITLE
Smir to formality basic set-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,7 @@ dependencies = [
  "formality-macros",
  "formality-prove",
  "formality-rust",
+ "formality-smir",
  "formality-types",
  "pretty_assertions",
  "ui_test",
@@ -606,6 +607,10 @@ dependencies = [
  "formality-types",
  "tracing",
 ]
+
+[[package]]
+name = "formality-smir"
+version = "0.1.0"
 
 [[package]]
 name = "formality-types"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,9 @@ dependencies = [
 [[package]]
 name = "formality-smir"
 version = "0.1.0"
+dependencies = [
+ "formality-types",
+]
 
 [[package]]
 name = "formality-types"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ formality-types = { version = "0.1.0", path = "crates/formality-types" }
 formality-check = { version = "0.1.0", path = "crates/formality-check" }
 formality-prove = { version = "0.1.0", path = "crates/formality-prove" }
 formality-core = { version = "0.1.0", path = "crates/formality-core" }
+formality-smir = { version = "0.1.0", path = "crates/formality-smir" }
 ui_test = "0.12"
 
 [workspace]
@@ -33,6 +34,7 @@ members = [
     "crates/formality-check",
     "crates/formality-rust",
     "crates/formality-prove",
+    "crates/formality-smir",
 ]
 
 [[test]]

--- a/crates/formality-smir/Cargo.toml
+++ b/crates/formality-smir/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+formality-types = { path = "../formality-types" }

--- a/crates/formality-smir/Cargo.toml
+++ b/crates/formality-smir/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "formality-smir"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/formality-smir/src/lib.rs
+++ b/crates/formality-smir/src/lib.rs
@@ -1,0 +1,7 @@
+/// Trait used to convert from Stable MIR to Formality types.
+pub trait ToFormality {
+    /// The formality representation of the stable MIR type implementing ToFormality.
+    type T;
+    /// Converts an object to the equivalent Formality representation.
+    fn formality(&self) -> Self::T;
+}

--- a/crates/formality-smir/src/lib.rs
+++ b/crates/formality-smir/src/lib.rs
@@ -1,7 +1,28 @@
+#![feature(rustc_private)]
+
+extern crate rustc_driver;
+extern crate rustc_smir;
+
+use rustc_smir::stable_mir;
+
 /// Trait used to convert from Stable MIR to Formality types.
 pub trait ToFormality {
     /// The formality representation of the stable MIR type implementing ToFormality.
     type T;
     /// Converts an object to the equivalent Formality representation.
     fn formality(&self) -> Self::T;
+}
+
+impl ToFormality for stable_mir::ty::GenericParamDefKind {
+    type T = formality_types::derive_links::ParameterKind;
+
+    fn formality(&self) -> Self::T {
+        use formality_types::derive_links::ParameterKind;
+
+        match self {
+            stable_mir::ty::GenericParamDefKind::Lifetime => ParameterKind::Lt,
+            stable_mir::ty::GenericParamDefKind::Type { .. } => ParameterKind::Ty,
+            stable_mir::ty::GenericParamDefKind::Const { .. } => ParameterKind::Const,
+        }
+    }
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "nightly"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "nightly"
+components = [ "rustc-dev", "llvm-tools" ]


### PR DESCRIPTION
This set-up a separate crate for conversions from SMIR types to Mir formality decls.
I think it won't make a lot of sense to unit test this, we can add some ui tests as we add more conversion. I've more stuff on my local repo but I guess we can start discussing the set-up of this idea in a smaller PR. 

r? @nikomatsakis 