### PR TITLE
add test to ensure wf of references

### DIFF
--- a/crates/formality-rust/src/prove/prove/prove/prove_wf.rs
+++ b/crates/formality-rust/src/prove/prove/prove/prove_wf.rs
@@ -6,7 +6,7 @@ use formality_core::{judgment_fn, Downcast, ProvenSet};
 
 use crate::prove::prove::{
     decls::Program,
-    prove::{combinators::for_all, prove_after::prove_after, prove_wc::prove_wc},
+    prove::{combinators::for_all, prove_after::prove_after},
 };
 
 use super::{constraints::Constraints, env::Env};
@@ -34,7 +34,8 @@ judgment_fn! {
         (
             // `&'a T` is well-formed if `T: 'a`
             (let (lt, ty) = parameters.downcast_err::<(Lt, Ty)>()?)
-            (prove_wc(decls, env, assumptions, Relation::outlives(ty, lt)) => c)
+            (prove_wf(decls, env, assumptions, ty) => c)
+            (prove_after(decls, c, assumptions, Relation::outlives(ty, lt)) => c)
             --- ("references")
             (prove_wf(decls, env, assumptions, RigidTy { name: RigidName::Ref(_), parameters }) => c)
         )

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -8,6 +8,7 @@ mod consts;
 mod decl_safety;
 mod functions;
 mod mir_typeck;
+mod references;
 mod well_formed_trait_ref;
 
 #[test]

--- a/src/test/references.rs
+++ b/src/test/references.rs
@@ -1,0 +1,41 @@
+/// See <https://github.com/rust-lang/a-mir-formality/issues/312> for more information.
+#[test]
+fn recursive_reference_validity() {
+    crate::assert_err!(
+        [
+            crate core {
+                trait Trait {}
+                struct A<X> where X: Trait {}
+                fn invalid<'a, X>(x: &'a A<X>) -> ()
+                where
+                    X: 'a,
+                {}
+            }
+        ]
+
+        expect_test::expect![[r#"
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: @ wf(&!lt_1 A<!ty_0>), via: !ty_0 : !lt_1, assumptions: {!ty_0 : !lt_1}, env: Env { variables: [!lt_1, !ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
+
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait(!ty_0), via: !ty_0 : !lt_1, assumptions: {!ty_0 : !lt_1}, env: Env { variables: [!lt_1, !ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
+
+            the rule "trait implied bound" at (prove_wc.rs) failed because
+              expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
+    );
+}
+
+#[test]
+fn reference_validity() {
+    crate::assert_ok!(
+        [
+            crate core {
+                trait Trait {}
+                struct A<X> where X: Trait {}
+                fn valid<'a, X>(x: &'a A<X>) -> ()
+                where
+                    X: 'a,
+                    X: Trait,
+                {}
+            }
+        ]
+    );
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a problem in the well-formedness rule of references. This code is successfully checked by a-mir-formality:
```rust
crate core {
    trait Trait {}
    struct A<X> where X: Trait {}
    fn invalid<'a, X>(x: &'a A<X>) -> ()
    where
        X: 'a,
    {}
}
```
This is obviously wrong, since `X` must implement `Trait` for `A<X>` to be wf.

## Disclosure and PR context

**AI tools used:** None

**Confidence level:** High in that this is an issue, a bit unsure on my solution, I don't know if I composed the constraints correctly.

**Testing:** `cargo test --all` and added a new test to catch invalid references (which failed before my modifications)