### PR TITLE
enable creation of lang item crate

### DIFF
--- a/crates/formality-rust/src/check/core_crate.rs
+++ b/crates/formality-rust/src/check/core_crate.rs
@@ -1,0 +1,8 @@
+use crate::grammar::Crate;
+
+pub fn krate() -> Crate {
+    Crate {
+        id: "core".to_string().into(),
+        items: vec![],
+    }
+}

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -21,6 +21,7 @@ pub mod borrow_check;
 
 mod adts;
 mod coherence;
+mod core_crate;
 mod fns;
 mod impls;
 mod traits;
@@ -33,6 +34,14 @@ judgment_fn! {
         debug(crates)
 
         (
+            // Add the core crate if the first crate isn't called `core`.
+            (let crates = if crates.crates.first().map_or(true, |first| &*first.id == "core") {
+                crates.clone()
+            } else {
+                let Crates { mut crates } = crates.clone();
+                crates.push(core_crate::krate());
+                Crates { crates: crates }
+            })
             // Check that all crates up to and including crate #i are valid.
             // Crate #i will be considered the "current crate".
             (for_all(i in 0..crates.len())


### PR DESCRIPTION
For the formality work on field projections, we need to define some custom traits that are always present. My idea was to just create a crate that's implicitly added to each `Program`. In order to do those changes later, I have made the `crates` field private and changed the constructors.

See my other branch on how I added the new lang items crate: https://github.com/BennoLossin/a-mir-formality/tree/field-projections

I spoke with @dingxiangfei2009 and he could also make use of this for the reborrowing project goal.