### PR TITLE
Make the grammar use `'static` for the static lifetime

### DIFF
--- a/crates/formality-rust/src/grammar/ty.rs
+++ b/crates/formality-rust/src/grammar/ty.rs
@@ -384,6 +384,7 @@ impl DowncastTo<LtData> for Lt {
 
 #[term]
 pub enum LtData {
+    #[grammar('static)]
     Static,
 
     #[variable(ParameterKind::Lt)]

--- a/src/test/well_formed_trait_ref.rs
+++ b/src/test/well_formed_trait_ref.rs
@@ -75,9 +75,9 @@ fn static_lifetime_param() {
 
                 struct S1 {}
 
-                impl Trait1<static> for S1 {}
+                impl Trait1<'static> for S1 {}
 
-                struct S2 where S1: Trait1<static> {}
+                struct S2 where S1: Trait1<'static> {}
             }
         ]
     )


### PR DESCRIPTION
#245 updated the lifetime syntax from `lt a` to `'a`. This makes a related change from `static` to `'static`.

