### PR TITLE
docs: add pull request template with AI/LLM disclosure section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,9 @@
 Closes #issue-number
 
 
-## AI/LLM disclosure
+## Disclosure and PR context
 
-<!-- If you used AI/LLM tools, fill in the sections below. Delete this section if not applicable. -->
+**AI tools used:** <!-- describe briefly if AI tools were used and how, e.g., "No" or "Yes, for research" or "Yes, for code". Feel free to provide more details, I'm curious to learn about people's workflows. =) -->
 
 **Confidence level:** <!-- e.g., "Early draft, want feedback" / "I think it's right, want confirmation" / "Feel good about it" -->
 


### PR DESCRIPTION
## Summary
- Add `.github/PULL_REQUEST_TEMPLATE.md` with a lightweight AI/LLM disclosure section
- Based on Niko's framework from the Zulip discussion (#t-types/formality > On the use of LLMs): confidence level, review depth, testing, and questions for mentors
- The AI section is optional — contributors can delete it if they didn't use LLM tools

## AI disclosure
**Confidence level:** I feel good about it.
**Review depth:** I reviewed closely and understand it well.
**Testing:** N/A (no code changes).
**Questions for mentors:** Is the wording/structure what you had in mind? Happy to adjust.