### PR TITLE
Configure triagebot to have label shortcut

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,1 +1,4 @@
 [assign]
+
+# Gives us the commands 'ready', 'author', 'blocked'
+[shortcut]


### PR DESCRIPTION
It is more convenient to give PR author access to add ``ready``, ``author`` and ``block`` label.

I believe someone with repo access needs to add all the labels below
- ``S-waiting-on-author``
- ``S-waiting-on-review``
- ``S-blocked``

for this to work.