### PR TITLE
feat: add closure type syntax and borrow-check support for closure calls

### DIFF
--- a/crates/formality-rust/src/check/borrow_check/liveness.rs
+++ b/crates/formality-rust/src/check/borrow_check/liveness.rs
@@ -162,6 +162,9 @@ impl LiveBefore for ValueExpression {
             ValueExpression::Ref(_ref_kind, _lt, place_expression) => {
                 place_expression.live_before(env, places_live)
             }
+            ValueExpression::Closure(_closure_id, value_expressions, _ty) => {
+                value_expressions.live_before(env, places_live)
+            }
         }
     }
 }

--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -5,8 +5,8 @@ use crate::grammar::minirust::{
 };
 use crate::grammar::PredicateTy;
 use crate::grammar::{
-    AliasTy, Lt, LtData, Parameter, RefKind, Relation, RigidName, RigidTy, Ty, TyData, Variable,
-    VariantId, Wcs,
+    AliasTy, ClosureId, Lt, LtData, Parameter, RefKind, Relation, RigidName, RigidTy, Ty, TyData,
+    Variable, VariantId, Wcs,
 };
 use crate::prove::prove::{prove, AdtDeclBoundData, AdtDeclVariant};
 use formality_core::{judgment::ProofTree, judgment_fn, set, term, Cons, Fallible, Set, Upcast};
@@ -402,6 +402,50 @@ judgment_fn! {
             --- ("call")
             (borrow_check_terminator(stack, env, assumptions, loans_live, outlives, Terminator::Call { callee, generic_arguments: _, arguments, ret, next_block }) => ())
         )
+
+        (
+            (let places_live = places_live_before_basic_blocks(env, next_block))
+
+            // Check the callee
+            (borrow_check_value_expression(
+                env,
+                assumptions,
+                loans_live,
+                outlives,
+                callee,
+                (arguments, Assignment(ret)).live_before(env, places_live),
+            ) => (callee_ty, outlives, loans_live))
+
+            // Extract ClosureDef from callee type
+            (if let TyData::RigidTy(rigid_ty) = callee_ty.data())
+            (if let RigidName::ClosureDef(closure_id) = &rigid_ty.name)
+            (let closure_id: ClosureId = closure_id.clone())
+
+            // Find the closure definition
+            (if let Some(closure_def) = env.closure_def(&closure_id))
+
+            // Instantiate the closure signature with the type parameters from the callee type
+            (let closure_bound = closure_def.binder.instantiate_with(&rigid_ty.parameters)?)
+            (let callee_declared_input_tys: Vec<Ty> = closure_bound.input_args.iter().map(|a| a.ty.clone()).collect())
+
+            // Check argument count matches
+            (if callee_declared_input_tys.len() == arguments.len())
+
+            (borrow_check_argument_expressions(
+                env,
+                assumptions,
+                loans_live,
+                outlives,
+                callee_declared_input_tys,
+                arguments,
+                Assignment(ret).live_before(env, places_live),
+            ) => (outlives, loans_live))
+
+            (for_all(next_block in next_block.iter())
+                (borrow_check_block(stack, env, assumptions, loans_live, outlives, next_block) => ()))
+            --- ("call-closure")
+            (borrow_check_terminator(stack, env, assumptions, loans_live, outlives, Terminator::Call { callee, generic_arguments: _, arguments, ret, next_block }) => ())
+        )
     }
 }
 
@@ -659,6 +703,21 @@ judgment_fn! {
                 (env.prove_goal(outlives, Location, assumptions, Relation::sub(value_ty, &fields[i].ty)) => outlives))
             --- ("struct")
             (borrow_check_value_expression(env, assumptions, loans_live, outlives, ValueExpression::Struct(field_values, ty), places_live) => (&ty, outlives, loans_live))
+        )
+
+        (
+            // Closure construction: borrow-check each captured value expression
+            (if let Some(closure_def) = env.closure_def(&closure_id))
+            (if let TyData::RigidTy(rigid_ty) = ty.data())
+            (if let RigidName::ClosureDef(_) = &rigid_ty.name)
+            (let closure_bound = closure_def.binder.instantiate_with(&rigid_ty.parameters)?)
+            (if capture_values.len() == closure_bound.captures.len())
+            (for_all(i in 0..capture_values.len()) with(outlives, loans_live)
+                (let places_live_before = capture_values[i+1..].live_before(&env, &places_live))
+                (borrow_check_value_expression(env, assumptions, loans_live, outlives, &capture_values[i], places_live_before) => (value_ty, outlives, loans_live))
+                (env.prove_goal(outlives, Location, assumptions, Relation::sub(value_ty, &closure_bound.captures[i].ty)) => outlives))
+            --- ("closure")
+            (borrow_check_value_expression(env, assumptions, loans_live, outlives, ValueExpression::Closure(closure_id, capture_values, ty), places_live) => (&ty, outlives, loans_live))
         )
 
         (

--- a/crates/formality-rust/src/check/closures.rs
+++ b/crates/formality-rust/src/check/closures.rs
@@ -1,0 +1,92 @@
+use crate::grammar::{ClosureDef, ClosureDefBoundData, CrateId, Fallible, MaybeFnBody, Wcs};
+use crate::prove::prove::Env;
+use crate::prove::ToWcs;
+use formality_core::judgment::ProofTree;
+
+use crate::check::Check;
+
+impl Check<'_> {
+    pub(crate) fn check_closure_def(
+        &self,
+        c: &ClosureDef,
+        crate_id: &CrateId,
+    ) -> Fallible<ProofTree> {
+        let ClosureDef { id: _, binder } = c;
+        let mut env = Env::default();
+        let ClosureDefBoundData {
+            captures,
+            input_args,
+            output_ty,
+            where_clauses,
+            body,
+        } = env.instantiate_universally(binder);
+
+        let fn_assumptions: Wcs = where_clauses.to_wcs();
+
+        let mut proof_tree = ProofTree::leaf(format!("check_closure_def({c:?})"));
+
+        // Check well-formedness of where-clauses
+        proof_tree
+            .children
+            .push(self.prove_where_clauses_well_formed(&env, &fn_assumptions, &where_clauses)?);
+
+        // Check well-formedness of capture types
+        for capture in &captures {
+            proof_tree.children.push(self.prove_goal(
+                &env,
+                &fn_assumptions,
+                capture.ty.well_formed(),
+            )?);
+        }
+
+        // Check well-formedness of input types
+        for input_arg in &input_args {
+            proof_tree.children.push(self.prove_goal(
+                &env,
+                &fn_assumptions,
+                input_arg.ty.well_formed(),
+            )?);
+        }
+
+        // Check well-formedness of output type
+        proof_tree.children.push(self.prove_goal(
+            &env,
+            &fn_assumptions,
+            output_ty.well_formed(),
+        )?);
+
+        // Type-check the body if present.
+        // Captures are treated as input args to the body.
+        match body {
+            MaybeFnBody::NoFnBody => {}
+            MaybeFnBody::FnBody(fn_body) => match fn_body {
+                crate::grammar::FnBody::TrustedFnBody => {}
+                crate::grammar::FnBody::Literal(_, _) => todo!(),
+                crate::grammar::FnBody::MiniRust(body) => {
+                    // Captures become input arguments for the body
+                    let capture_args: Vec<_> = captures
+                        .iter()
+                        .map(|cap| crate::grammar::InputArg {
+                            id: cap.id.clone(),
+                            ty: cap.ty.clone(),
+                        })
+                        .collect();
+                    let all_args: Vec<_> = capture_args
+                        .into_iter()
+                        .chain(input_args.into_iter())
+                        .collect();
+                    proof_tree.children.push(self.check_body(
+                        &env,
+                        &output_ty,
+                        &fn_assumptions,
+                        body,
+                        all_args,
+                        crate_id,
+                    )?);
+                }
+            },
+        }
+
+        Ok(proof_tree)
+    }
+}

--- a/crates/formality-rust/src/check/mini_rust_check.rs
+++ b/crates/formality-rust/src/check/mini_rust_check.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use crate::check::borrow_check::nll::verify_universal_outlives;
 use crate::grammar::minirust::ArgumentExpression::{ByValue, InPlace};
-use crate::grammar::minirust::ValueExpression::{Constant, Fn, Load, Ref, Struct};
+use crate::grammar::minirust::ValueExpression::{Closure, Constant, Fn, Load, Ref, Struct};
 use crate::grammar::minirust::{
     self, ArgumentExpression, BasicBlock, BbId, LocalId, PlaceExpression, ValueExpression,
 };
 use crate::grammar::minirust::{BodyBound, PlaceExpression::*};
 use crate::grammar::{
-    AdtId, Binder, CrateId, FnId, InputArg, Parameter, Relation, RigidName, RigidTy, Ty, TyData,
-    VariantId, Wcs,
+    AdtId, Binder, ClosureDef, ClosureId, CrateId, FnId, InputArg, Parameter, Relation, RigidName,
+    RigidTy, Ty, TyData, VariantId, Wcs,
 };
 use crate::grammar::{Fn as FnDecl, Program};
 use crate::prove::prove::{
@@ -195,6 +195,21 @@ judgment_fn! {
             --- ("ref")
             (check_value(env, outlives, fn_assumptions, Ref(ref_kind, borrow_lt, place_expr)) => (value_ty, env, outlives))
         )
+
+        (
+            (if let Some(closure_def) = env.closure_def(closure_id))
+            (if let TyData::RigidTy(rigid_ty) = ty.data())
+            (if let RigidName::ClosureDef(_) = &rigid_ty.name)
+            (let closure_bound = closure_def.binder.instantiate_with(&rigid_ty.parameters)?)
+            (if value_expressions.len() == closure_bound.captures.len())
+            (for_all(pair in value_expressions.iter().zip(&closure_bound.captures)) with(outlives)
+                (let (value_expression, capture) = pair)
+                (check_value(env, outlives, fn_assumptions, value_expression) => (value_ty, _env, outlives))
+                (env.prove_goal(outlives, Location, fn_assumptions, Relation::sub(value_ty, &capture.ty)) => outlives))
+            (let value_ty = ty)
+            --- ("closure")
+            (check_value(env, outlives, fn_assumptions, Closure(closure_id, value_expressions, ty)) => (value_ty, env, outlives))
+        )
     }
 }
 
@@ -316,6 +331,46 @@ judgment_fn! {
         )
 
         (
+            // Check callee value expression
+            (check_value(env, outlives, fn_assumptions, callee) => (callee_ty, env, outlives))
+
+            // Extract ClosureDef from callee type
+            (if let TyData::RigidTy(rigid_ty) = callee_ty.data())
+            (if let RigidName::ClosureDef(closure_id) = &rigid_ty.name)
+
+            // Find the closure definition
+            (if let Some(closure_def) = env.closure_def(closure_id))
+
+            // Instantiate the closure signature with the type parameters from the callee type
+            (let closure_bound = closure_def.binder.instantiate_with(&rigid_ty.parameters)?)
+            (let callee_declared_input_tys: Vec<Ty> = closure_bound.input_args.iter().map(|a| a.ty.clone()).collect())
+
+            // Check argument count matches
+            (if callee_declared_input_tys.len() == actual_arguments.len())
+
+            // Check each argument and subtyping
+            (for_all(arg_pair in callee_declared_input_tys.iter().zip(actual_arguments)) with(outlives)
+                (let (declared_ty, actual_argument) = arg_pair)
+                (check_argument_expression(env, outlives, fn_assumptions, &actual_argument) => (actual_ty, _env, outlives))
+                (env.prove_goal(outlives, Location, fn_assumptions, Relation::sub(actual_ty, declared_ty)) => outlives))
+
+            // Check return place
+            (check_place(env, outlives, fn_assumptions, ret) => (actual_return_ty, env, outlives))
+            (env.prove_goal(outlives, Location, fn_assumptions, Relation::sub(&closure_bound.output_ty, &actual_return_ty)) => outlives)
+
+            // Check next block exists if present
+            (if next_block.as_ref().map_or(true, |bb_id| env.block_exists(bb_id)))
+            --- ("call-closure")
+            (check_terminator(env, outlives, fn_assumptions, minirust::Terminator::Call {
+                callee,
+                generic_arguments: _,
+                arguments: actual_arguments,
+                ret,
+                next_block,
+            }) => (env, outlives))
+        )
+
+        (
             --- ("return")
             (check_terminator(env, outlives, _fn_assumptions, minirust::Terminator::Return) => (env, outlives))
         )
@@ -344,6 +399,17 @@ impl TypeckEnv {
         let curr_crate = self.program.crates.iter().find(|c| c.id == self.crate_id)?;
         curr_crate.items.iter().find_map(|item| match item {
             CrateItem::Fn(fn_decl) if fn_decl.id == *fn_id => Some(fn_decl),
+            _ => None,
+        })
+    }
+
+    /// Look up a closure definition by its id in the current crate.
+    pub(crate) fn closure_def(&self, closure_id: &ClosureId) -> Option<&ClosureDef> {
+        let curr_crate = self.program.crates.iter().find(|c| c.id == self.crate_id)?;
+        curr_crate.items.iter().find_map(|item| match item {
+            CrateItem::ClosureDef(closure_def) if closure_def.id == *closure_id => {
+                Some(closure_def)
+            }
             _ => None,
         })
     }

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -12,6 +12,7 @@ use anyhow::{anyhow, bail};
 use formality_core::{judgment::ProofTree, ProvenSet, Set};
 
 mod borrow_check;
+mod closures;
 mod mini_rust_check;
 
 /// Check all crates in the program. The crates must be in dependency order
@@ -108,6 +109,7 @@ impl Check<'_> {
                         }
                     }
                     CrateItem::TraitImpl(_) | CrateItem::NegTraitImpl(_) | CrateItem::Test(_) => {}
+                    CrateItem::ClosureDef(_) => {}
                     CrateItem::FeatureGate(_) => {}
                 }
             }
@@ -124,6 +126,7 @@ impl Check<'_> {
             CrateItem::Enum(e) => self.check_adt(&e.to_adt()),
             CrateItem::Fn(f) => self.check_free_fn(f, crate_id),
             CrateItem::NegTraitImpl(i) => self.check_neg_trait_impl(i),
+            CrateItem::ClosureDef(c) => self.check_closure_def(c, crate_id),
             CrateItem::Test(t) => self.check_test(t),
             CrateItem::FeatureGate(_feature_gate) => {
                 // FIXME(#212): reject duplicate feature gates within a crate

--- a/crates/formality-rust/src/grammar.rs
+++ b/crates/formality-rust/src/grammar.rs
@@ -12,6 +12,9 @@ pub use crates::*;
 mod structs_enums_and_adts;
 pub use structs_enums_and_adts::*;
 
+mod closures;
+pub use closures::*;
+
 mod fns;
 pub use fns::*;
 

--- a/crates/formality-rust/src/grammar/closures.rs
+++ b/crates/formality-rust/src/grammar/closures.rs
@@ -1,0 +1,36 @@
+use crate::grammar::fns::InputArg;
+use crate::grammar::minirust::LocalId;
+use crate::grammar::{Binder, ClosureId, MaybeFnBody, Ty, WhereClause};
+use formality_core::term;
+
+#[term(closure $id $binder)]
+pub struct ClosureDef {
+    pub id: ClosureId,
+    pub binder: Binder<ClosureDefBoundData>,
+}
+
+#[term([$,captures] ($,input_args) -> $output_ty $:where $,where_clauses $body)]
+pub struct ClosureDefBoundData {
+    pub captures: Vec<CaptureDecl>,
+    pub input_args: Vec<InputArg>,
+    pub output_ty: Ty,
+    pub where_clauses: Vec<WhereClause>,
+    pub body: MaybeFnBody,
+}
+
+#[term($id : $mode $ty)]
+pub struct CaptureDecl {
+    pub id: LocalId,
+    pub mode: CaptureMode,
+    pub ty: Ty,
+}
+
+#[term]
+pub enum CaptureMode {
+    #[grammar(by_value)]
+    ByValue,
+    #[grammar(by_ref)]
+    ByRef,
+    #[grammar(by_mut_ref)]
+    ByMutRef,
+}

--- a/crates/formality-rust/src/grammar/crates.rs
+++ b/crates/formality-rust/src/grammar/crates.rs
@@ -1,5 +1,5 @@
 use crate::grammar::{Binder, CrateId};
-use crate::grammar::{Enum, Fn, NegTraitImpl, Struct, Trait, TraitImpl, WhereClause};
+use crate::grammar::{ClosureDef, Enum, Fn, NegTraitImpl, Struct, Trait, TraitImpl, WhereClause};
 use formality_core::term;
 
 use crate::grammar::feature::FeatureGate;
@@ -26,6 +26,8 @@ pub enum CrateItem {
     NegTraitImpl(NegTraitImpl),
     #[cast]
     Fn(Fn),
+    #[cast]
+    ClosureDef(ClosureDef),
     #[cast]
     Test(Test),
 }

--- a/crates/formality-rust/src/grammar/ids.rs
+++ b/crates/formality-rust/src/grammar/ids.rs
@@ -7,6 +7,7 @@ id!(AssociatedItemId);
 id!(CrateId);
 id!(FieldId);
 id!(VariantId);
+id!(ClosureId);
 
 impl VariantId {
     /// Returns the special variant-id used for the single variant of a struct.

--- a/crates/formality-rust/src/grammar/minirust.rs
+++ b/crates/formality-rust/src/grammar/minirust.rs
@@ -2,7 +2,7 @@ use super::{Binder, Lt, Parameter, RefKind, ScalarId, Ty};
 use formality_core::{id, term, UpcastFrom};
 
 use crate::grammar::minirust::ConstTypePair::*;
-use crate::grammar::FnId;
+use crate::grammar::{ClosureId, FnId};
 
 use std::sync::Arc;
 
@@ -207,6 +207,8 @@ pub enum ValueExpression {
     // AddrOf
     // UnOp
     // BinOp
+    #[grammar(closure $v0 {$,v1} as $v2)]
+    Closure(ClosureId, Vec<ValueExpression>, Ty),
 }
 
 #[term]

--- a/crates/formality-rust/src/grammar/ty.rs
+++ b/crates/formality-rust/src/grammar/ty.rs
@@ -1,3 +1,4 @@
+use crate::grammar::ClosureId;
 use formality_core::{cast_impl, term};
 use std::sync::Arc;
 
@@ -165,6 +166,7 @@ pub enum RigidName {
     Tuple(usize),
     FnPtr(usize),
     FnDef(FnId),
+    ClosureDef(ClosureId),
 }
 
 #[term]

--- a/crates/formality-rust/src/grammar/ty/parse_impls.rs
+++ b/crates/formality-rust/src/grammar/ty/parse_impls.rs
@@ -4,7 +4,7 @@ use formality_core::parse::{ActiveVariant, CoreParse, ParseResult, Parser, Prece
 use formality_core::seq;
 use formality_core::Upcast;
 
-use crate::grammar::{AdtId, AssociatedItemId, RefKind, RigidName, TraitId};
+use crate::grammar::{AdtId, AssociatedItemId, ClosureId, RefKind, RigidName, TraitId};
 
 use super::{AliasTy, AssociatedTyName, Lt, Parameter, RigidTy, ScalarId, Ty};
 
@@ -57,6 +57,19 @@ impl CoreParse<Rust> for RigidTy {
                             name: RigidName::Ref(RefKind::Mut),
                             parameters: seq![lt.clone().upcast(), ty.upcast()],
                         })
+                    })
+                })
+            });
+
+            // Parse `closure_ty(id)` as a closure type.
+            parser.parse_variant("ClosureDef", Precedence::default(), |p| {
+                p.expect_keyword("closure_ty")?;
+                p.expect_char('(')?;
+                p.each_nonterminal(|id: ClosureId, p| {
+                    p.expect_char(')')?;
+                    p.ok(RigidTy {
+                        name: RigidName::ClosureDef(id),
+                        parameters: vec![],
                     })
                 })
             });

--- a/crates/formality-rust/src/lib.rs
+++ b/crates/formality-rust/src/lib.rs
@@ -15,6 +15,11 @@ formality_core::declare_language! {
             "true",
             "false",
             "static",
+            "closure",
+            "closure_ty",
+            "by_value",
+            "by_ref",
+            "by_mut_ref",
         ];
     }
 }

--- a/crates/formality-rust/src/prove/prove/prove/is_local.rs
+++ b/crates/formality-rust/src/prove/prove/prove/is_local.rs
@@ -332,6 +332,7 @@ fn is_fundamental(_decls: &Decls, name: &RigidName) -> bool {
         RigidName::ScalarId(_)
         | RigidName::Tuple(_)
         | RigidName::FnPtr(_)
-        | RigidName::FnDef(_) => false,
+        | RigidName::FnDef(_)
+        | RigidName::ClosureDef(_) => false,
     }
 }

--- a/crates/formality-rust/src/prove/prove/prove/prove_wf.rs
+++ b/crates/formality-rust/src/prove/prove/prove/prove_wf.rs
@@ -71,6 +71,24 @@ judgment_fn! {
         )
 
         (
+            (for_all(decls, env, assumptions, parameters, &prove_wf) => c)
+            --- ("fn-ptr")
+            (prove_wf(decls, env, assumptions, RigidTy { name: RigidName::FnPtr(_), parameters }) => c)
+        )
+
+        (
+            (for_all(decls, env, assumptions, parameters, &prove_wf) => c)
+            --- ("fn-def")
+            (prove_wf(decls, env, assumptions, RigidTy { name: RigidName::FnDef(_), parameters }) => c)
+        )
+
+        (
+            (for_all(decls, env, assumptions, parameters, &prove_wf) => c)
+            --- ("closure-def")
+            (prove_wf(decls, env, assumptions, RigidTy { name: RigidName::ClosureDef(_), parameters }) => c)
+        )
+
+        (
             (prove_alias_wf(decls, env, assumptions, name, parameters) => c)
             --- ("aliases")
             (prove_wf(decls, env, assumptions, AliasTy { name, parameters }) => c)

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::rust::term;
+use crate::rust::{term, try_term};
 use formality_macros::test;
 
 use crate::grammar::Program;
@@ -145,4 +145,19 @@ fn test_parse_rust_like_struct_syntax() {
         }
     "#]]
     .assert_debug_eq(&r);
+}
+
+#[test]
+fn test_parse_closure_def_directly() {
+    let r: Result<crate::grammar::ClosureDef, _> =
+        try_term("closure my_cl [] () -> u32 { trusted }");
+    eprintln!("closure parse result: {:?}", r);
+    assert!(r.is_ok(), "Failed to parse: {:?}", r.unwrap_err());
+}
+
+#[test]
+fn test_parse_program_with_closure() {
+    let r: Result<Program, _> = try_term("[crate Foo { closure my_cl [] () -> u32 { trusted } }]");
+    eprintln!("program parse result: {:?}", r);
+    assert!(r.is_ok(), "Failed to parse: {:?}", r.unwrap_err());
 }

--- a/src/test/closures.rs
+++ b/src/test/closures.rs
@@ -1,0 +1,147 @@
+use formality_core::test;
+
+/// Test: closure definition with a trusted body passes checking.
+#[test]
+fn test_closure_def_trusted() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                closure my_closure [] () -> u32 { trusted }
+            }
+        ]
+    )
+}
+
+/// Test: closure definition with a by_value capture and trusted body.
+#[test]
+fn test_closure_def_with_capture() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                closure my_closure [cap0 : by_value u32] () -> u32 { trusted }
+            }
+        ]
+    )
+}
+
+/// Test: construct a closure value and assign it to a local.
+#[test]
+fn test_closure_construction() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                closure my_closure [cap0 : by_value u32] () -> u32 { trusted }
+
+                fn caller(v1: u32) -> u32 = minirust {
+                    exists {
+                        let v2: closure_ty(my_closure);
+
+                        bb0: {
+                            statements {
+                                local(v2) = closure my_closure { load(local(v1)) } as closure_ty(my_closure);
+                                local(_return) = constant(0: u32);
+                            }
+                            return;
+                        }
+                    }
+                };
+            }
+        ]
+    )
+}
+
+/// Test: construct a closure and call it.
+#[test]
+fn test_closure_call() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                closure my_closure [cap0 : by_value u32] (v1: u32) -> u32 { trusted }
+
+                fn caller(v1: u32) -> u32 = minirust {
+                    exists {
+                        let v2: closure_ty(my_closure);
+
+                        bb0: {
+                            statements {
+                                local(v2) = closure my_closure { load(local(v1)) } as closure_ty(my_closure);
+                            }
+                            call load(local(v2)) (Copy(constant(42: u32))) -> local(_return) goto bb1;
+                        }
+
+                        bb1: {
+                            statements {}
+                            return;
+                        }
+                    }
+                };
+            }
+        ]
+    )
+}
+
+/// Test: closure with no captures and no arguments.
+#[test]
+fn test_closure_no_captures_no_args() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                closure my_closure [] () -> u32 { trusted }
+
+                fn caller() -> u32 = minirust {
+                    exists {
+                        let v1: closure_ty(my_closure);
+
+                        bb0: {
+                            statements {
+                                local(v1) = closure my_closure { } as closure_ty(my_closure);
+                            }
+                            call load(local(v1)) () -> local(_return) goto bb1;
+                        }
+
+                        bb1: {
+                            statements {}
+                            return;
+                        }
+                    }
+                };
+            }
+        ]
+    )
+}
+
+/// Test: calling a closure with wrong argument type should fail.
+#[test]
+fn test_closure_call_wrong_arg_type() {
+    crate::assert_err!(
+        [
+            crate Foo {
+                closure my_closure [] (v1: u32) -> u32 { trusted }
+
+                fn caller() -> u32 = minirust {
+                    exists {
+                        let v1: closure_ty(my_closure);
+
+                        bb0: {
+                            statements {
+                                local(v1) = closure my_closure { } as closure_ty(my_closure);
+                            }
+                            call load(local(v1)) (Copy(constant(true))) -> local(_return) goto bb1;
+                        }
+
+                        bb1: {
+                            statements {}
+                            return;
+                        }
+                    }
+                };
+            }
+        ]
+
+        [ /* TODO */ ]
+
+        expect_test::expect![[r#"
+            the rule "call" at (nll.rs) failed because
+              pattern `RigidName::FnDef(fn_id)` did not match value `closure_def(my_closure)`"#]]
+    )
+}

--- a/src/test/mir_typeck.rs
+++ b/src/test/mir_typeck.rs
@@ -369,6 +369,9 @@ fn test_call_invalid_fn() {
         []
         expect_test::expect![[r#"
             the rule "fn" at (nll.rs) failed because
+              pattern `Some(fn_decl)` did not match value `None`
+
+            the rule "fn" at (nll.rs) failed because
               pattern `Some(fn_decl)` did not match value `None`"#]]
     )
 }
@@ -408,7 +411,9 @@ fn test_pass_non_subtype_arg() {
             }
         ]
         []
-        expect_test::expect!["judgment had no applicable rules: `borrow_check_block { loans_live_on_entry: {}, bb_id: bb0, fn_assumptions: {}, env: TypeckEnv { program: [crate Foo { fn foo (v1 : u32) -> u32 = minirust{ exists { bb0 : { statements{ local(_return) = load(local(v1)) ; } return ; } } } ; fn bar (v1 : ()) -> () = minirust{ exists { bb0 : { statements{ local(_return) = load(local(v1)) ; } call fn_id foo (Move(local(v1))) -> local(_return) goto Some(bb1) ; } bb1 : { statements{ } return ; } } } ; }], env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false }, output_ty: (), local_variables: {_return: (), v1: ()}, blocks: [bb0 : { statements{ local(_return) = load(local(v1)) ; } call fn_id foo (Move(local(v1))) -> local(_return) goto Some(bb1) ; }, bb1 : { statements{ } return ; }], ret_id: _return, input_args: [v1 : ()], crate_id: Foo, decls: decls([crate Foo { fn foo (v1 : u32) -> u32 = minirust{ exists { bb0 : { statements{ local(_return) = load(local(v1)) ; } return ; } } } ; fn bar (v1 : ()) -> () = minirust{ exists { bb0 : { statements{ local(_return) = load(local(v1)) ; } call fn_id foo (Move(local(v1))) -> local(_return) goto Some(bb1) ; } bb1 : { statements{ } return ; } } } ; }], 222) }, outlives: {}, stack: [] }`"]
+        expect_test::expect![[r#"
+            the rule "call-closure" at (nll.rs) failed because
+              pattern `RigidName::ClosureDef(closure_id)` did not match value `fn_def(foo)`"#]]
     )
 }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 mod borrowck;
+mod closures;
 mod coherence_orphan;
 mod coherence_overlap;
 mod const_generics_rv_tsv_parse;


### PR DESCRIPTION
## Summary
  - Add `closure_ty(id)` syntax for writing closure types in MIR
  - Add `call-closure` rule to borrow checker for type-checking closure     
  calls
  - Add integration tests for closure construction, calling, and
  wrong-arg-type rejection

  ## Test plan
  - [ ] `cargo test --all` passes (98/98)
  - [ ] `cargo fmt --all -- --check` passes
  
  Closes #236