### PR TITLE
Improvements to unsafe trait support

### DIFF
--- a/crates/formality-check/src/impls.rs
+++ b/crates/formality-check/src/impls.rs
@@ -19,6 +19,8 @@ use formality_types::{
 impl super::Check<'_> {
     #[context("check_trait_impl({trait_impl:?})")]
     pub(super) fn check_trait_impl(&self, trait_impl: &TraitImpl) -> Fallible<()> {
+        let TraitImpl { binder, safety: _ } = trait_impl;
+
         let mut env = Env::default();
 
         let TraitImplBoundData {
@@ -27,7 +29,7 @@ impl super::Check<'_> {
             trait_parameters,
             where_clauses,
             impl_items,
-        } = env.instantiate_universally(&trait_impl.binder);
+        } = env.instantiate_universally(&binder);
 
         let trait_ref = trait_id.with(self_ty, trait_parameters);
 

--- a/crates/formality-check/src/impls.rs
+++ b/crates/formality-check/src/impls.rs
@@ -56,6 +56,8 @@ impl super::Check<'_> {
 
     #[context("check_neg_trait_impl({trait_impl:?})")]
     pub(super) fn check_neg_trait_impl(&self, trait_impl: &NegTraitImpl) -> Fallible<()> {
+        let NegTraitImpl { binder, safety } = trait_impl;
+
         let mut env = Env::default();
 
         let NegTraitImplBoundData {
@@ -63,12 +65,12 @@ impl super::Check<'_> {
             self_ty,
             trait_parameters,
             where_clauses,
-        } = env.instantiate_universally(&trait_impl.binder);
+        } = env.instantiate_universally(binder);
 
         let trait_ref = trait_id.with(self_ty, trait_parameters);
 
         // Negative impls are always safe (rustc E0198) regardless of the trait's safety.
-        if trait_impl.safety == Safety::Unsafe {
+        if *safety == Safety::Unsafe {
             bail!("negative impls cannot be unsafe");
         }
 

--- a/crates/formality-prove/src/decls.rs
+++ b/crates/formality-prove/src/decls.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use formality_core::{set, Set, Upcast};
 use formality_macros::term;
 use formality_types::grammar::{
@@ -144,21 +142,11 @@ pub struct NegImplDeclBoundData {
 
 /// Mark a trait or trait impl as `unsafe`.
 #[term]
-#[customize(debug)]
 #[derive(Default)]
 pub enum Safety {
     #[default]
     Safe,
     Unsafe,
-}
-
-impl fmt::Debug for Safety {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Safety::Safe => write!(f, "safe"),
-            Safety::Unsafe => write!(f, "unsafe"),
-        }
-    }
 }
 
 /// A "trait declaration" declares a trait that exists, its generics, and its where-clauses.


### PR DESCRIPTION
This PR contains the few improvements discussed in review of #128 (but has already been merged, hence this new PR):
- I initially customized `Safety`'s `Debug` impl to special-case the default value and print nothing. That was unnecessary after the recent parser changes and the pretty-printing fix cherry-picked in that PR: it ended up being similar to the default derived `Debug`  impl for `#[term]`s, and can be removed.
- re-introduces the struct pattern in `check_trait_impl` for better errors if the struct is modified.
- introduces the same pattern for `check_neg_trait_impl` for the same reason.