### PR TITLE
Reject moves out of references

### DIFF
--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -432,15 +432,7 @@ judgment_fn! {
             (access_permitted(env, assumptions, state, Access::new(AccessKind::Read, place), places_live_on_exit) => state)
             // FIXME(#296): also need to track that the place has been moved from
             (prove_place_is_movable(env, assumptions, state, place) => state)
-            ------------------------------------------------------------ ("place-move")
-            (borrow_check_expr(env, assumptions, state, ExprData::Place(place), places_live_on_exit) => (&place.ty, state))
-        )
-
-        (
-            (borrow_check_place_expr(env, assumptions, state, place) => (place, state))
-            (access_permitted(env, assumptions, state, Access::new(AccessKind::Read, place), places_live_on_exit) => state)
-            (prove_ty_is_copy(env, assumptions, state, &place.ty) => state)
-            ------------------------------------------------------------ ("place-copy")
+            ------------------------------------------------------------ ("place")
             (borrow_check_expr(env, assumptions, state, ExprData::Place(place), places_live_on_exit) => (&place.ty, state))
         )
 
@@ -750,8 +742,10 @@ judgment_fn! {
 }
 
 judgment_fn! {
-    /// Prove that a type is `Copy`. For now, scalar types and references are
-    /// considered `Copy`. This will eventually be replaced by a proper trait check.
+    /// Prove that a type is `Copy`. For now, scalar types and shared references
+    /// are considered `Copy`.
+    ///
+    /// FIXME: replace with a proper trait check once lang-items are available.
     fn prove_ty_is_copy(
         env: TypeckEnv,
         assumptions: Wcs,
@@ -790,21 +784,36 @@ judgment_fn! {
         debug(env, assumptions, state, place)
 
         (
-            (if let TypedPlaceExpressionData::Local(_) = place.data())
             ------------------------------------------------------------ ("local")
-            (prove_place_is_movable(_env, _assumptions, state, place) => state)
+            (prove_place_is_movable(
+                _env,
+                _assumptions,
+                state,
+                TypedPlaceExpressionData::Local(_),
+            ) => state)
         )
 
         (
-            (if let TypedPlaceExpressionData::Field(prefix, _) = place.data())
             (prove_place_is_movable(env, assumptions, state, prefix) => state)
             ------------------------------------------------------------ ("field")
+            (prove_place_is_movable(
+                env,
+                assumptions,
+                state,
+                TypedPlaceExpressionData::Field(prefix, _),
+            ) => state)
+        )
+
+        (
+            (prove_ty_is_copy(env, assumptions, state, &place.ty) => state)
+            ------------------------------------------------------------ ("copy")
             (prove_place_is_movable(env, assumptions, state, place) => state)
         )
 
-        // For a deref, we would need to prove the prefix type is an "owned deref"
-        // (e.g., Box). Since no owned deref types exist yet, this rule has no
-        // matching cases and derefs through references naturally fail.
+        // For a deref of a non-Copy type, we would need to prove the prefix type
+        // is an "owned deref" (e.g., Box). Since no owned deref types exist yet,
+        // this rule has no matching cases and derefs through references naturally
+        // fail.
     }
 }
 

--- a/crates/formality-rust/src/check/borrow_check/typed_place_expression.rs
+++ b/crates/formality-rust/src/check/borrow_check/typed_place_expression.rs
@@ -2,7 +2,7 @@ use crate::grammar::{
     expr::{PlaceExpr, PlaceExprData},
     FieldName, Ty, ValueId,
 };
-use formality_core::{cast_impl, term, Upcast};
+use formality_core::{cast_impl, term, DowncastTo, Upcast};
 use std::sync::Arc;
 
 #[term($data: $ty)]
@@ -26,6 +26,12 @@ pub enum TypedPlaceExpressionData {
     Field(TypedPlaceExpr, FieldName),
     // Index
     // Downcast
+}
+
+impl DowncastTo<TypedPlaceExpressionData> for TypedPlaceExpr {
+    fn downcast_to(&self) -> Option<TypedPlaceExpressionData> {
+        Some(self.data().clone())
+    }
 }
 
 impl TypedPlaceExpr {

--- a/src/test/borrowck.rs
+++ b/src/test/borrowck.rs
@@ -427,13 +427,7 @@ fn move_out_of_shared_ref() {
               pattern `(RigidTy { name: RigidName::ScalarId(_), .. }, state)` did not match value `(Datum, flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(some(U(2)), None, {}, None, [(x, Datum), (r, &?lt_1 Datum)], [x : Datum, r : &?lt_1 Datum])], point_flow_state({pending_outlives(?lt_2, ?lt_1)}, {loan(?lt_2, x : Datum, shared)}), {}, {}))`
 
             the rule "shared-ref" at (nll.rs) failed because
-              pattern `(RigidTy { name: RigidName::Ref(RefKind::Shared), .. }, state)` did not match value `(Datum, flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(some(U(2)), None, {}, None, [(x, Datum), (r, &?lt_1 Datum)], [x : Datum, r : &?lt_1 Datum])], point_flow_state({pending_outlives(?lt_2, ?lt_1)}, {loan(?lt_2, x : Datum, shared)}), {}, {}))`
-
-            the rule "field" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Field(prefix, _)` did not match value `*(r : &?lt_1 Datum)`
-
-            the rule "local" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Local(_)` did not match value `*(r : &?lt_1 Datum)`"#]]
+              pattern `(RigidTy { name: RigidName::Ref(RefKind::Shared), .. }, state)` did not match value `(Datum, flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(some(U(2)), None, {}, None, [(x, Datum), (r, &?lt_1 Datum)], [x : Datum, r : &?lt_1 Datum])], point_flow_state({pending_outlives(?lt_2, ?lt_1)}, {loan(?lt_2, x : Datum, shared)}), {}, {}))`"#]]
     )
 }
 
@@ -473,13 +467,7 @@ fn move_out_of_mut_ref() {
               pattern `(RigidTy { name: RigidName::ScalarId(_), .. }, state)` did not match value `(Datum, flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(some(U(2)), None, {}, None, [(x, Datum), (r, &mut ?lt_1 Datum)], [x : Datum, r : &mut ?lt_1 Datum])], point_flow_state({pending_outlives(?lt_2, ?lt_1)}, {loan(?lt_2, x : Datum, mut)}), {}, {}))`
 
             the rule "shared-ref" at (nll.rs) failed because
-              pattern `(RigidTy { name: RigidName::Ref(RefKind::Shared), .. }, state)` did not match value `(Datum, flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(some(U(2)), None, {}, None, [(x, Datum), (r, &mut ?lt_1 Datum)], [x : Datum, r : &mut ?lt_1 Datum])], point_flow_state({pending_outlives(?lt_2, ?lt_1)}, {loan(?lt_2, x : Datum, mut)}), {}, {}))`
-
-            the rule "field" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Field(prefix, _)` did not match value `*(r : &mut ?lt_1 Datum)`
-
-            the rule "local" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Local(_)` did not match value `*(r : &mut ?lt_1 Datum)`"#]]
+              pattern `(RigidTy { name: RigidName::Ref(RefKind::Shared), .. }, state)` did not match value `(Datum, flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(some(U(2)), None, {}, None, [(x, Datum), (r, &mut ?lt_1 Datum)], [x : Datum, r : &mut ?lt_1 Datum])], point_flow_state({pending_outlives(?lt_2, ?lt_1)}, {loan(?lt_2, x : Datum, mut)}), {}, {}))`"#]]
     )
 }
 

--- a/src/test/mir_typeck.rs
+++ b/src/test/mir_typeck.rs
@@ -313,9 +313,6 @@ fn test_call_invalid_fn() {
               no fn named `foo`
 
             the rule "local" at (nll.rs) failed because
-              unknown local variable `foo`
-
-            the rule "local" at (nll.rs) failed because
               unknown local variable `foo`"#]]
     )
 }
@@ -362,9 +359,6 @@ fn test_call_generic_fn_without_turbofish() {
         expect_test::expect![[r#"
             the rule "fn-name" at (nll.rs) failed because
               condition evaluated to false: `fn_decl.binder.len() == 0`
-
-            the rule "local" at (nll.rs) failed because
-              unknown local variable `identity`
 
             the rule "local" at (nll.rs) failed because
               unknown local variable `identity`"#]]


### PR DESCRIPTION
## What does this PR do?

- Add `prove_place_is_movable` judgment function that walks a `TypedPlaceExpr` and succeeds only when the place is not behind a reference. It handles `Local` and `Field` cases; `Deref` has no matching rules yet (no owned deref types like `Box`), so all derefs through `&`/`&mut` naturally fail.
- Wire `prove_place_is_movable` into the "place" rule in `borrow_check_expr` at the existing FIXME
- Un-ignore `move_out_of_shared_ref` and `move_out_of_mut_ref` tests and update their expected errors

 Closes #297


## Disclosure and PR context

**AI tools used:** Claude Code helped with codebase exploration, implementation approach, and drafting the judgment function

**Confidence level:** High — the approach was discussed with @nikomatsakis on Zulip and follows his guidance to "think positively" with a `prove_place_is_movable` judgment rather than a negative `place_is_behind_ref` check

**Review depth:** I read and understand all changes

**Testing:** `move_out_of_shared_ref` and `move_out_of_mut_ref` both pass. `cargo check` passes. Full `cargo test --all` hit OOM on Windows locally — relying on CI for full suite.

**Questions for mentors:** None
