### PR TITLE
Adjust grammar for `trusted` functions to prevent early consumtion of the `trusted` keyword

### DIFF
--- a/crates/formality-rust/src/grammar/fns.rs
+++ b/crates/formality-rust/src/grammar/fns.rs
@@ -33,7 +33,7 @@ pub enum MaybeFnBody {
 
 #[term]
 pub enum FnBody {
-    #[grammar(trusted;)]
+    #[grammar({trusted})]
     TrustedFnBody,
 
     #[cast]

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -154,7 +154,7 @@ fn test_parse_trusted_fn() {
     let r: Program = term(
         "[
             crate core {
-              fn run() -> () trusted;
+              fn run() -> () {trusted}
             }
         ]",
     );

--- a/src/test/functions.rs
+++ b/src/test/functions.rs
@@ -36,7 +36,7 @@ fn lifetime() {
                 fn one_lt_arg<'a, T>(v0: &'a T) -> ()
                 where
                     T: 'a, // FIXME(#202): Implied bounds should not have to be explicit
-                trusted;
+                {trusted}
             }
         ]
     )


### PR DESCRIPTION
## What does this PR do?

The new Expr syntax has changed the format for trusted functions. However, this new format is not always parsed correctly.
If there is no where clause (and therefore no `where` keyword), the `trusted` keyword is consumed by the parser when checking whether the next string is the `where` keyword. By surrounding the `trusted` keyword with curly braces, the parser no longer consumes `trusted` when figuring out, if there are where clauses.


## Disclosure and PR context

**AI tools used:** No

**Confidence level:** The code works. However, I'm not sure if this is the correct solution to the problem, as it seems like a bug in the parser implementation.

**Review depth:** I reviewed closely and understand it well (only a few lines...)

**Testing:** I ran full test suite (cargo test --all)

**Questions for mentors:** Would the proposed syntax also be OK for you? Would you like the parser to at least throw an error?