### PR TITLE
Replace length comparison to zero by `is_empty()` method

### DIFF
--- a/crates/formality-prove/src/decls.rs
+++ b/crates/formality-prove/src/decls.rs
@@ -54,7 +54,7 @@ impl Decls {
             .iter()
             .filter(|t| t.id == *trait_id)
             .collect();
-        assert!(v.len() > 0, "no traits named `{trait_id:?}`");
+        assert!(!v.is_empty(), "no traits named `{trait_id:?}`");
         assert!(v.len() <= 1, "multiple traits named `{trait_id:?}`");
         v.pop().unwrap()
     }

--- a/crates/formality-prove/src/prove/constraints.rs
+++ b/crates/formality-prove/src/prove/constraints.rs
@@ -118,7 +118,7 @@ impl Constraints {
     where
         V: Upcast<Variable> + Copy,
     {
-        if v.len() == 0 {
+        if v.is_empty() {
             return self;
         }
 

--- a/crates/formality-prove/src/prove/env.rs
+++ b/crates/formality-prove/src/prove/env.rs
@@ -180,7 +180,7 @@ impl Env {
     where
         V: Upcast<Variable> + Copy,
     {
-        if v.len() == 0 {
+        if v.is_empty() {
             return vec![];
         }
 

--- a/crates/formality-types/src/parse.rs
+++ b/crates/formality-types/src/parse.rs
@@ -415,7 +415,7 @@ where
         panic!("parsing ambiguity: {results:?}");
     } else if results.len() == 1 {
         Ok(results.pop().unwrap())
-    } else if errors.len() == 0 {
+    } else if errors.is_empty() {
         Err(ParseError::at(text, format!("{} expected", expected)))
     } else {
         Err(errors)


### PR DESCRIPTION
```
warning: length comparison to one
  --> crates/formality-rust/src/grammar.rs:37:12
   |
37 |         if traits.len() < 1 {
   |            ^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `traits.is_empty()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
   = note: `#[warn(clippy::len_zero)]` on by default
```