### PR TITLE
convert top-level functions to judgment_fn

### DIFF
--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::{collections::VecDeque, fmt::Debug};
+use std::fmt::Debug;
 
 use crate::prove::prove::{is_definitely_not_proveable, Constraints, Env, Program};
 use crate::rust::Visit;
@@ -9,7 +9,7 @@ use crate::{
     prove::ToWcs,
 };
 use anyhow::{anyhow, bail};
-use formality_core::{judgment::ProofTree, ProvenSet, Set};
+use formality_core::{judgment::ProofTree, judgment_fn, ProvenSet, Set};
 
 use adts::check_adt;
 use coherence::check_coherence;
@@ -19,30 +19,6 @@ use traits::check_trait;
 
 pub mod borrow_check;
 
-/// Check all crates in the program. The crates must be in dependency order
-/// such that any prefix of the crates is a complete program.
-pub fn check_all_crates(all_crates: &Crates) -> Fallible<ProofTree> {
-    let Crates { crates } = all_crates;
-    let mut crates: VecDeque<_> = crates.iter().cloned().collect();
-
-    let mut proof_tree = ProofTree::new("check_all_crates", None, vec![]);
-    let mut prefix_crates = Crates { crates: vec![] };
-    while let Some(c) = crates.pop_front() {
-        prefix_crates.crates.push(c);
-        proof_tree
-            .children
-            .push(check_current_crate(&prefix_crates)?);
-    }
-
-    Ok(proof_tree)
-}
-
-/// Checks the current crate in the program, assuming all other crates are valid.
-fn check_current_crate(crates: &Crates) -> Fallible<ProofTree> {
-    let program = crates.to_prove_decls();
-    check(&program)
-}
-
 mod adts;
 mod coherence;
 mod fns;
@@ -50,33 +26,45 @@ mod impls;
 mod traits;
 mod where_clauses;
 
-fn check(program: &Program) -> Fallible<ProofTree> {
-    let Crates { crates } = program.program();
-    if let Some(current_crate) = crates.last() {
-        check_crate(program, current_crate)
-    } else {
-        Ok(ProofTree::leaf("check (no crates)"))
+judgment_fn! {
+    pub fn check_all_crates(
+        crates: Crates,
+    ) => () {
+        debug(crates)
+
+        (
+            // Check that all crates up to and including crate #i are valid.
+            // Crate #i will be considered the "current crate".
+            (for_all(i in 0..crates.len())
+                (let program = crates.prefix(i).to_prove_decls())
+                (check_crate(program, &crates.crates[i]) => ()))
+            ------------------------------------------------------------ ("check all prefixes")
+            (check_all_crates(crates) => ())
+        )
     }
 }
 
-fn check_crate(program: &Program, c: &Crate) -> Fallible<ProofTree> {
-    let Crate { id, items } = c;
-    let mut proof_tree = ProofTree::new(format!("check_current_crate({id:?})"), None, vec![]);
+judgment_fn! {
+    /// Check that the current crate `c` is valid,
+    /// given the complete program (which includes dependencies).
+    fn check_crate(
+        program: Program,
+        c: Crate,
+    ) => () {
+        debug(c, program)
 
-    check_for_duplicate_items(program)?;
-
-    for item in items {
-        proof_tree
-            .children
-            .push(check_crate_item(program, item, &id)?);
+        (
+            (check_for_duplicate_items(program) => ())
+            (for_all(item in items)
+                (check_crate_item(program, item, id) => ()))
+            (check_coherence(program, c) => ())
+            ------------------------------------------------------------ ("check crate")
+            (check_crate(program, Crate { id, items }) => ())
+        )
     }
-
-    proof_tree.children.push(check_coherence(program, c)?);
-
-    Ok(proof_tree)
 }
 
-fn check_for_duplicate_items(program: &Program) -> Fallible<()> {
+fn check_for_duplicate_items(program: &Program) -> Fallible<ProofTree> {
     let Crates { crates } = program.program();
     for c in crates.iter() {
         let mut items = Set::new();
@@ -105,21 +93,60 @@ fn check_for_duplicate_items(program: &Program) -> Fallible<()> {
         }
     }
 
-    Ok(())
+    Ok(ProofTree::leaf(
+        "check_for_duplicate_items: no duplicates found",
+    ))
 }
 
-fn check_crate_item(program: &Program, c: &CrateItem, crate_id: &CrateId) -> Fallible<ProofTree> {
-    match c {
-        CrateItem::Trait(v) => check_trait(program, v, crate_id),
-        CrateItem::TraitImpl(v) => check_trait_impl(program, v, crate_id),
-        CrateItem::AdtItem(s) => check_adt(program, &s.to_adt()),
-        CrateItem::Fn(f) => check_free_fn(program, f, crate_id),
-        CrateItem::NegTraitImpl(i) => check_neg_trait_impl(program, i),
-        CrateItem::Test(t) => check_test(program, t),
-        CrateItem::FeatureGate(_feature_gate) => {
+judgment_fn! {
+    fn check_crate_item(
+        program: Program,
+        c: CrateItem,
+        crate_id: CrateId,
+    ) => () {
+        debug(program, c, crate_id)
+
+        (
+            (check_trait(program, v, crate_id) => ())
+            ------------------------------------------------------------ ("trait")
+            (check_crate_item(program, CrateItem::Trait(v), crate_id) => ())
+        )
+
+        (
+            (check_trait_impl(program, v, crate_id) => ())
+            ------------------------------------------------------------ ("trait impl")
+            (check_crate_item(program, CrateItem::TraitImpl(v), crate_id) => ())
+        )
+
+        (
+            (check_adt(program, &s.to_adt()) => ())
+            ------------------------------------------------------------ ("adt")
+            (check_crate_item(program, CrateItem::AdtItem(s), crate_id) => ())
+        )
+
+        (
+            (check_free_fn(program, f, crate_id) => ())
+            ------------------------------------------------------------ ("free fn")
+            (check_crate_item(program, CrateItem::Fn(f), crate_id) => ())
+        )
+
+        (
+            (check_neg_trait_impl(program, i) => ())
+            ------------------------------------------------------------ ("neg trait impl")
+            (check_crate_item(program, CrateItem::NegTraitImpl(i), crate_id) => ())
+        )
+
+        (
+            (check_test(program, t) => ())
+            ------------------------------------------------------------ ("test")
+            (check_crate_item(program, CrateItem::Test(t), crate_id) => ())
+        )
+
+        (
             // FIXME(#212): reject duplicate feature gates within a crate
-            Ok(ProofTree::leaf("feature gates are OK with me!"))
-        }
+            ------------------------------------------------------------ ("feature gate")
+            (check_crate_item(program, CrateItem::FeatureGate(_feature_gate), crate_id) => ())
+        )
     }
 }
 

--- a/crates/formality-rust/src/grammar/program.rs
+++ b/crates/formality-rust/src/grammar/program.rs
@@ -10,6 +10,16 @@ pub struct Crates {
 }
 
 impl Crates {
+    pub fn len(&self) -> usize {
+        self.crates.len()
+    }
+
+    pub fn prefix(&self, tail: usize) -> Crates {
+        Crates {
+            crates: self.crates[..=tail].to_vec(),
+        }
+    }
+
     pub fn items_from_all_crates(&self) -> impl Iterator<Item = &CrateItem> {
         self.crates.iter().flat_map(|c| &c.items)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub fn main() -> anyhow::Result<()> {
         eprintln!("{:#?}", program);
     }
 
-    let _proof_tree = check_all_crates(&program)?;
+    let _proof_tree = check_all_crates(&program).check_proven()?;
     Ok(())
 }
 
@@ -61,14 +61,14 @@ macro_rules! assert_err {
 
 pub fn test_program_ok(input: &str) -> anyhow::Result<ProofTree> {
     let program: Crates = try_term(input)?;
-    let proof_tree = check_all_crates(&program)?;
+    let proof_tree = check_all_crates(&program).check_proven()?;
     Ok(proof_tree)
 }
 
 pub fn test_where_clause(program: &str, assertion: &str) -> formality_core::ProvenSet<Constraints> {
     formality_core::with_tracing_logs(|| {
         let program: Crates = try_term(program).unwrap();
-        let _proof_tree = check_all_crates(&program).unwrap();
+        let _proof_tree = check_all_crates(&program).check_proven().unwrap();
         let assertion: Arc<TestAssertion> = try_term(assertion).unwrap();
         let decls = program.to_prove_decls();
         formality_rust::prove::prove::test_util::test_prove(decls, assertion)

--- a/src/test/coherence_overlap.rs
+++ b/src/test/coherence_overlap.rs
@@ -57,9 +57,10 @@ fn foo_crate_cannot_assume_CoreStruct_does_not_impl_CoreTrait() {
         ]
 
         expect_test::expect![[r#"
-            impls may overlap:
-            impl <ty> FooTrait for ^ty0_0 where ^ty0_0 : CoreTrait { }
-            impl FooTrait for CoreStruct { }"#]]
+            the rule "check crate" at (mod.rs) failed because
+              impls may overlap:
+              impl <ty> FooTrait for ^ty0_0 where ^ty0_0 : CoreTrait { }
+              impl FooTrait for CoreStruct { }"#]]
     )
 }
 
@@ -80,10 +81,11 @@ fn T_where_Foo_not_u32_impls() {
         ]
 
         expect_test::expect![[r#"
-            check_trait_impl(impl <ty> Foo for ^ty0_0 where ^ty0_0 : Foo { })
+            the rule "trait impl" at (mod.rs) failed because
+              check_trait_impl(impl <ty> Foo for ^ty0_0 where ^ty0_0 : Foo { })
 
-            Caused by:
-                failed to prove {! Foo(!ty_1)} given {Foo(!ty_1)}, got [Constraints { env: Env { variables: [!ty_1], bias: Soundness, pending: [], allow_pending_outlives: false }, known_true: false, substitution: {} }]"#]]
+              Caused by:
+                  failed to prove {! Foo(!ty_1)} given {Foo(!ty_1)}, got [Constraints { env: Env { variables: [!ty_1], bias: Soundness, pending: [], allow_pending_outlives: false }, known_true: false, substitution: {} }]"#]]
     )
 }
 
@@ -104,9 +106,10 @@ fn u32_T_where_T_Is_impls() {
         ]
 
         expect_test::expect![[r#"
-            impls may overlap:
-            impl Foo for u32 { }
-            impl <ty> Foo for ^ty0_0 where ^ty0_0 : Is { }"#]]
+            the rule "check crate" at (mod.rs) failed because
+              impls may overlap:
+              impl Foo for u32 { }
+              impl <ty> Foo for ^ty0_0 where ^ty0_0 : Is { }"#]]
     )
 }
 
@@ -142,7 +145,9 @@ fn u32_u32_impls() {
             }
         ]
 
-        expect_test::expect!["duplicate impl in current crate: impl Foo for u32 { }"]
+        expect_test::expect![[r#"
+            the rule "check crate" at (mod.rs) failed because
+              duplicate impl in current crate: impl Foo for u32 { }"#]]
     )
 }
 
@@ -172,9 +177,10 @@ fn u32_T_impls() {
         ]
 
         expect_test::expect![[r#"
-            impls may overlap:
-            impl Foo for u32 { }
-            impl <ty> Foo for ^ty0_0 { }"#]]
+            the rule "check crate" at (mod.rs) failed because
+              impls may overlap:
+              impl Foo for u32 { }
+              impl <ty> Foo for ^ty0_0 { }"#]]
     )
 }
 
@@ -194,9 +200,10 @@ fn T_and_T_bar() {
         ]
 
         expect_test::expect![[r#"
-            impls may overlap:
-            impl <ty> Foo for ^ty0_0 { }
-            impl <ty> Foo for ^ty0_0 where ^ty0_0 : Bar { }"#]]
+            the rule "check crate" at (mod.rs) failed because
+              impls may overlap:
+              impl <ty> Foo for ^ty0_0 { }
+              impl <ty> Foo for ^ty0_0 where ^ty0_0 : Bar { }"#]]
     }
 }
 
@@ -218,9 +225,10 @@ fn T_and_Local_Bar_T() {
         ]
 
         expect_test::expect![[r#"
-            impls may overlap:
-            impl <ty> Foo for ^ty0_0 { }
-            impl <ty> Foo for ^ty0_0 where LocalType : Bar <^ty0_0> { }"#]]
+            the rule "check crate" at (mod.rs) failed because
+              impls may overlap:
+              impl <ty> Foo for ^ty0_0 { }
+              impl <ty> Foo for ^ty0_0 where LocalType : Bar <^ty0_0> { }"#]]
     }
 }
 
@@ -281,8 +289,9 @@ fn is_local_with_unconstrained_self_ty_blanket_impl() {
         ]
 
         expect_test::expect![[r#"
-            impls may overlap:
-            impl <ty, ty> Overlap <^ty0_1> for ^ty0_0 where <^ty0_0 as Project>::Assoc : Foo <^ty0_1> { }
-            impl <ty> Overlap <LocalType> for ^ty0_0 { }"#]]
+            the rule "check crate" at (mod.rs) failed because
+              impls may overlap:
+              impl <ty, ty> Overlap <^ty0_1> for ^ty0_0 where <^ty0_0 as Project>::Assoc : Foo <^ty0_1> { }
+              impl <ty> Overlap <LocalType> for ^ty0_0 { }"#]]
     }
 }

--- a/src/test/decl_safety.rs
+++ b/src/test/decl_safety.rs
@@ -50,10 +50,11 @@ fn unsafe_trait_negative_impl_mismatch() {
         ]
 
         expect_test::expect![[r#"
-            check_neg_trait_impl(unsafe impl ! Foo for u32 {})
+            the rule "neg trait impl" at (mod.rs) failed because
+              check_neg_trait_impl(unsafe impl ! Foo for u32 {})
 
-            Caused by:
-                negative impls cannot be unsafe"#]]
+              Caused by:
+                  negative impls cannot be unsafe"#]]
     )
 }
 
@@ -68,10 +69,11 @@ fn safe_trait_negative_impl_mismatch() {
         ]
 
         expect_test::expect![[r#"
-            check_neg_trait_impl(unsafe impl ! Foo for u32 {})
+            the rule "neg trait impl" at (mod.rs) failed because
+              check_neg_trait_impl(unsafe impl ! Foo for u32 {})
 
-            Caused by:
-                negative impls cannot be unsafe"#]]
+              Caused by:
+                  negative impls cannot be unsafe"#]]
     )
 }
 
@@ -86,10 +88,11 @@ fn unsafe_trait_mismatch() {
         ]
 
         expect_test::expect![[r#"
-            check_trait_impl(impl Foo for u32 { })
+            the rule "trait impl" at (mod.rs) failed because
+              check_trait_impl(impl Foo for u32 { })
 
-            Caused by:
-                the trait `Foo` requires an `unsafe impl` declaration"#]]
+              Caused by:
+                  the trait `Foo` requires an `unsafe impl` declaration"#]]
     )
 }
 
@@ -104,9 +107,10 @@ fn safe_trait_mismatch() {
         ]
 
         expect_test::expect![[r#"
-            check_trait_impl(unsafe impl Foo for u32 { })
+            the rule "trait impl" at (mod.rs) failed because
+              check_trait_impl(unsafe impl Foo for u32 { })
 
-            Caused by:
-                implementing the trait `Foo` is not unsafe"#]]
+              Caused by:
+                  implementing the trait `Foo` is not unsafe"#]]
     )
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -132,7 +132,9 @@ fn basic_adt_variant_dup() {
             }
         ]
 
-        expect_test::expect![[r#"variant "Baz" defined multiple times"#]]
+        expect_test::expect![[r#"
+            the rule "adt" at (mod.rs) failed because
+              variant "Baz" defined multiple times"#]]
     )
 }
 
@@ -148,7 +150,9 @@ fn basic_adt_field_dup() {
             }
         ]
 
-        expect_test::expect![[r#"field "baz" of variant "struct" defined multiple times"#]]
+        expect_test::expect![[r#"
+            the rule "adt" at (mod.rs) failed because
+              field "baz" of variant "struct" defined multiple times"#]]
     )
 }
 
@@ -165,10 +169,11 @@ fn trait_items_with_duplicate_fn_names() {
         ]
 
         expect_test::expect![[r#"
-            check_trait(A)
+            the rule "trait" at (mod.rs) failed because
+              check_trait(A)
 
-            Caused by:
-                the function name `a` is defined multiple times"#]]
+              Caused by:
+                  the function name `a` is defined multiple times"#]]
 
     );
 }
@@ -186,10 +191,11 @@ fn trait_items_with_duplicate_associated_type_names() {
         ]
 
         expect_test::expect![[r#"
-            check_trait(A)
+            the rule "trait" at (mod.rs) failed because
+              check_trait(A)
 
-            Caused by:
-                the associated type name `Assoc` is defined multiple times"#]]
+              Caused by:
+                  the associated type name `Assoc` is defined multiple times"#]]
     );
 }
 
@@ -204,7 +210,9 @@ fn crate_with_duplicate_item_names() {
             }
         ]
 
-        expect_test::expect![[r#"the item name `A` is defined multiple times"#]]
+        expect_test::expect![[r#"
+            the rule "check crate" at (mod.rs) failed because
+              the item name `A` is defined multiple times"#]]
     );
 
     crate::assert_err!(
@@ -216,7 +224,9 @@ fn crate_with_duplicate_item_names() {
             }
         ]
 
-        expect_test::expect![[r#"the trait name `a` is defined multiple times"#]]
+        expect_test::expect![[r#"
+            the rule "check crate" at (mod.rs) failed because
+              the trait name `a` is defined multiple times"#]]
     );
 
     crate::assert_err!(
@@ -228,7 +238,9 @@ fn crate_with_duplicate_item_names() {
             }
         ]
 
-        expect_test::expect![[r#"the function name `a` is defined multiple times"#]]
+        expect_test::expect![[r#"
+            the rule "check crate" at (mod.rs) failed because
+              the function name `a` is defined multiple times"#]]
     );
 
     crate::assert_ok!(

--- a/tests/coherence_overlap.rs
+++ b/tests/coherence_overlap.rs
@@ -49,9 +49,13 @@ fn test_overlap_normalize_alias_to_LocalType() {
 
     test_program_ok(&gen_program("impl Iterator for LocalType {}")).assert_err(
         expect_test::expect![[r#"
-            impls may overlap:
-            impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { }
-            impl LocalTrait for <LocalType as Mirror>::T { }"#]],
+            judgment `check_all_crates { crates: [crate core { trait Iterator <ty> { } trait Mirror <ty> { type T : [] ; } impl <ty> Mirror for ^ty0_0 { type T = ^ty1_0 ; } struct LocalType { } trait LocalTrait <ty> { } impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { } impl LocalTrait for <LocalType as Mirror>::T { } impl Iterator for LocalType { } }] }` failed at the following rule(s):
+              the rule "check all prefixes" at (mod.rs) failed because
+                judgment `check_crate { c: crate core { trait Iterator <ty> { } trait Mirror <ty> { type T : [] ; } impl <ty> Mirror for ^ty0_0 { type T = ^ty1_0 ; } struct LocalType { } trait LocalTrait <ty> { } impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { } impl LocalTrait for <LocalType as Mirror>::T { } impl Iterator for LocalType { } }, program: program([crate core { trait Iterator <ty> { } trait Mirror <ty> { type T : [] ; } impl <ty> Mirror for ^ty0_0 { type T = ^ty1_0 ; } struct LocalType { } trait LocalTrait <ty> { } impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { } impl LocalTrait for <LocalType as Mirror>::T { } impl Iterator for LocalType { } }], 222) }` failed at the following rule(s):
+                  the rule "check crate" at (mod.rs) failed because
+                    impls may overlap:
+                    impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { }
+                    impl LocalTrait for <LocalType as Mirror>::T { }"#]],
     );
 }
 
@@ -93,16 +97,22 @@ fn test_overlap_alias_not_normalizable() {
     // trait for some local type, in which case it would overlap.
 
     test_program_ok(&gen_program("")).assert_err(expect_test::expect![[r#"
-        impls may overlap:
-        impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { }
-        impl <ty> LocalTrait for <^ty0_0 as Mirror>::T where ^ty0_0 : Mirror { }"#]]);
+        judgment `check_all_crates { crates: [crate core { trait Iterator <ty> { } trait Mirror <ty> { type T : [] ; } impl <ty> Mirror for ^ty0_0 { type T = ^ty1_0 ; } struct LocalType { } trait LocalTrait <ty> { } impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { } impl <ty> LocalTrait for <^ty0_0 as Mirror>::T where ^ty0_0 : Mirror { } }] }` failed at the following rule(s):
+          the rule "check all prefixes" at (mod.rs) failed because
+            judgment `check_crate { c: crate core { trait Iterator <ty> { } trait Mirror <ty> { type T : [] ; } impl <ty> Mirror for ^ty0_0 { type T = ^ty1_0 ; } struct LocalType { } trait LocalTrait <ty> { } impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { } impl <ty> LocalTrait for <^ty0_0 as Mirror>::T where ^ty0_0 : Mirror { } }, program: program([crate core { trait Iterator <ty> { } trait Mirror <ty> { type T : [] ; } impl <ty> Mirror for ^ty0_0 { type T = ^ty1_0 ; } struct LocalType { } trait LocalTrait <ty> { } impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { } impl <ty> LocalTrait for <^ty0_0 as Mirror>::T where ^ty0_0 : Mirror { } }], 222) }` failed at the following rule(s):
+              the rule "check crate" at (mod.rs) failed because
+                impls may overlap:
+                impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { }
+                impl <ty> LocalTrait for <^ty0_0 as Mirror>::T where ^ty0_0 : Mirror { }"#]]);
 
     // ...and if there is at least one Iterator impl, we also flag an error.
 
-    test_program_ok(&gen_program("impl Iterator for u32 {}")).assert_err(expect_test::expect![[
-        r#"
-        impls may overlap:
-        impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { }
-        impl <ty> LocalTrait for <^ty0_0 as Mirror>::T where ^ty0_0 : Mirror { }"#
-    ]]);
+    test_program_ok(&gen_program("impl Iterator for u32 {}")).assert_err(expect_test::expect![[r#"
+        judgment `check_all_crates { crates: [crate core { trait Iterator <ty> { } trait Mirror <ty> { type T : [] ; } impl <ty> Mirror for ^ty0_0 { type T = ^ty1_0 ; } struct LocalType { } trait LocalTrait <ty> { } impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { } impl <ty> LocalTrait for <^ty0_0 as Mirror>::T where ^ty0_0 : Mirror { } impl Iterator for u32 { } }] }` failed at the following rule(s):
+          the rule "check all prefixes" at (mod.rs) failed because
+            judgment `check_crate { c: crate core { trait Iterator <ty> { } trait Mirror <ty> { type T : [] ; } impl <ty> Mirror for ^ty0_0 { type T = ^ty1_0 ; } struct LocalType { } trait LocalTrait <ty> { } impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { } impl <ty> LocalTrait for <^ty0_0 as Mirror>::T where ^ty0_0 : Mirror { } impl Iterator for u32 { } }, program: program([crate core { trait Iterator <ty> { } trait Mirror <ty> { type T : [] ; } impl <ty> Mirror for ^ty0_0 { type T = ^ty1_0 ; } struct LocalType { } trait LocalTrait <ty> { } impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { } impl <ty> LocalTrait for <^ty0_0 as Mirror>::T where ^ty0_0 : Mirror { } impl Iterator for u32 { } }], 222) }` failed at the following rule(s):
+              the rule "check crate" at (mod.rs) failed because
+                impls may overlap:
+                impl <ty> LocalTrait for ^ty0_0 where ^ty0_0 : Iterator { }
+                impl <ty> LocalTrait for <^ty0_0 as Mirror>::T where ^ty0_0 : Mirror { }"#]]);
 }


### PR DESCRIPTION
## What does this PR do?

Convert the top-level functions (`check_all_crates`, `check_crate`, `check_crate_item`) to judgment functions. Avoids the need to manually construct proof trees.

This will serve as an exemplar for converting similar functions elsewhere.

## Disclosure and PR context

**AI tools used:** not this time.

**Confidence level:** feel good about it

**Review depth:** I reviewed closely and understand it well

**Testing:** `UPDATE_EXPECT=1 cargo test --all --workspace`

**Questions for mentors:** none
