### PR TITLE
Display matched rules in more proof paths

### DIFF
--- a/crates/formality-core/src/judgment.rs
+++ b/crates/formality-core/src/judgment.rs
@@ -240,6 +240,7 @@ macro_rules! push_rules {
 
     (@match $conclusion_name:ident inputs() patterns() args(@body ($judgment_name:ident; $n:literal; $v:expr; $output:expr); $inputs:tt; $($m:tt)*)) => {
         tracing::trace_span!("matched rule", rule = $n, judgment = stringify!($judgment_name)).in_scope(|| {
+            tracing::debug!("matched rule {:?}", $n);
             $crate::push_rules!(@body ($judgment_name, $n, $v, $output); $inputs; 0; $($m)*);
         });
     };


### PR DESCRIPTION
Currently, the names of the matched rules are displayed in certain paths, prominently when there is an error or constraints are produced. This PR displays the names of the rules whenever a rule is matched. The benefit is that the rules picked are easily identified when debugging, even when the test case does not expect a failure. From experience, I find it particularly helpful for beginners to this project.

![image](https://github.com/user-attachments/assets/c82e22e6-0f2e-4e69-ac1e-db6068f7b4cc)
