### PR TITLE
typo: fixed keyword on sample code

### DIFF
--- a/book/src/formality_core/parse.md
+++ b/book/src/formality_core/parse.md
@@ -13,7 +13,7 @@ For enums, the grammar is placed in `#[grammar]` attributes on each variant:
 
 ```rust
 #[term]
-struct MyEnum {
+enum MyEnum {
     #[grammar( /* grammar here */ )]
     Foo(...),
 }


### PR DESCRIPTION
Just a small fix, the sample for the `enum` was using the wrong keyword.