### PR TITLE
Some clippy fixes

### DIFF
--- a/crates/formality-check/src/impls.rs
+++ b/crates/formality-check/src/impls.rs
@@ -29,7 +29,7 @@ impl super::Check<'_> {
             trait_parameters,
             where_clauses,
             impl_items,
-        } = env.instantiate_universally(&binder);
+        } = env.instantiate_universally(binder);
 
         let trait_ref = trait_id.with(self_ty, trait_parameters);
 
@@ -45,7 +45,7 @@ impl super::Check<'_> {
             trait_items,
         } = trait_decl.binder.instantiate_with(&trait_ref.parameters)?;
 
-        self.check_safety_matches(&trait_decl, &trait_impl)?;
+        self.check_safety_matches(trait_decl, trait_impl)?;
 
         for impl_item in &impl_items {
             self.check_trait_impl_item(&env, &where_clauses, &trait_items, impl_item)?;

--- a/crates/formality-core/src/cast.rs
+++ b/crates/formality-core/src/cast.rs
@@ -233,9 +233,7 @@ impl DowncastTo<()> for () {
 }
 
 impl UpcastFrom<()> for () {
-    fn upcast_from((): ()) -> Self {
-        ()
-    }
+    fn upcast_from((): ()) -> Self {}
 }
 
 impl<T: Clone, U> UpcastFrom<Arc<T>> for Arc<U>

--- a/crates/formality-core/src/collections.rs
+++ b/crates/formality-core/src/collections.rs
@@ -113,7 +113,7 @@ impl<T: Ord + Clone> SetExt<T> for Set<T> {
 
     fn split_nth(&self, i: usize) -> Option<(T, Set<T>)> {
         let mut s = self.clone();
-        let item = self.iter().skip(i).next()?;
+        let item = self.iter().nth(i)?;
         let item = s.take(item).unwrap();
         Some((item, s))
     }

--- a/crates/formality-core/src/judgment/proven_set.rs
+++ b/crates/formality-core/src/judgment/proven_set.rs
@@ -502,11 +502,11 @@ impl<T: Debug> std::fmt::Display for ProvenSet<T> {
         match &self.data {
             Data::Failure(err) => std::fmt::Display::fmt(err, f),
             Data::Success(set) => {
-                write!(f, "{{\n")?;
+                writeln!(f, "{{")?;
                 for item in set {
-                    write!(f, "{},\n", indent(format!("{item:?}")))?;
+                    writeln!(f, "{},", indent(format!("{item:?}")))?;
                 }
-                write!(f, "}}\n")?;
+                writeln!(f, "}}")?;
                 Ok(())
             }
         }

--- a/crates/formality-core/src/judgment/proven_set.rs
+++ b/crates/formality-core/src/judgment/proven_set.rs
@@ -57,7 +57,7 @@ impl<T: Ord + Debug> ProvenSet<T> {
 
     /// Creates a judgment set that resulted from a failed judgment.
     /// Meant to be used from the judgment macro, probably annoying to call manually.
-    pub fn failed_rules(judgment: &impl std::fmt::Debug, failed_rules: Set<FailedRule>) -> Self {
+    pub fn failed_rules(judgment: impl std::fmt::Debug, failed_rules: Set<FailedRule>) -> Self {
         let judgment = format!("{judgment:?}");
         FailedJudgment::new(judgment, failed_rules).into()
     }
@@ -131,7 +131,7 @@ impl<T: Ord + Debug> ProvenSet<T> {
                 if !items.is_empty() {
                     ProvenSet::proven(items)
                 } else {
-                    ProvenSet::failed_rules(&"flat_map", failures)
+                    ProvenSet::failed_rules("flat_map", failures)
                 }
             }
         }

--- a/crates/formality-core/src/judgment/proven_set.rs
+++ b/crates/formality-core/src/judgment/proven_set.rs
@@ -567,7 +567,7 @@ impl<'a, T> TryIntoIter for &'a ProvenSet<T> {
     ) -> Result<Self::IntoIter, RuleFailureCause> {
         match &self.data {
             Data::Failure(e) => Err(RuleFailureCause::FailedJudgment(e.clone())),
-            Data::Success(s) => Ok(s.into_iter()),
+            Data::Success(s) => Ok(s.iter()),
         }
     }
 }

--- a/crates/formality-core/src/judgment/proven_set.rs
+++ b/crates/formality-core/src/judgment/proven_set.rs
@@ -178,7 +178,7 @@ impl<I: Ord + Debug> FromIterator<I> for ProvenSet<I> {
     fn from_iter<T: IntoIterator<Item = I>>(iter: T) -> Self {
         let set: Set<I> = iter.into_iter().collect();
         if set.is_empty() {
-            ProvenSet::failed(&"collect", &"empty collection")
+            ProvenSet::failed("collect", "empty collection")
         } else {
             ProvenSet::proven(set)
         }

--- a/crates/formality-core/src/parse.rs
+++ b/crates/formality-core/src/parse.rs
@@ -187,7 +187,7 @@ impl<L: Language> Scope<L> {
         self.bindings
             .iter()
             .rev()
-            .flat_map(|(n, p)| if name == n { Some(p.clone()) } else { None })
+            .flat_map(|(n, p)| if name == n { Some(*p) } else { None })
             .next()
     }
 

--- a/crates/formality-core/src/parse/parser.rs
+++ b/crates/formality-core/src/parse/parser.rs
@@ -410,7 +410,7 @@ where
 
     /// Return the set of variables in scope
     pub fn scope(&self) -> &Scope<L> {
-        &self.scope
+        self.scope
     }
 
     /// Skips whitespace in the input, producing no reduction.

--- a/crates/formality-core/src/parse/parser.rs
+++ b/crates/formality-core/src/parse/parser.rs
@@ -343,7 +343,7 @@ where
                 .zip(0..)
                 .all(|(s_j, j)| i == j || Self::is_preferable(s_i, s_j))
             {
-                let s_i = self.successes.into_iter().skip(i).next().unwrap();
+                let s_i = self.successes.into_iter().nth(i).unwrap();
                 // It's better to print this result alongside the main parsing section.
                 drop(guard);
                 tracing::trace!("best parse = `{:?}`", s_i);

--- a/crates/formality-core/src/parse/parser.rs
+++ b/crates/formality-core/src/parse/parser.rs
@@ -105,7 +105,7 @@ impl Precedence {
         assert!(level < std::usize::MAX);
         Self {
             level,
-            associativity: associativity,
+            associativity,
         }
     }
 }

--- a/crates/formality-core/src/parse/parser.rs
+++ b/crates/formality-core/src/parse/parser.rs
@@ -635,7 +635,7 @@ where
         let id = self.identifier()?;
         match self.scope.lookup(&id) {
             Some(v) => Ok(v),
-            None => Err(ParseError::at(text0, format!("unrecognized variable"))),
+            None => Err(ParseError::at(text0, "unrecognized variable".to_string())),
         }
     }
 
@@ -678,7 +678,7 @@ where
             Ok(t) => Ok(t),
             Err(_) => Err(ParseError::at(
                 skip_whitespace(text0),
-                format!("invalid number"),
+                "invalid number".to_string(),
             )),
         }
     }

--- a/crates/formality-core/src/parse/parser/left_recursion.rs
+++ b/crates/formality-core/src/parse/parser/left_recursion.rs
@@ -129,10 +129,10 @@ impl StackEntry {
     ///
     /// This variant will recurse *again*. But this time the current text is `"2 + 3)"`.
     /// This is not considered a recursive match.
-    pub fn matches_current_state<'t, L, T>(
+    pub fn matches_current_state<L, T>(
         &self,
         scope: &Scope<L>,
-        start_text: &'t str,
+        start_text: &str,
     ) -> Option<CurrentState>
     where
         L: Language,
@@ -439,7 +439,7 @@ where
     }
 }
 
-pub(super) fn recurse<'s, 't, R>(current_state: CurrentState, op: impl FnOnce() -> R) -> R {
+pub(super) fn recurse<R>(current_state: CurrentState, op: impl FnOnce() -> R) -> R {
     STACK.with_borrow_mut(|stack| {
         let top = stack.last_mut().unwrap();
         assert!(

--- a/crates/formality-macros/src/attrs.rs
+++ b/crates/formality-macros/src/attrs.rs
@@ -69,8 +69,7 @@ where
             attrs
                 .iter()
                 .filter(|a| a.path().is_ident(name))
-                .skip(1)
-                .next()
+                .nth(1)
                 .unwrap()
                 .path()
                 .span(),

--- a/crates/formality-macros/src/constructors.rs
+++ b/crates/formality-macros/src/constructors.rs
@@ -17,7 +17,7 @@ pub(crate) fn constructor_methods(s: synstructure::Structure) -> TokenStream {
     match s.ast().data {
         syn::Data::Struct(_) => derive_new_for_struct(s),
         syn::Data::Enum(_) => derive_new_for_variants(s),
-        syn::Data::Union(_) => return Default::default(),
+        syn::Data::Union(_) => Default::default(),
     }
 }
 

--- a/crates/formality-macros/src/fold.rs
+++ b/crates/formality-macros/src/fold.rs
@@ -11,7 +11,7 @@ pub(crate) fn derive_fold(mut s: synstructure::Structure) -> TokenStream {
 
     let substitute_body = s.each_variant(|vi| {
         let bindings = vi.bindings();
-        if has_variable_attr(&vi.ast().attrs) {
+        if has_variable_attr(vi.ast().attrs) {
             if bindings.len() != 1 {
                 return syn::Error::new(
                     vi.ast().ident.span(),

--- a/crates/formality-macros/src/parse.rs
+++ b/crates/formality-macros/src/parse.rs
@@ -188,7 +188,7 @@ fn parse_variant_with_attr(
             spec::FormalitySpecSymbol::Keyword { ident } => {
                 let literal = as_literal(ident);
                 quote_spanned!(ident.span() =>
-                    let () = __p.expect_keyword(#literal)?;
+                    __p.expect_keyword(#literal)?;
                 )
             }
 
@@ -196,14 +196,14 @@ fn parse_variant_with_attr(
                 let literal = Literal::character(punct.as_char());
                 quote_spanned!(
                     punct.span() =>
-                    let () = __p.expect_char(#literal)?;
+                    __p.expect_char(#literal)?;
                 )
             }
 
             spec::FormalitySpecSymbol::Delimeter { text } => {
                 let literal = Literal::character(*text);
                 quote!(
-                    let () = __p.expect_char(#literal)?;
+                    __p.expect_char(#literal)?;
                 )
             }
         });

--- a/crates/formality-macros/src/parse.rs
+++ b/crates/formality-macros/src/parse.rs
@@ -49,7 +49,7 @@ pub(crate) fn derive_parse_with_spec(
     for variant in s.variants() {
         let variant_name = Literal::string(&format!("{}::{}", s.ast().ident, variant.ast().ident));
         let v = parse_variant(variant, external_spec, any_variable_variant)?;
-        let precedence = precedence(&variant.ast().attrs)?.expr();
+        let precedence = precedence(variant.ast().attrs)?.expr();
         parse_variants.extend(quote_spanned!(
             variant.ast().ident.span() =>
             __parser.parse_variant(#variant_name, #precedence, |__p| { #v });

--- a/crates/formality-macros/src/precedence.rs
+++ b/crates/formality-macros/src/precedence.rs
@@ -81,7 +81,7 @@ impl syn::parse::Parse for Precedence {
                         _ => {
                             return Err(syn::Error::new(
                                 comma_token.span(),
-                                &format!(
+                                format!(
                                     "expected valid associativity after comma, one of `{:?}`",
                                     VALID_ASSOCIATIVITIES
                                 ),

--- a/crates/formality-macros/src/precedence.rs
+++ b/crates/formality-macros/src/precedence.rs
@@ -4,8 +4,9 @@ use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote;
 use syn::spanned::Spanned;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) enum Precedence {
+    #[default]
     Defaulted,
     Parsed {
         level: usize,
@@ -28,12 +29,6 @@ impl Precedence {
                 quote!(formality_core::parse::Precedence::#associativity(#level))
             }
         }
-    }
-}
-
-impl Default for Precedence {
-    fn default() -> Self {
-        Precedence::Defaulted
     }
 }
 

--- a/crates/formality-macros/src/spec.rs
+++ b/crates/formality-macros/src/spec.rs
@@ -260,7 +260,7 @@ fn parse_variable_binding(
         };
 
         Ok(FormalitySpecSymbol::Field {
-            name: name,
+            name,
             mode: guard_mode,
         })
     }

--- a/crates/formality-types/src/grammar/ty.rs
+++ b/crates/formality-types/src/grammar/ty.rs
@@ -212,7 +212,7 @@ impl AliasTy {
                 item_arity,
             }
             .upcast(),
-            parameters: parameters,
+            parameters,
         }
     }
 }

--- a/crates/formality-types/src/grammar/ty/debug_impls.rs
+++ b/crates/formality-types/src/grammar/ty/debug_impls.rs
@@ -84,7 +84,7 @@ impl<'a> PrettyParameters<'a> {
 
 impl Debug for PrettyParameters<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.p.len() == 0 {
+        if self.p.is_empty() {
             Ok(())
         } else {
             write!(f, "{}", self.open)?;

--- a/crates/formality-types/src/grammar/ty/parse_impls.rs
+++ b/crates/formality-types/src/grammar/ty/parse_impls.rs
@@ -110,7 +110,7 @@ impl CoreParse<Rust> for AliasTy {
 fn parse_parameters<'t>(
     p: &mut ActiveVariant<'_, 't, Rust>,
 ) -> Result<Vec<Parameter>, Set<ParseError<'t>>> {
-    if let Err(_) = p.expect_char('<') {
+    if p.expect_char('<').is_err() {
         return Ok(vec![]);
     }
     let parameters: Vec<Parameter> = p.comma_nonterminal()?;

--- a/crates/formality-types/src/grammar/ty/parse_impls.rs
+++ b/crates/formality-types/src/grammar/ty/parse_impls.rs
@@ -81,7 +81,7 @@ impl CoreParse<Rust> for AliasTy {
             parser.parse_variant("associated type", Precedence::default(), |p| {
                 p.expect_char('<')?;
                 let ty0: Ty = p.nonterminal()?;
-                let () = p.expect_keyword("as")?;
+                p.expect_keyword("as")?;
                 let trait_id: TraitId = p.nonterminal()?;
                 let trait_parameters1 = parse_parameters(p)?;
                 p.expect_char('>')?;


### PR DESCRIPTION
When adding rustfmt to CI, I noticed clippy was installed by default so I tried it and heard its many complaints with aplomb. (It hates the macro parsing in particular). 

This PR cuts down on the number of warnings it generated, in different commits so they can be dropped in case some of its suggestions are suboptimal.