### PR TITLE
fix: correct evaluted typo to evaluated in proof rules output

### DIFF
--- a/crates/formality-core/src/judgment/proven_set.rs
+++ b/crates/formality-core/src/judgment/proven_set.rs
@@ -748,7 +748,7 @@ impl std::fmt::Display for RuleFailureCause {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             RuleFailureCause::IfFalse(IfThen { cond, args }) => {
-                write!(f, "condition evaluted to false: `{cond}`")?;
+                write!(f, "condition evaluated to false: `{cond}`")?;
                 for (arg_expr, arg_value) in args {
                     write!(f, "\n  {arg_expr} = {arg_value:?}")?;
                 }

--- a/crates/formality-core/src/judgment/test_filtered.rs
+++ b/crates/formality-core/src/judgment/test_filtered.rs
@@ -50,7 +50,7 @@ fn judgment() {
 
     transitive_reachable(&graph, 0).assert_err(expect_test::expect![[r#"
         the rule "base" at (test_filtered.rs) failed because
-          condition evaluted to false: `b % 2 == 0`"#]]);
+          condition evaluated to false: `b % 2 == 0`"#]]);
 
     transitive_reachable(&graph, 2).assert_ok(expect_test::expect!["{4, 8, 10}"]);
 }

--- a/crates/formality-core/src/judgment/test_for_all.rs
+++ b/crates/formality-core/src/judgment/test_for_all.rs
@@ -42,7 +42,7 @@ fn test_for_all_failure() {
     let nums = vec![Num(2), Num(3), Num(6)];
     all_even(nums).assert_err(expect_test::expect![[r#"
         the rule "all_even" at (test_for_all.rs) failed because
-          condition evaluted to false: `is_even(n).is_ok()`"#]]);
+          condition evaluated to false: `is_even(n).is_ok()`"#]]);
 }
 
 #[test]

--- a/crates/formality-rust/src/prove/prove/test/eq_assumptions.rs
+++ b/crates/formality-rust/src/prove/prove/test/eq_assumptions.rs
@@ -46,13 +46,13 @@ fn test_normalize_assoc_ty_existential0() {
           pattern `None` did not match value `Some(!ty_1)`
 
         the rule "existential-universal" at (prove_eq.rs) failed because
-          condition evaluted to false: `env.universe(p) < env.universe(v)`
+          condition evaluated to false: `env.universe(p) < env.universe(v)`
 
         the rule "existential-nonvar" at (prove_eq.rs) failed because
           pattern `None` did not match value `Some(!ty_1)`
 
         the rule "existential-universal" at (prove_eq.rs) failed because
-          condition evaluted to false: `env.universe(p) < env.universe(v)`
+          condition evaluated to false: `env.universe(p) < env.universe(v)`
 
         the rule "normalize-via-impl" at (prove_normalize.rs) failed because
           expression evaluated to an empty collection: `decls.alias_eq_decls(&a.name)`
@@ -65,7 +65,7 @@ fn test_normalize_assoc_ty_existential0() {
           pattern `None` did not match value `Some(!ty_0)`
 
         the rule "existential-universal" at (prove_eq.rs) failed because
-          condition evaluted to false: `env.universe(p) < env.universe(v)`
+          condition evaluated to false: `env.universe(p) < env.universe(v)`
 
         crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:55:1: no applicable rules for prove_normalize_via { goal: ?ty_1, via: <!ty_0 as Iterator>::Item = u32, assumptions: {<!ty_0 as Iterator>::Item = u32}, env: Env { variables: [?ty_1, !ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
@@ -75,13 +75,13 @@ fn test_normalize_assoc_ty_existential0() {
           pattern `None` did not match value `Some(!ty_0)`
 
         the rule "existential-universal" at (prove_eq.rs) failed because
-          condition evaluted to false: `env.universe(p) < env.universe(v)`
+          condition evaluated to false: `env.universe(p) < env.universe(v)`
 
         the rule "existential-nonvar" at (prove_eq.rs) failed because
           pattern `None` did not match value `Some(!ty_0)`
 
         the rule "existential-universal" at (prove_eq.rs) failed because
-          condition evaluted to false: `env.universe(p) < env.universe(v)`
+          condition evaluated to false: `env.universe(p) < env.universe(v)`
 
         the rule "normalize-via-impl" at (prove_normalize.rs) failed because
           expression evaluated to an empty collection: `decls.alias_eq_decls(&a.name)`
@@ -92,7 +92,7 @@ fn test_normalize_assoc_ty_existential0() {
           pattern `None` did not match value `Some(!ty_0)`
 
         the rule "existential-universal" at (prove_eq.rs) failed because
-          condition evaluted to false: `env.universe(p) < env.universe(v)`
+          condition evaluated to false: `env.universe(p) < env.universe(v)`
 
         crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:55:1: no applicable rules for prove_normalize_via { goal: ?ty_1, via: <!ty_0 as Iterator>::Item = u32, assumptions: {<!ty_0 as Iterator>::Item = u32}, env: Env { variables: [?ty_1, !ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
@@ -100,13 +100,13 @@ fn test_normalize_assoc_ty_existential0() {
           pattern `None` did not match value `Some(!ty_0)`
 
         the rule "existential-universal" at (prove_eq.rs) failed because
-          condition evaluted to false: `env.universe(p) < env.universe(v)`
+          condition evaluated to false: `env.universe(p) < env.universe(v)`
 
         the rule "existential-nonvar" at (prove_eq.rs) failed because
           pattern `None` did not match value `Some(!ty_0)`
 
         the rule "existential-universal" at (prove_eq.rs) failed because
-          condition evaluted to false: `env.universe(p) < env.universe(v)`
+          condition evaluated to false: `env.universe(p) < env.universe(v)`
 
         the rule "normalize-via-impl" at (prove_normalize.rs) failed because
           expression evaluated to an empty collection: `decls.alias_eq_decls(&a.name)`"#]]);

--- a/crates/formality-rust/src/prove/prove/test/is_local.rs
+++ b/crates/formality-rust/src/prove/prove/test/is_local.rs
@@ -12,7 +12,7 @@ fn test_forall_not_local() {
         crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: !ty_1, assumptions: {}, env: Env { variables: [!ty_1], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
         the rule "local trait" at (is_local.rs) failed because
-          condition evaluted to false: `decls.is_local_trait_id(&goal.trait_id)`
+          condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
             decls = decls([], 222)
             &goal.trait_id = Debug"#]]);
 }

--- a/crates/formality-rust/src/prove/prove/test/universes.rs
+++ b/crates/formality-rust/src/prove/prove/test/universes.rs
@@ -17,7 +17,7 @@ fn exists_u_for_t() {
           pattern `None` did not match value `Some(!ty_1)`
 
         the rule "existential-universal" at (prove_eq.rs) failed because
-          condition evaluted to false: `env.universe(p) < env.universe(v)`
+          condition evaluated to false: `env.universe(p) < env.universe(v)`
 
         crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: ?ty_0, assumptions: {}, env: Env { variables: [?ty_0, !ty_1], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]]);
 }

--- a/src/test/borrowck.rs
+++ b/src/test/borrowck.rs
@@ -30,12 +30,12 @@ fn mutable_ref_prevents_mutation() {
 
         expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v1 : i32
                 &access.place = v1 : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -74,12 +74,12 @@ fn shared_ref_prevents_mutation() {
 
         expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v1 : i32
                 &access.place = v1 : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -160,12 +160,12 @@ fn drop_while_borrowed() {
 
         expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v1 : i32
                 &access.place = v1 : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -240,12 +240,12 @@ fn drop_while_mutably_borrowed() {
 
         expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v1 : i32
                 &access.place = v1 : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -288,12 +288,12 @@ fn drop_on_break_while_borrowed() {
 
         expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v1 : i32
                 &access.place = v1 : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -631,12 +631,12 @@ fn continue_drops_borrowed_local_false_edge() {
 
         expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = y : i32
                 &access.place = y : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -644,12 +644,12 @@ fn continue_drops_borrowed_local_false_edge() {
               pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `y`
 
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = y : i32
                 &access.place = y : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -683,12 +683,12 @@ fn continue_drops_borrowed_local_loop_carried() {
 
         expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = y : i32
                 &access.place = y : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -696,12 +696,12 @@ fn continue_drops_borrowed_local_loop_carried() {
               pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `y`
 
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = y : i32
                 &access.place = y : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -746,12 +746,12 @@ fn break_drops_borrowed_local() {
 
         expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = x : i32
                 &access.place = x : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -759,12 +759,12 @@ fn break_drops_borrowed_local() {
               pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `x`
 
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = x : i32
                 &access.place = x : i32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -883,12 +883,12 @@ fn write_to_borrowed_before_continue() {
 
         expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = a : u32
                 &access.place = a : u32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -896,12 +896,12 @@ fn write_to_borrowed_before_continue() {
               pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `a`
 
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = a : u32
                 &access.place = a : u32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 
@@ -946,12 +946,12 @@ fn write_to_borrowed_before_zero_iteration_loop() {
 
         expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
-              condition evaluted to false: `place_disjoint_from_place(&loan.place, &access.place)`
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = a : u32
                 &access.place = a : u32
 
             the rule "loan_cannot_outlive" at (nll.rs) failed because
-              condition evaluted to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
                 &lifetime.upcast() = ?lt_1
 

--- a/src/test/coherence_orphan.rs
+++ b/src/test/coherence_orphan.rs
@@ -15,19 +15,19 @@ fn neg_CoreTrait_for_CoreStruct_in_Foo() {
 
         expect_test::expect![[r#"
             the rule "fundamental rigid type" at (is_local.rs) failed because
-              condition evaluted to false: `is_fundamental(decls, name)`
+              condition evaluated to false: `is_fundamental(decls, name)`
                 decls = decls([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl ! CoreTrait for CoreStruct {} }], 222)
                 name = (adt CoreStruct)
 
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: CoreStruct, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             the rule "local rigid type" at (is_local.rs) failed because
-              condition evaluted to false: `decls.is_local_adt_id(a)`
+              condition evaluated to false: `decls.is_local_adt_id(a)`
                 decls = decls([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl ! CoreTrait for CoreStruct {} }], 222)
                 a = CoreStruct
 
             the rule "local trait" at (is_local.rs) failed because
-              condition evaluted to false: `decls.is_local_trait_id(&goal.trait_id)`
+              condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
                 decls = decls([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl ! CoreTrait for CoreStruct {} }], 222)
                 &goal.trait_id = CoreTrait"#]]
     )
@@ -56,19 +56,19 @@ fn mirror_CoreStruct() {
 
         expect_test::expect![[r#"
             the rule "fundamental rigid type" at (is_local.rs) failed because
-              condition evaluted to false: `is_fundamental(decls, name)`
+              condition evaluated to false: `is_fundamental(decls, name)`
                 decls = decls([crate core { trait CoreTrait <ty> { } struct CoreStruct { } trait Mirror <ty> { type Assoc : [] ; } impl <ty> Mirror for ^ty0_0 { type Assoc = ^ty1_0 ; } }, crate foo { impl CoreTrait for <CoreStruct as Mirror>::Assoc { } }], 222)
                 name = (adt CoreStruct)
 
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: CoreStruct, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             the rule "local rigid type" at (is_local.rs) failed because
-              condition evaluted to false: `decls.is_local_adt_id(a)`
+              condition evaluated to false: `decls.is_local_adt_id(a)`
                 decls = decls([crate core { trait CoreTrait <ty> { } struct CoreStruct { } trait Mirror <ty> { type Assoc : [] ; } impl <ty> Mirror for ^ty0_0 { type Assoc = ^ty1_0 ; } }, crate foo { impl CoreTrait for <CoreStruct as Mirror>::Assoc { } }], 222)
                 a = CoreStruct
 
             the rule "local trait" at (is_local.rs) failed because
-              condition evaluted to false: `decls.is_local_trait_id(&goal.trait_id)`
+              condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
                 decls = decls([crate core { trait CoreTrait <ty> { } struct CoreStruct { } trait Mirror <ty> { type Assoc : [] ; } impl <ty> Mirror for ^ty0_0 { type Assoc = ^ty1_0 ; } }, crate foo { impl CoreTrait for <CoreStruct as Mirror>::Assoc { } }], 222)
                 &goal.trait_id = CoreTrait"#]]
     )
@@ -132,7 +132,7 @@ fn uncovered_T() {
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: !ty_0, assumptions: {}, env: Env { variables: [!ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             the rule "local trait" at (is_local.rs) failed because
-              condition evaluted to false: `decls.is_local_trait_id(&goal.trait_id)`
+              condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
                 decls = decls([crate core { trait CoreTrait <ty, ty> { } }, crate foo { struct FooStruct { } impl <ty> CoreTrait <FooStruct> for ^ty0_0 { } }], 222)
                 &goal.trait_id = CoreTrait"#]]
     )
@@ -161,14 +161,14 @@ fn alias_to_unit() {
 
         expect_test::expect![[r#"
             the rule "fundamental rigid type" at (is_local.rs) failed because
-              condition evaluted to false: `is_fundamental(decls, name)`
+              condition evaluated to false: `is_fundamental(decls, name)`
                 decls = decls([crate core { trait CoreTrait <ty> { } trait Unit <ty> { type Assoc : [] ; } impl <ty> Unit for ^ty0_0 { type Assoc = () ; } }, crate foo { struct FooStruct { } impl CoreTrait for <FooStruct as Unit>::Assoc { } }], 222)
                 name = tuple(0)
 
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: (), assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             the rule "local trait" at (is_local.rs) failed because
-              condition evaluted to false: `decls.is_local_trait_id(&goal.trait_id)`
+              condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
                 decls = decls([crate core { trait CoreTrait <ty> { } trait Unit <ty> { type Assoc : [] ; } impl <ty> Unit for ^ty0_0 { type Assoc = () ; } }, crate foo { struct FooStruct { } impl CoreTrait for <FooStruct as Unit>::Assoc { } }], 222)
                 &goal.trait_id = CoreTrait"#]]
     )
@@ -189,19 +189,19 @@ fn CoreTrait_for_CoreStruct_in_Foo() {
 
         expect_test::expect![[r#"
             the rule "fundamental rigid type" at (is_local.rs) failed because
-              condition evaluted to false: `is_fundamental(decls, name)`
+              condition evaluated to false: `is_fundamental(decls, name)`
                 decls = decls([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl CoreTrait for CoreStruct { } }], 222)
                 name = (adt CoreStruct)
 
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: CoreStruct, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             the rule "local rigid type" at (is_local.rs) failed because
-              condition evaluted to false: `decls.is_local_adt_id(a)`
+              condition evaluated to false: `decls.is_local_adt_id(a)`
                 decls = decls([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl CoreTrait for CoreStruct { } }], 222)
                 a = CoreStruct
 
             the rule "local trait" at (is_local.rs) failed because
-              condition evaluted to false: `decls.is_local_trait_id(&goal.trait_id)`
+              condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
                 decls = decls([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl CoreTrait for CoreStruct { } }], 222)
                 &goal.trait_id = CoreTrait"#]]
     )

--- a/src/test/mir_typeck.rs
+++ b/src/test/mir_typeck.rs
@@ -264,7 +264,7 @@ fn test_call_generic_fn_without_turbofish() {
         ]
         expect_test::expect![[r#"
             the rule "fn-name" at (nll.rs) failed because
-              condition evaluted to false: `fn_decl.binder.len() == 0`
+              condition evaluated to false: `fn_decl.binder.len() == 0`
 
             the rule "local" at (nll.rs) failed because
               unknown local variable `identity`"#]]
@@ -308,7 +308,7 @@ fn test_call_generic_fn_wrong_arity() {
         ]
         expect_test::expect![[r#"
             the rule "turbofish" at (nll.rs) failed because
-              condition evaluted to false: `fn_decl.binder.len() == args.len()`"#]]
+              condition evaluated to false: `fn_decl.binder.len() == args.len()`"#]]
     )
 }
 
@@ -522,7 +522,7 @@ fn test_invalid_struct_field() {
         ]
         expect_test::expect![[r#"
             the rule "struct field" at (nll.rs) failed because
-              condition evaluted to false: `field.name == *field_name`"#]]
+              condition evaluated to false: `field.name == *field_name`"#]]
     )
 }
 

--- a/tests/judgment-error-reporting/cyclic_judgment.rs
+++ b/tests/judgment-error-reporting/cyclic_judgment.rs
@@ -72,52 +72,52 @@ fn test() {
     };
     sub(foo, bar).assert_err(expect_test::expect![[r#"
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "equivalent" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `a1 != a || b1 != b`
+          condition evaluated to false: `a1 != a || b1 != b`
 
         the rule "same class" at (cyclic_judgment.rs) failed because
-          condition evaluted to false: `name_a == name_b`
+          condition evaluated to false: `name_a == name_b`
             name_a = Foo
             name_b = Bar"#]]);
 }
@@ -131,74 +131,74 @@ fn test1() {
         name: ClassName::new("Bar"),
     };
     sub(foo, bar).assert_err(expect_test::expect![[r#"
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "same class" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `name_a == name_b`
-              name_a = Foo
-              name_b = Bar
+        the rule "same class" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `name_a == name_b`
+            name_a = Foo
+            name_b = Bar
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "same class" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `name_a == name_b`
-              name_a = Foo
-              name_b = Bar
+        the rule "same class" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `name_a == name_b`
+            name_a = Foo
+            name_b = Bar
 
-          the rule "same class" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `name_a == name_b`
-              name_a = Foo
-              name_b = Bar
+        the rule "same class" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `name_a == name_b`
+            name_a = Foo
+            name_b = Bar
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "same class" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `name_a == name_b`
-              name_a = Foo
-              name_b = Bar
+        the rule "same class" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `name_a == name_b`
+            name_a = Foo
+            name_b = Bar
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "same class" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `name_a == name_b`
-              name_a = Foo
-              name_b = Bar
+        the rule "same class" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `name_a == name_b`
+            name_a = Foo
+            name_b = Bar
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "same class" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `name_a == name_b`
-              name_a = Foo
-              name_b = Bar
+        the rule "same class" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `name_a == name_b`
+            name_a = Foo
+            name_b = Bar
 
-          the rule "equivalent" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `a1 != a || b1 != b`
+        the rule "equivalent" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `a1 != a || b1 != b`
 
-          the rule "same class" at (cyclic_judgment.rs) failed because
-            condition evaluted to false: `name_a == name_b`
-              name_a = Foo
-              name_b = Bar"#]]);
+        the rule "same class" at (cyclic_judgment.rs) failed because
+          condition evaluated to false: `name_a == name_b`
+            name_a = Foo
+            name_b = Bar"#]]);
 }

--- a/tests/judgment-error-reporting/fallible.rs
+++ b/tests/judgment-error-reporting/fallible.rs
@@ -43,7 +43,7 @@ fn test() {
         Caused by:
             judgment `sub { a: class(Foo), b: class(Bar) }` failed at the following rule(s):
               the rule "same class" at (fallible.rs) failed because
-                condition evaluted to false: `name_a == name_b`
+                condition evaluated to false: `name_a == name_b`
                   name_a = Foo
                   name_b = Bar"#]]);
 }


### PR DESCRIPTION
Closes #264

Fix "evaluted" → "evaluated" typo in `proven_set.rs` proof rules output. All expect-test snapshots updated via `UPDATE_EXPECT=1 cargo test`. Testing: ran full test suite, verified zero remaining occurrences     

**AI disclosure:**
- Confidence: feel good about it, the fix was already in the issue so no reliance on the LLM
- Review depth: reviewed closely and understood it well   
- Questions: none — straightforward typo fix