### PR TITLE
When proving WellFormedTraitRef, require the parameters to be well-formed

### DIFF
--- a/crates/formality-prove/src/prove/prove_wc.rs
+++ b/crates/formality-prove/src/prove/prove_wc.rs
@@ -4,6 +4,7 @@ use formality_types::grammar::{Predicate, Relation, Wc, WcData, Wcs};
 use crate::{
     decls::Decls,
     prove::{
+        combinators::for_all,
         env::{Bias, Env},
         is_local::{is_local_trait_ref, may_be_remote},
         prove,
@@ -105,9 +106,10 @@ judgment_fn! {
         )
 
         (
-            (let t = decls.trait_decl(&trait_ref.trait_id))
+            (for_all(&decls, &env, &assumptions, &trait_ref.parameters, &prove_wf) => c)
+            (let t = &decls.trait_decl(&trait_ref.trait_id))
             (let t = t.binder.instantiate_with(&trait_ref.parameters).unwrap())
-            (prove(decls, env, assumptions, t.where_clause) => c)
+            (prove_after(&decls, c, &assumptions, t.where_clause) => c)
             ----------------------------- ("trait well formed")
             (prove_wc(decls, env, assumptions, Predicate::WellFormedTraitRef(trait_ref)) => c)
         )

--- a/crates/formality-prove/src/prove/prove_wf.rs
+++ b/crates/formality-prove/src/prove/prove_wf.rs
@@ -1,6 +1,7 @@
 use formality_core::{judgment_fn, ProvenSet};
 use formality_types::grammar::{
-    AliasName, AliasTy, ConstData, Parameter, Parameters, RigidName, RigidTy, UniversalVar, Wcs,
+    AliasName, AliasTy, ConstData, LtData, Parameter, Parameters, RigidName, RigidTy, UniversalVar,
+    Wcs,
 };
 
 use crate::{
@@ -49,6 +50,11 @@ judgment_fn! {
             (prove_after(&decls, c, &assumptions, t.where_clause) => c)
             --- ("ADT")
             (prove_wf(decls, env, assumptions, RigidTy { name: RigidName::AdtId(adt_id), parameters }) => c)
+        )
+
+        (
+            --- ("static lifetime")
+            (prove_wf(_decls, env, _assumptions, LtData::Static) => Constraints::none(env))
         )
 
         (

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -5,6 +5,7 @@ mod coherence_overlap;
 mod consts;
 mod decl_safety;
 mod functions;
+mod well_formed_trait_ref;
 
 #[test]
 fn parser() {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -52,14 +52,16 @@ fn hello_world_fail() {
                        judgment `prove_wc_list { goal: {@ WellFormedTraitRef(Bar(!ty_0, !ty_1))}, assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness } }` failed at the following rule(s):
                          the rule "some" failed at step #0 (src/file.rs:LL:CC) because
                            judgment `prove_wc { goal: @ WellFormedTraitRef(Bar(!ty_0, !ty_1)), assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness } }` failed at the following rule(s):
-                             the rule "trait well formed" failed at step #2 (src/file.rs:LL:CC) because
-                               judgment `prove { goal: {Baz(!ty_1)}, assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness }, decls: decls(222, [trait Foo <ty, ty> where {Bar(^ty0_1, ^ty0_0)}, trait Bar <ty, ty> where {Baz(^ty0_1)}, trait Baz <ty> ], [], [], [], [], [], {Bar, Baz, Foo}, {}) }` failed at the following rule(s):
-                                 failed at (src/file.rs:LL:CC) because
-                                   judgment `prove_wc_list { goal: {Baz(!ty_1)}, assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness } }` failed at the following rule(s):
-                                     the rule "some" failed at step #0 (src/file.rs:LL:CC) because
-                                       judgment `prove_wc { goal: Baz(!ty_1), assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness } }` failed at the following rule(s):
-                                         the rule "trait implied bound" failed at step #0 (src/file.rs:LL:CC) because
-                                           expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
+                             the rule "trait well formed" failed at step #3 (src/file.rs:LL:CC) because
+                               judgment `prove_after { constraints: Constraints { env: Env { variables: [!ty_1, !ty_0], bias: Soundness }, known_true: true, substitution: {} }, goal: {Baz(!ty_1)}, assumptions: {Bar(!ty_0, !ty_1)} }` failed at the following rule(s):
+                                 the rule "prove_after" failed at step #1 (src/file.rs:LL:CC) because
+                                   judgment `prove { goal: {Baz(!ty_1)}, assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness }, decls: decls(222, [trait Foo <ty, ty> where {Bar(^ty0_1, ^ty0_0)}, trait Bar <ty, ty> where {Baz(^ty0_1)}, trait Baz <ty> ], [], [], [], [], [], {Bar, Baz, Foo}, {}) }` failed at the following rule(s):
+                                     failed at (src/file.rs:LL:CC) because
+                                       judgment `prove_wc_list { goal: {Baz(!ty_1)}, assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness } }` failed at the following rule(s):
+                                         the rule "some" failed at step #0 (src/file.rs:LL:CC) because
+                                           judgment `prove_wc { goal: Baz(!ty_1), assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness } }` failed at the following rule(s):
+                                             the rule "trait implied bound" failed at step #0 (src/file.rs:LL:CC) because
+                                               expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
     )
 }
 
@@ -133,14 +135,16 @@ fn basic_where_clauses_fail() {
                            judgment `prove_wc { goal: for <ty> @ WellFormedTraitRef(A(u32, ^ty0_0)), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [], bias: Soundness } }` failed at the following rule(s):
                              the rule "forall" failed at step #2 (src/file.rs:LL:CC) because
                                judgment `prove_wc { goal: @ WellFormedTraitRef(A(u32, !ty_1)), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_1], bias: Soundness } }` failed at the following rule(s):
-                                 the rule "trait well formed" failed at step #2 (src/file.rs:LL:CC) because
-                                   judgment `prove { goal: {B(!ty_0)}, assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
-                                     failed at (src/file.rs:LL:CC) because
-                                       judgment `prove_wc_list { goal: {B(!ty_0)}, assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness } }` failed at the following rule(s):
-                                         the rule "some" failed at step #0 (src/file.rs:LL:CC) because
-                                           judgment `prove_wc { goal: B(!ty_0), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness } }` failed at the following rule(s):
-                                             the rule "trait implied bound" failed at step #0 (src/file.rs:LL:CC) because
-                                               expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
+                                 the rule "trait well formed" failed at step #3 (src/file.rs:LL:CC) because
+                                   judgment `prove_after { constraints: Constraints { env: Env { variables: [!ty_1], bias: Soundness }, known_true: true, substitution: {} }, goal: {B(!ty_1)}, assumptions: {for <ty> A(u32, ^ty0_0)} }` failed at the following rule(s):
+                                     the rule "prove_after" failed at step #1 (src/file.rs:LL:CC) because
+                                       judgment `prove { goal: {B(!ty_0)}, assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness }, decls: decls(222, [trait A <ty, ty> where {B(^ty0_1)}, trait B <ty> , trait WellFormed <ty> where {for <ty> A(u32, ^ty0_0)}], [], [], [], [], [], {A, B, WellFormed}, {}) }` failed at the following rule(s):
+                                         failed at (src/file.rs:LL:CC) because
+                                           judgment `prove_wc_list { goal: {B(!ty_0)}, assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness } }` failed at the following rule(s):
+                                             the rule "some" failed at step #0 (src/file.rs:LL:CC) because
+                                               judgment `prove_wc { goal: B(!ty_0), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0], bias: Soundness } }` failed at the following rule(s):
+                                                 the rule "trait implied bound" failed at step #0 (src/file.rs:LL:CC) because
+                                                   expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
     )
 }
 

--- a/src/test/well_formed_trait_ref.rs
+++ b/src/test/well_formed_trait_ref.rs
@@ -68,3 +68,61 @@ fn missing_dependent_where_clause() {
                                                 expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
     )
 }
+
+#[test]
+fn lifetime_param() {
+    crate::assert_ok!(
+        //@check-pass
+        [
+            crate foo {
+                trait Trait1<lt a> {}
+
+                struct S1 {}
+
+                struct S2<lt a> where S1: Trait1<a> {}
+            }
+        ]
+
+        expect_test::expect!["()"]
+    )
+}
+
+#[test]
+fn static_lifetime_param() {
+    crate::assert_ok!(
+        //@check-pass
+        [
+            crate foo {
+                trait Trait1<lt a> {}
+
+                struct S1 {}
+
+                impl Trait1<static> for S1 {}
+
+                struct S2 where S1: Trait1<static> {}
+            }
+        ]
+
+        expect_test::expect!["()"]
+    )
+}
+
+#[test]
+fn const_param() {
+    crate::assert_ok!(
+        //@check-pass
+        [
+            crate foo {
+                trait Trait1<const C> where type_of_const C is u32 {}
+
+                struct S1 {}
+
+                impl Trait1<const 3_u32> for S1 {}
+
+                struct S2 where S1: Trait1<const 3_u32> {}
+            }
+        ]
+
+        expect_test::expect!["()"]
+    )
+}

--- a/src/test/well_formed_trait_ref.rs
+++ b/src/test/well_formed_trait_ref.rs
@@ -45,6 +45,26 @@ fn missing_dependent_where_clause() {
 
         [ /* TODO */ ]
 
-        expect_test::expect![[r#"..."#]]
+        expect_test::expect![[r#"
+            prove_where_clauses_well_formed([S1<!ty_1> : Trait2])
+
+            Caused by:
+                judgment `prove { goal: {@ WellFormedTraitRef(Trait2(S1<!ty_0>))}, assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0], bias: Soundness }, decls: decls(222, [trait Trait1 <ty> , trait Trait2 <ty> ], [], [], [], [], [adt S1 <ty> where {Trait1(^ty0_0)}, adt S2 <ty> where {Trait2(S1<^ty0_0>)}], {Trait1, Trait2}, {S1, S2}) }` failed at the following rule(s):
+                  failed at (src/file.rs:LL:CC) because
+                    judgment `prove_wc_list { goal: {@ WellFormedTraitRef(Trait2(S1<!ty_0>))}, assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0], bias: Soundness } }` failed at the following rule(s):
+                      the rule "some" failed at step #0 (src/file.rs:LL:CC) because
+                        judgment `prove_wc { goal: @ WellFormedTraitRef(Trait2(S1<!ty_0>)), assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0], bias: Soundness } }` failed at the following rule(s):
+                          the rule "trait well formed" failed at step #0 (src/file.rs:LL:CC) because
+                            judgment `prove_wf { goal: S1<!ty_0>, assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0], bias: Soundness } }` failed at the following rule(s):
+                              the rule "ADT" failed at step #3 (src/file.rs:LL:CC) because
+                                judgment `prove_after { constraints: Constraints { env: Env { variables: [!ty_0], bias: Soundness }, known_true: true, substitution: {} }, goal: {Trait1(!ty_0)}, assumptions: {Trait2(S1<!ty_0>)} }` failed at the following rule(s):
+                                  the rule "prove_after" failed at step #1 (src/file.rs:LL:CC) because
+                                    judgment `prove { goal: {Trait1(!ty_0)}, assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0], bias: Soundness }, decls: decls(222, [trait Trait1 <ty> , trait Trait2 <ty> ], [], [], [], [], [adt S1 <ty> where {Trait1(^ty0_0)}, adt S2 <ty> where {Trait2(S1<^ty0_0>)}], {Trait1, Trait2}, {S1, S2}) }` failed at the following rule(s):
+                                      failed at (src/file.rs:LL:CC) because
+                                        judgment `prove_wc_list { goal: {Trait1(!ty_0)}, assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0], bias: Soundness } }` failed at the following rule(s):
+                                          the rule "some" failed at step #0 (src/file.rs:LL:CC) because
+                                            judgment `prove_wc { goal: Trait1(!ty_0), assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0], bias: Soundness } }` failed at the following rule(s):
+                                              the rule "trait implied bound" failed at step #0 (src/file.rs:LL:CC) because
+                                                expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
     )
 }

--- a/src/test/well_formed_trait_ref.rs
+++ b/src/test/well_formed_trait_ref.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 #[test]
 fn dependent_where_clause() {
     crate::assert_ok!(
@@ -125,4 +123,38 @@ fn const_param() {
 
         expect_test::expect!["()"]
     )
+}
+
+#[test]
+#[should_panic(expected = "wrong number of parameters")]
+fn type_with_wrong_number_of_parameters() {
+    crate::test_program_ok(
+        " [
+            crate foo {
+                trait Trait1 {}
+
+                struct S1 {}
+
+                struct S2<ty T> where S1<T> : Trait1 {
+                    dummy: T,
+                }
+            }
+        ] ",
+    )
+    .unwrap();
+}
+
+#[test]
+#[should_panic(expected = "no ADT named `Nonex`")]
+fn where_clause_with_nonexistent_type() {
+    crate::test_program_ok(
+        " [
+            crate foo {
+                trait Trait1 {}
+
+                struct S1 where Nonex: Trait1 {}
+            }
+        ] ",
+    )
+    .unwrap();
 }

--- a/src/test/well_formed_trait_ref.rs
+++ b/src/test/well_formed_trait_ref.rs
@@ -1,0 +1,50 @@
+#![allow(non_snake_case)]
+
+#[test]
+fn dependent_where_clause() {
+    crate::assert_ok!(
+        //@check-pass
+        [
+            crate foo {
+                trait Trait1 {}
+
+                trait Trait2 {}
+
+                struct S1<ty T> where T: Trait1 {
+                    dummy: T,
+                }
+
+                struct S2<ty T> where T: Trait1, S1<T> : Trait2 {
+                    dummy: T,
+                }
+            }
+        ]
+
+        expect_test::expect!["()"]
+    )
+}
+
+#[test]
+fn missing_dependent_where_clause() {
+    crate::assert_err!(
+        [
+            crate foo {
+                trait Trait1 {}
+
+                trait Trait2 {}
+
+                struct S1<ty T> where T: Trait1 {
+                    dummy: T,
+                }
+
+                struct S2<ty T> where S1<T> : Trait2 {
+                    dummy: T,
+                }
+            }
+        ]
+
+        [ /* TODO */ ]
+
+        expect_test::expect![[r#"..."#]]
+    )
+}


### PR DESCRIPTION
Closes #189

Also adds a rule to `prove_wf()` saying that the `'static` lifetime counts as well-formed.

