### PR TITLE
Check that `let` uses a well-formed type

### DIFF
--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -174,6 +174,7 @@ judgment_fn! {
         debug(state, statement, places_live_on_exit, assumptions, env)
 
         (
+            (prove_ty_is_wf(env, assumptions, state, ty) => state)
             // The variable being declared is not yet live before this `let`,
             // so remove it from places_live_on_exit before checking the initializer (if any).
             (for_all(init in init.into_iter()) with (state) // FIXME: should make syntax for this
@@ -823,6 +824,15 @@ fn prove_where_clauses(
     where_clauses: &[WhereClause],
 ) -> ProvenSet<FlowState> {
     TypeckEnv::prove_goal(env, assumptions, state, where_clauses)
+}
+
+fn prove_ty_is_wf(
+    env: &TypeckEnv,
+    assumptions: &Wcs,
+    state: &FlowState,
+    ty: &Ty,
+) -> ProvenSet<FlowState> {
+    TypeckEnv::prove_goal(env, assumptions, state, ty.well_formed())
 }
 
 fn prove_normalize_ty(

--- a/src/test/mir_typeck.rs
+++ b/src/test/mir_typeck.rs
@@ -216,6 +216,46 @@ fn test_struct() {
     )
 }
 
+/// Test let statement with well-formed type
+#[test]
+fn test_let_with_well_formed_type() {
+    crate::assert_ok!(
+        [
+            crate Foo {
+                trait Trait1 {}
+                struct S1<T> {
+                    t: T,
+                }
+                fn foo() -> () {
+                    let s1: S1<u8>;
+                }
+            }
+        ]
+    )
+}
+
+/// Test let statement with ill-formed type
+#[test]
+fn test_let_with_ill_formed_type() {
+    crate::assert_err!(
+        [
+            crate Foo {
+                trait Trait1 {}
+                struct S1 {}
+                struct S2<T> where T: Trait1 {
+                    t: T,
+                }
+                fn foo() -> () {
+                    let s2: S2<S1>;
+                }
+            }
+        ]
+        expect_test::expect![[r#"
+            the rule "trait implied bound" at (prove_wc.rs) failed because
+              expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
+    )
+}
+
 // Test calling a function that does not exist.
 #[test]
 fn test_call_invalid_fn() {


### PR DESCRIPTION
a-mir-formality currently accepts the `let` below, although `S2<S1>` isn't well formed.

```
crate Crate1 {
    trait Trait1 {}
    struct S1 {}
    struct S2<T> where T: Trait1 {
        t: T,
    }
    fn f() -> () {
        let s2: S2<S1>;
    }
}
```

I think this is the natural fix, basically just adding `ty.well_formed()` to the "Let" case of `borrow_check_statement()`.

## Disclosure and PR context

**AI tools used:**

No

**Confidence level:**

I think it's right, want confirmation

**Testing:**

Adds one `assert_ok` and one `assert_err` testcase
