### PR TITLE
test: add borrowck and type-check coverage for ExprData::False

### DIFF
--- a/src/test/borrowck.rs
+++ b/src/test/borrowck.rs
@@ -910,6 +910,45 @@ fn write_to_borrowed_before_continue() {
     )
 }
 
+/// Test that `false` works as a condition in `if` with borrow checking.
+/// The borrow checker must analyse both branches regardless of the
+/// statically-known condition value.
+///
+/// ```rust,ignore
+/// fn foo() -> &'a Map {
+///     let m: Map = Map {};
+///     let n: &mut Map = &mut m;
+///     if false {
+///         return n;
+///     } else {
+///         let o: &mut Map = &mut m;
+///         return o;
+///     }
+/// }
+/// ```
+#[test]
+fn if_false_borrowck() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                struct Map { }
+
+                fn foo<'a>(m: &mut 'a Map) -> &mut 'a Map {
+                    exists<'r0, 'r1> {
+                        let n: &mut 'r0 Map = &mut 'r0 *m;
+                        if false {
+                            return n;
+                        } else {
+                            let o: &mut 'r1 Map = &mut 'r1 *m;
+                            return o;
+                        }
+                    }
+                }
+            }
+        ]
+    )
+}
+
 /// Writing to a borrowed variable before a loop that might not execute
 /// should be an error, because the borrow is live along the zero-iteration path.
 ///

--- a/src/test/mir_typeck.rs
+++ b/src/test/mir_typeck.rs
@@ -593,6 +593,28 @@ fn test_non_adt_ty_for_struct() {
     )
 }
 
+/// Test that the `false` literal type-checks as `bool`.
+///
+/// ```rust,ignore
+/// fn foo() -> bool {
+///     let v1: bool = false;
+///     return v1;
+/// }
+/// ```
+#[test]
+fn test_false_literal() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                fn foo() -> bool {
+                    let v1: bool = false;
+                    return v1;
+                }
+            }
+        ]
+    )
+}
+
 /// Basic pass test for lifetime.
 ///
 /// The test is equivalent to:


### PR DESCRIPTION
## Summary
- Add borrow-check test (`if_false_borrowck`) exercising `false` as a condition in `if` with `&mut` reborrowing across branches
- Add type-check test (`test_false_literal`) verifying `false` type-checks as `bool`

Closes #266

## Test plan
- [ ] `cargo test -- if_false_borrowck` passes
- [ ] `cargo test -- test_false_literal` passes
- [ ] `cargo test --all` passes
- [ ] `cargo fmt --all -- --check` passes

## AI disclosure
- **Confidence:** I think it's right but I want confirmation.
- **Review depth:** I read it over and understand it well.
- **Testing:** Ran the full test suite and it passed.
- **Questions:** Are these the right test patterns for `false`? Should I add an `assert_err!` case too (e.g., using `false` where a non-bool is expected)?