### PR TITLE
Add rustfmt check to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      - name: Check formatting of all crates in the workspace
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
       - name: Run cargo test --all
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check formatting of all crates in the workspace
         uses: actions-rs/cargo@v1
         with:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2023-10-08"
 components = ["rustc-dev", "llvm-tools", "rustfmt"]
+profile = "minimal"

--- a/src/test/coherence_orphan.rs
+++ b/src/test/coherence_orphan.rs
@@ -12,7 +12,7 @@ fn neg_CoreTrait_for_CoreStruct_in_Foo() {
                 impl !CoreTrait for CoreStruct {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -48,11 +48,11 @@ fn mirror_CoreStruct() {
             crate core {
                 trait CoreTrait {}
                 struct CoreStruct {}
-        
+
                 trait Mirror {
                     type Assoc : [];
                 }
-        
+
                 impl<ty T> Mirror for T {
                     type Assoc = T;
                 }
@@ -61,7 +61,7 @@ fn mirror_CoreStruct() {
                 impl CoreTrait for <CoreStruct as Mirror>::Assoc {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -99,11 +99,11 @@ fn mirror_FooStruct() {
         [
             crate core {
                 trait CoreTrait {}
-        
+
                 trait Mirror {
                     type Assoc : [];
                 }
-        
+
                 impl<ty T> Mirror for T {
                     type Assoc = T;
                 }
@@ -113,7 +113,7 @@ fn mirror_FooStruct() {
                 impl CoreTrait for <FooStruct as Mirror>::Assoc {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -132,7 +132,7 @@ fn covered_VecT() {
                 impl<ty T> CoreTrait<FooStruct> for Vec<T> {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -149,7 +149,7 @@ fn uncovered_T() {
                 impl<ty T> CoreTrait<FooStruct> for T {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -174,11 +174,11 @@ fn alias_to_unit() {
         [
             crate core {
                 trait CoreTrait {}
-        
+
                 trait Unit {
                     type Assoc : [];
                 }
-        
+
                 impl<ty T> Unit for T {
                     type Assoc = ();
                 }
@@ -188,7 +188,7 @@ fn alias_to_unit() {
                 impl CoreTrait for <FooStruct as Unit>::Assoc {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -227,7 +227,7 @@ fn CoreTrait_for_CoreStruct_in_Foo() {
                 impl CoreTrait for CoreStruct {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"

--- a/src/test/consts.rs
+++ b/src/test/consts.rs
@@ -10,7 +10,7 @@ fn nonsense_rigid_const_bound() {
                 trait Foo where type_of_const true is u32 {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -48,11 +48,11 @@ fn ok() {
             crate Foo {
                 trait Foo<const C> where type_of_const C is bool {}
                 trait Bar<const C> where type_of_const C is u32 {}
-        
+
                 impl<const C> Foo<const C> for u32 where type_of_const C is bool {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -63,11 +63,11 @@ fn mismatch() {
         [
             crate Foo {
                 trait Foo<const C> where type_of_const C is bool {}
-        
+
                 impl Foo<const 42_u32> for u32 {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -89,11 +89,11 @@ fn holds() {
         [
             crate Foo {
                 trait Foo<const C> where type_of_const C is bool {}
-        
+
                 impl Foo<const true> for u32 {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -109,7 +109,7 @@ fn rigid_const_bound() {
                 trait Foo where type_of_const true is bool {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -120,11 +120,11 @@ fn generic_mismatch() {
         [
             crate Foo {
                 trait Foo<const C> where type_of_const C is bool {}
-        
+
                 impl<const C> Foo<const C> for u32 where type_of_const C is u32 {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -160,7 +160,7 @@ fn multiple_type_of_const() {
                 trait Foo<const C> where type_of_const C is bool, type_of_const C is u32 {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }

--- a/src/test/decl_safety.rs
+++ b/src/test/decl_safety.rs
@@ -10,7 +10,7 @@ fn unsafe_trait() {
                 unsafe impl Foo for u32 {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -25,7 +25,7 @@ fn safe_trait() {
                 safe impl Foo for u32 {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -40,7 +40,7 @@ fn unsafe_trait_negative_impl() {
                 impl !Foo for u32 {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -54,7 +54,7 @@ fn unsafe_trait_negative_impl_mismatch() {
                 unsafe impl !Foo for u32 {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -74,7 +74,7 @@ fn safe_trait_negative_impl_mismatch() {
                 unsafe impl !Foo for u32 {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -94,7 +94,7 @@ fn unsafe_trait_mismatch() {
                 impl Foo for u32 {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -114,7 +114,7 @@ fn safe_trait_mismatch() {
                 unsafe impl Foo for u32 {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"

--- a/src/test/functions.rs
+++ b/src/test/functions.rs
@@ -9,21 +9,21 @@ fn ok() {
             crate Foo {
                 // fn simple_fn() {}
                 fn simple_fn() -> () { trusted }
-        
+
                 // fn one_arg<T>(_: T) {}
                 fn one_arg<ty T>(T) -> () { trusted }
-        
+
                 // fn one_ret<T>(_: T) {}
                 fn one_ret<ty T>() -> T { trusted }
-        
+
                 // fn arg_ret<T, U>(_: T) -> U {}
                 fn arg_ret<ty T, ty U>(T) -> U { trusted }
-        
+
                 // fn multi_arg_ret<T, Y, U, I>(_: T, _: Y) -> (U, I) {}
                 fn multi_arg_ret<ty T, ty Y, ty U, ty I>(T, Y) -> (U, I) { trusted }
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -38,7 +38,7 @@ fn lifetime() {
                 fn one_lt_arg<lt a, ty T>(&a T) -> () { trusted }
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2,19 +2,19 @@
 
 mod coherence_orphan;
 mod coherence_overlap;
-mod functions;
-mod decl_safety;
 mod consts;
+mod decl_safety;
+mod functions;
 
 #[test]
 fn parser() {
     crate::assert_err!(
         [
-            crate Foo {        
+            crate Foo {
                 trait Baz where  cake  {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -32,13 +32,13 @@ fn hello_world_fail() {
         [
             crate Foo {
                 trait Foo<ty T> where T: Bar<Self> {}
-        
+
                 trait Bar<ty T> where T: Baz {}
-                
+
                 trait Baz {}
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"
@@ -65,18 +65,18 @@ fn hello_world() {
         [
             crate Foo {
                 trait Foo<ty T> where T: Bar<Self>, Self: Baz {}
-        
+
                 trait Bar<ty T> where T: Baz {}
-                
+
                 trait Baz {}
-        
+
                 impl Baz for u32 {}
-        
+
                 impl Bar<u32> for u32 {}
                 impl<ty T> Bar<T> for () where T: Baz {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -88,15 +88,15 @@ fn basic_where_clauses_pass() {
         [
             crate core {
                 trait A<ty T> where T: B { }
-        
+
                 trait B { }
-        
+
                 trait WellFormed where for<ty T> u32: A<T> { }
-        
+
                 impl <ty T> B for T {}
             }
         ]
-        
+
         expect_test::expect!["()"]
     )
 }
@@ -107,13 +107,13 @@ fn basic_where_clauses_fail() {
         [
             crate core {
                 trait A<ty T> where T: B { }
-        
+
                 trait B { }
-        
+
                 trait WellFormed where for<ty T> u32: A<T> { }
             }
         ]
-        
+
         [ /* TODO */ ]
 
         expect_test::expect![[r#"

--- a/tests/judgment-error-reporting/cyclic_judgment.rs
+++ b/tests/judgment-error-reporting/cyclic_judgment.rs
@@ -70,14 +70,12 @@ fn test() {
     let bar = Ty::Class {
         name: ClassName::new("Bar"),
     };
-    sub(foo, bar).assert_err(
-      expect_test::expect![[r#"
+    sub(foo, bar).assert_err(expect_test::expect![[r#"
           judgment `sub { a: class(Foo), b: class(Bar) }` failed at the following rule(s):
             the rule "same class" failed at step #0 (src/file.rs:LL:CC) because
               condition evaluted to false: `name_a == name_b`
                 name_a = Foo
-                name_b = Bar"#]]
-    );
+                name_b = Bar"#]]);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a `rustfmt` step to CI, and reformats everything to make it pass.

Fixes #170

I've also removed some default rustup components, as they are currently unused and slow down CI and local toolchain installs, e.g. unpacking all the documentation. 

(This also updates a CI action triggering [deprecation warnings](https://github.com/rust-lang/a-mir-formality/actions/runs/9077579003?pr=172), but [the other one](https://github.com/actions-rs/cargo) the repo uses is also deprecated and [triggers warnings](https://github.com/rust-lang/a-mir-formality/actions/runs/9078065678)).