### PR TITLE
test: add type-check coverage for PlaceExprData::Parens

### DIFF
--- a/src/test/mir_typeck.rs
+++ b/src/test/mir_typeck.rs
@@ -750,6 +750,38 @@ fn test_continue_block_label() {
     )
 }
 
+/// Test parenthesized place expression: `(*v).field`.
+///
+/// The parens around `*v1` are required so the deref applies before
+/// the field projection (without them, `*v1.value` would try to
+/// project first and then deref).
+///
+/// ```rust,ignore
+/// fn foo(v1: &Pair) -> u32 {
+///     let v2: u32 = (*v1).value;
+///     v2
+/// }
+/// ```
+#[test]
+fn test_parens_place_expr() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                struct Pair {
+                    value: u32,
+                }
+
+                fn foo<'a>(v1: &'a Pair) -> u32 {
+                    exists<'r0> {
+                        let v2: u32 = (*v1).value;
+                        return v2;
+                    }
+                }
+            }
+        ]
+    )
+}
+
 /// `break` targeting a block label (not a loop) should pass.
 /// In Rust, you can `break` out of a labeled block.
 ///


### PR DESCRIPTION
## Summary

  - Add type-check test (test_parens_place_expr) exercising parenthesized  
  place expressions like (*v).field
  - The test dereferences a &Pair and accesses a field, requiring parens   
  for correct parse precedence

  Closes #269

 ## Test plan

  - cargo test -- test_parens_place_expr passes
  - cargo test --all passes
  - cargo fmt --all -- --check passes

 ## AI disclosure

  - Confidence: I feel good about it.
  - Review depth: I read it over and understand it well.
  - Testing: Ran the full test suite (some were ignored as always but most passed).
  - Questions: None — this is a straightforward assert_ok! test mirroring the existing borrow-check coverage in problem_case_4.