### PR TITLE
docs: fill in intro page and fix outdated crate names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,12 @@ Like any Rust project:
 
 ## Layers of formality
 
-Formality is structured into several layers. These layers are meant to also map
-fairly closely onto chalk and the eventual Rust trait solver implementation.
-Ideally, one should be able to map back and forth between formality and the code
-with ease.
+Formality is structured into several layers:
 
-* **formality-check**: Defines the top-level routines for checking Rust programs.
-  `check_all_crates` is effectively the `main`, so it's a good place to start reading.
-* **formality-core**: Defines logging macros.
 * **formality-macros**: Defines procedural macros like `#[term]` as well as various derives.
   These are used to generate the boilerplate code for parsing, pretty printing, folding, etc.
-* **formality-prove**: Defines the rules for proving goals (e.g., is this trait implemented?)
-* **formality-rust:** This is the "Rust declarations" layer, defining Rust
-  "top-level items" and their semantics. This includes crates, structs, traits,
-  impls, but excludes function bodies.
-* **formality-types:** This is the "types" layer, defining Rust types and
-  functions for equating/relating them. The representation is meant to cover
-  all Rust types, but is optimized for extracting their "essential properties".
+* **formality-core**: Language-independent foundation for formal semantics — variable binding,
+  the judgment/proof system, fixed-point computation, and collections.
+* **formality-rust**: The Rust-specific model. Contains `grammar/` (AST definitions),
+  `check/` (semantic checking, with `check_all_crates` as the entry point),
+  and `prove/` (trait solving and type normalization).

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -1,1 +1,60 @@
 # Intro
+
+`a-mir-formality` is an early-stage experimental project maintained by the [Rust types team](https://www.rust-lang.org/governance/teams/compiler#types).
+Its goal is to be a complete, authoritative formal model of the [Rust MIR](https://rustc-dev-guide.rust-lang.org/mir/index.html) and type system.
+If successful, the intention is to bring this model into Rust as an RFC and develop it as an official part of the language definition.
+
+## Workspace structure
+
+The project is a Cargo workspace with three main crates, organized in layers:
+
+- **`formality-macros`** — Procedural macros that generate boilerplate for formality terms. The `#[term]` macro auto-derives `Parse`, `Debug`, `Fold`, and `Visit` traits.
+- **`formality-core`** — Language-independent foundation for formal semantics: variable binding, the judgment/proof system, fixed-point computation, and collections. Reusable for modeling any language, not just Rust.
+- **`formality-rust`** — The Rust-specific model, containing three subsystems:
+  - `grammar/` — AST definitions for types, traits, impls, functions, ADTs, and a MIR subset
+  - `check/` — Semantic checking (entry point: `check_all_crates()`)
+  - `prove/` — Trait solving and type normalization
+
+The root `a-mir-formality` binary parses a Rust program file and runs `check_all_crates()`.
+
+## Data flow
+
+```
+Program text
+    → try_term()       (parse)
+    → Program AST
+    → check_all_crates()
+    → per-crate checking
+    → trait proving / normalization
+    → ProofTree result
+```
+
+## Running tests
+
+```bash
+# Run the full test suite (what CI runs)
+cargo test --all
+
+# Run all targets including doc tests
+cargo test --all-targets
+
+# Run a single integration test by name
+cargo test -p a-mir-formality -- test_name
+
+# Run tests in a specific crate
+cargo test -p formality-rust
+cargo test -p formality-core
+```
+
+To see tracing output from a test, set the `RUST_LOG` environment variable:
+
+```bash
+RUST_LOG=debug cargo test -p a-mir-formality -- test_name
+```
+
+## Test macros
+
+Integration tests use two snapshot-testing macros (powered by [`expect-test`](https://crates.io/crates/expect-test)):
+
+- `assert_ok!([ ... ])` — asserts that a program type-checks successfully
+- `assert_err!([ ... ] expect![[...]])` — asserts that a program fails with a specific error message


### PR DESCRIPTION
## Summary

- Fills in the previously empty book/src/intro.md with a project overview, workspace structure, data flow diagram, running tests section, and test macro documentation
- Fixes outdated crate names in README.md (formality-check, formality-prove, formality-types no longer exist as separate crates; replaced with accurate descriptions of formality-macros, formality-core, and formality-rust)

## Test plan

- No code changes; only documentation updates

AI Disclosure: Used Claude as a learning aid for exploring the codebase and drafting documentation. All content verified against the actual code.

Confidence: 8/10 — the crate descriptions and test commands are accurate (verified locally), but open to feedback on what else newcomers would find useful.

Questions: Should the intro page link to any external resources (rustc dev guide, Zulip channel)? Is there anything I got wrong or missed about the architecture?
  
Closes #261 