### PR TITLE
replace custom wf check with well_formed constructor 

### DIFF
--- a/crates/formality-check/src/where_clauses.rs
+++ b/crates/formality-check/src/where_clauses.rs
@@ -1,85 +1,20 @@
 use fn_error_context::context;
-use formality_core::Upcast;
 use formality_prove::Env;
-use formality_rust::{
-    grammar::{WhereClause, WhereClauseData},
-    prove::ToWcs,
-};
-use formality_types::grammar::{ConstData, Fallible, Parameter, Relation, TraitRef};
+use formality_rust::{grammar::WhereClause, prove::ToWcs};
+use formality_types::grammar::{Fallible, Wcs};
 
 impl super::Check<'_> {
+    #[context("prove_where_clauses_well_formed({where_clauses:?})")]
     pub(crate) fn prove_where_clauses_well_formed(
         &self,
         env: &Env,
         assumptions: impl ToWcs,
         where_clauses: &[WhereClause],
     ) -> Fallible<()> {
-        for where_clause in where_clauses {
-            self.prove_where_clause_well_formed(env, &assumptions, where_clause)?;
-        }
-        Ok(())
-    }
-
-    #[context("prove_where_clause_well_formed({where_clause:?})")]
-    // FIXME(oli-obk): figure out why is this a function and not a `judgment_fn`.
-    fn prove_where_clause_well_formed(
-        &self,
-        in_env: &Env,
-        assumptions: impl ToWcs,
-        where_clause: &WhereClause,
-    ) -> Fallible<()> {
-        match where_clause.data() {
-            WhereClauseData::IsImplemented(self_ty, trait_id, parameters) => self
-                .prove_trait_ref_well_formed(
-                    in_env,
-                    assumptions,
-                    trait_id.with(self_ty, parameters),
-                ),
-            WhereClauseData::AliasEq(alias_ty, ty) => {
-                self.prove_parameter_well_formed(in_env, &assumptions, alias_ty)?;
-                self.prove_parameter_well_formed(in_env, &assumptions, ty)
-            }
-            WhereClauseData::Outlives(a, b) => {
-                self.prove_parameter_well_formed(in_env, &assumptions, a)?;
-                self.prove_parameter_well_formed(in_env, assumptions, b)
-            }
-            WhereClauseData::ForAll(binder) => {
-                let mut e = in_env.clone();
-                let wc = e.instantiate_universally(binder);
-                self.prove_where_clause_well_formed(&e, assumptions, &wc)
-            }
-            WhereClauseData::TypeOfConst(ct, ty) => {
-                match ct.data() {
-                    ConstData::Value(_, t) => {
-                        self.prove_goal(in_env, &assumptions, Relation::equals(ty, t))?
-                    }
-                    ConstData::Variable(_) => {}
-                }
-                // FIXME(oli-obk): prove that there is no `TypeOfConst` bound for a different type.
-                self.prove_parameter_well_formed(in_env, &assumptions, ct.clone())?;
-                self.prove_parameter_well_formed(in_env, assumptions, ty.clone())
-            }
-        }
-    }
-
-    fn prove_parameter_well_formed(
-        &self,
-        env: &Env,
-        assumptions: impl ToWcs,
-        parameter: impl Upcast<Parameter>,
-    ) -> Fallible<()> {
-        let parameter: Parameter = parameter.upcast();
-        self.prove_goal(env, assumptions, parameter.well_formed())
-    }
-
-    fn prove_trait_ref_well_formed(
-        &self,
-        env: &Env,
-        assumptions: impl ToWcs,
-        trait_ref: impl Upcast<TraitRef>,
-    ) -> Fallible<()> {
-        let trait_ref: TraitRef = trait_ref.upcast();
-        self.prove_goal(env, assumptions, trait_ref.well_formed())?;
-        Ok(())
+        let wcs: Wcs = where_clauses
+            .into_iter()
+            .flat_map(|wc| wc.well_formed().into_iter())
+            .collect();
+        self.prove_goal(env, assumptions, wcs)
     }
 }

--- a/src/test/consts.rs
+++ b/src/test/consts.rs
@@ -17,8 +17,8 @@ fn nonsense_rigid_const_bound() {
             check_trait(Foo)
 
             Caused by:
-                0: prove_where_clause_well_formed(type_of_const value(0, bool) is u32)
-                1: judgment `prove_wc_list { goal: {u32 = bool}, assumptions: {@ ConstHasType(value(0, bool) , u32)}, env: Env { variables: [], bias: Soundness }, decls: decls(222, [trait Foo <ty> where {@ ConstHasType(value(0, bool) , u32)}], [], [], [], [], [], {Foo}, {}) }` failed at the following rule(s):
+                0: prove_where_clauses_well_formed([type_of_const value(0, bool) is u32])
+                1: judgment `prove_wc_list { goal: {u32 = bool, @ wf(u32), @ wf(const value(0, bool))}, assumptions: {@ ConstHasType(value(0, bool) , u32)}, env: Env { variables: [], bias: Soundness }, decls: decls(222, [trait Foo <ty> where {@ ConstHasType(value(0, bool) , u32)}], [], [], [], [], [], {Foo}, {}) }` failed at the following rule(s):
                      the rule "some" failed at step #0 (src/file.rs:LL:CC) because
                        judgment `prove_wc { goal: u32 = bool, assumptions: {@ ConstHasType(value(0, bool) , u32)}, env: Env { variables: [], bias: Soundness }, decls: decls(222, [trait Foo <ty> where {@ ConstHasType(value(0, bool) , u32)}], [], [], [], [], [], {Foo}, {}) }` failed at the following rule(s):
                          the rule "assumption" failed at step #1 (src/file.rs:LL:CC) because

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -45,7 +45,7 @@ fn hello_world_fail() {
             check_trait(Foo)
 
             Caused by:
-                0: prove_where_clause_well_formed(!ty_2 : Bar <!ty_1>)
+                0: prove_where_clauses_well_formed([!ty_2 : Bar <!ty_1>])
                 1: judgment `prove_wc_list { goal: {@ WellFormedTraitRef(Bar(!ty_0, !ty_1))}, assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness }, decls: decls(222, [trait Foo <ty, ty> where {Bar(^ty0_1, ^ty0_0)}, trait Bar <ty, ty> where {Baz(^ty0_1)}, trait Baz <ty> ], [], [], [], [], [], {Bar, Baz, Foo}, {}) }` failed at the following rule(s):
                      the rule "some" failed at step #0 (src/file.rs:LL:CC) because
                        judgment `prove_wc { goal: @ WellFormedTraitRef(Bar(!ty_0, !ty_1)), assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness }, decls: decls(222, [trait Foo <ty, ty> where {Bar(^ty0_1, ^ty0_0)}, trait Bar <ty, ty> where {Baz(^ty0_1)}, trait Baz <ty> ], [], [], [], [], [], {Bar, Baz, Foo}, {}) }` failed at the following rule(s):
@@ -120,16 +120,17 @@ fn basic_where_clauses_fail() {
             check_trait(WellFormed)
 
             Caused by:
-                0: prove_where_clause_well_formed(for <ty> u32 : A <^ty0_0>)
-                1: prove_where_clause_well_formed(u32 : A <!ty_2>)
-                2: judgment `prove_wc_list { goal: {@ WellFormedTraitRef(A(u32, !ty_0))}, assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
+                0: prove_where_clauses_well_formed([for <ty> u32 : A <^ty0_0>])
+                1: judgment `prove_wc_list { goal: {for <ty> @ WellFormedTraitRef(A(u32, ^ty0_0))}, assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
                      the rule "some" failed at step #0 (src/file.rs:LL:CC) because
-                       judgment `prove_wc { goal: @ WellFormedTraitRef(A(u32, !ty_0)), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
-                         the rule "trait well formed" failed at step #2 (src/file.rs:LL:CC) because
-                           judgment `prove_wc_list { goal: {B(!ty_0)}, assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
-                             the rule "some" failed at step #0 (src/file.rs:LL:CC) because
-                               judgment `prove_wc { goal: B(!ty_0), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
-                                 the rule "trait implied bound" failed at step #0 (src/file.rs:LL:CC) because
-                                   expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
+                       judgment `prove_wc { goal: for <ty> @ WellFormedTraitRef(A(u32, ^ty0_0)), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
+                         the rule "forall" failed at step #2 (src/file.rs:LL:CC) because
+                           judgment `prove_wc { goal: @ WellFormedTraitRef(A(u32, !ty_1)), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_1], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
+                             the rule "trait well formed" failed at step #2 (src/file.rs:LL:CC) because
+                               judgment `prove_wc_list { goal: {B(!ty_0)}, assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
+                                 the rule "some" failed at step #0 (src/file.rs:LL:CC) because
+                                   judgment `prove_wc { goal: B(!ty_0), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
+                                     the rule "trait implied bound" failed at step #0 (src/file.rs:LL:CC) because
+                                       expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
     )
 }


### PR DESCRIPTION
This change is mostly motivated by a comment on `prove_where_clause_well_formed`:
> FIXME(oli-obk): figure out why is this a function and not a `judgment_fn`.

I originally started with converting it to a `judgement_fn` but found I was duplicating a lot of logic from `prove_wc` which already exists. So I settled on moving the logic to a `WhereClause::well_formed` method which creates a set of goals to prove, and then calls `prove_wc` on those goals. 

I'm not _certain_ this is an improvement on the current code. There is more code being run (constructing a set of goals, then checking them is more than just checking), so I wouldn't expect any performance improvement, and it sort of looks like the same code just in a different place, so it's not removing much. The only justification I have is that I wouldn't ever do the reverse of this change (remove the `well_formed` constructor in favour of custom well_formed check).