### PR TITLE
test: add test for ExprData::True for type-check coverage

### DIFF
--- a/src/test/mir_typeck.rs
+++ b/src/test/mir_typeck.rs
@@ -114,6 +114,20 @@ fn test_cyclic_goto() {
     )
 }
 
+/// Returns true (ExprData::True) type-checking coverage
+#[test]
+fn test_ret_true() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                fn foo () -> bool {
+                    return true;
+                }
+            }
+        ]
+    )
+}
+
 /// Test valid call: bar calls foo.
 #[test]
 fn test_call_terminator() {


### PR DESCRIPTION
This PR adds a test in `mir_typeck.rs` as discussed in https://github.com/rust-lang/a-mir-formality/issues/268

A new test `test_ret_true()`  is added .

This test covers `ExprData::True` type-check coverage in `mir_typeck.rs` .

Test via :
cargo test if_else
cargo test

AI disclosure:
No AI was used .