### PR TITLE
convert check_trait_impl and helpers to judgment functions

### DIFF
--- a/crates/formality-rust/src/check/impls.rs
+++ b/crates/formality-rust/src/check/impls.rs
@@ -1,86 +1,43 @@
 use anyhow::bail;
 
+use crate::grammar::{
+    AssociatedTy, AssociatedTyBoundData, AssociatedTyValue, AssociatedTyValueBoundData, Binder,
+    CrateId, Fallible, Fn, FnBoundData, ImplItem, NegTraitImpl, NegTraitImplBoundData, Relation,
+    Substitution, Trait, TraitBoundData, TraitImpl, TraitImplBoundData, TraitItem, Wcs,
+};
 use crate::prove::prove::{Env, Program, Safety};
 use crate::rust::Term;
-use crate::{
-    grammar::{
-        AssociatedTy, AssociatedTyBoundData, AssociatedTyValue, AssociatedTyValueBoundData, Binder,
-        CrateId, Fallible, Fn, FnBoundData, ImplItem, NegTraitImpl, NegTraitImplBoundData,
-        Relation, Substitution, Trait, TraitBoundData, TraitImpl, TraitImplBoundData, TraitItem,
-        Wcs,
-    },
-    prove::ToWcs,
-};
 use fn_error_context::context;
-use formality_core::{judgment::ProofTree, Downcasted};
+use formality_core::{judgment::ProofTree, judgment_fn, Downcasted};
 
-#[context("check_trait_impl({trait_impl:?})")]
-pub(super) fn check_trait_impl(
-    program: &Program,
-    trait_impl: &TraitImpl,
-    crate_id: &CrateId,
-) -> Fallible<ProofTree> {
-    let TraitImpl { binder, safety: _ } = trait_impl;
-    let mut proof_tree = ProofTree::leaf("check_trait_impl");
+judgment_fn! {
+    pub(super) fn check_trait_impl(
+        program: Program,
+        trait_impl: TraitImpl,
+        crate_id: CrateId,
+    ) => () {
+        debug(program, trait_impl, crate_id)
+        (
+            (let TraitImpl { binder, safety: _ } = &trait_impl)
+            (let (env, bound_data) = Env::default().instantiate_universally(binder))
+            (let TraitImplBoundData { trait_id, self_ty, trait_parameters, where_clauses, impl_items } = bound_data)
+            (let trait_ref = trait_id.with(self_ty, trait_parameters))
 
-    let (
-        env,
-        TraitImplBoundData {
-            trait_id,
-            self_ty,
-            trait_parameters,
-            where_clauses,
-            impl_items,
-        },
-    ) = Env::default().instantiate_universally(binder);
+            (super::where_clauses::prove_where_clauses_well_formed(program, &env, &where_clauses, &where_clauses) => ())
+            (super::prove_goal(program, &env, &where_clauses, trait_ref.is_implemented()) => ())
+            (super::prove_not_goal(program, &env, &where_clauses, trait_ref.not_implemented()) => ())
 
-    let trait_ref = trait_id.with(self_ty, trait_parameters);
+            (let trait_decl = program.program().trait_named(&trait_ref.trait_id)?)
+            (let TraitBoundData { where_clauses: _, trait_items } = trait_decl.binder.instantiate_with(&trait_ref.parameters)?)
+            (check_safety_matches(&trait_decl, &trait_impl) => ())
 
-    proof_tree
-        .children
-        .push(super::where_clauses::prove_where_clauses_well_formed(
-            program,
-            &env,
-            &where_clauses,
-            &where_clauses,
-        )?);
+            (for_all(impl_item in impl_items)
+                (check_trait_impl_item(program, &env, &where_clauses, &trait_items, impl_item, crate_id) => ()))
 
-    proof_tree.children.push(super::prove_goal(
-        program,
-        &env,
-        &where_clauses,
-        trait_ref.is_implemented(),
-    )?);
-
-    proof_tree.children.push(super::prove_not_goal(
-        program,
-        &env,
-        &where_clauses,
-        trait_ref.not_implemented(),
-    )?);
-
-    let trait_decl = program.program().trait_named(&trait_ref.trait_id)?;
-    let TraitBoundData {
-        where_clauses: _,
-        trait_items,
-    } = trait_decl.binder.instantiate_with(&trait_ref.parameters)?;
-
-    proof_tree
-        .children
-        .push(check_safety_matches(trait_decl, trait_impl)?);
-
-    for impl_item in &impl_items {
-        proof_tree.children.push(check_trait_impl_item(
-            program,
-            &env,
-            &where_clauses,
-            &trait_items,
-            impl_item,
-            crate_id,
-        )?);
+            ---- ("check_trait_impl")
+            (check_trait_impl(program, trait_impl, crate_id) => ())
+        )
     }
-
-    Ok(proof_tree)
 }
 
 #[context("check_neg_trait_impl({trait_impl:?})")]
@@ -129,232 +86,131 @@ pub(super) fn check_neg_trait_impl(
     Ok(proof_tree)
 }
 
-/// Validate that the declared safety of an impl matches the one from the trait declaration.
-fn check_safety_matches(trait_decl: &Trait, trait_impl: &TraitImpl) -> Fallible<ProofTree> {
-    let proof_tree = ProofTree::leaf(format!(
-        "safety_matches({:?}, {:?})",
-        trait_decl.safety, trait_impl.safety
-    ));
-
-    if trait_decl.safety != trait_impl.safety {
-        match trait_decl.safety {
-            Safety::Safe => bail!("implementing the trait `{:?}` is not unsafe", trait_decl.id),
-            Safety::Unsafe => bail!(
-                "the trait `{:?}` requires an `unsafe impl` declaration",
-                trait_decl.id
-            ),
-        }
-    }
-
-    Ok(proof_tree)
-}
-
-fn check_trait_impl_item(
-    program: &Program,
-    env: &Env,
-    assumptions: impl ToWcs,
-    trait_items: &[TraitItem],
-    impl_item: &ImplItem,
-    crate_id: &CrateId,
-) -> Fallible<ProofTree> {
-    let assumptions: Wcs = assumptions.to_wcs();
-    assert!(env.only_universal_variables() && env.encloses((&assumptions, trait_items, impl_item)));
-
-    match impl_item {
-        ImplItem::Fn(v) => check_fn_in_impl(program, env, &assumptions, trait_items, v, crate_id),
-        ImplItem::AssociatedTyValue(v) => {
-            check_associated_ty_value(program, env, assumptions, trait_items, v)
-        }
-    }
-}
-
-fn check_fn_in_impl(
-    program: &Program,
-    env: &Env,
-    impl_assumptions: impl ToWcs,
-    trait_items: &[TraitItem],
-    ii_fn: &Fn,
-    crate_id: &CrateId,
-) -> Fallible<ProofTree> {
-    let impl_assumptions: Wcs = impl_assumptions.to_wcs();
-    assert!(
-        env.only_universal_variables() && env.encloses((&impl_assumptions, trait_items, ii_fn))
-    );
-
-    // Find the corresponding function from the trait:
-    let ti_fn = match trait_items
-        .iter()
-        .downcasted::<Fn>()
-        .find(|trait_f| trait_f.id == ii_fn.id)
-    {
-        Some(trait_f) => trait_f,
-        None => bail!("no fn `{:?}` in the trait", ii_fn.id),
-    };
-
-    tracing::debug!(?ti_fn);
-
-    let mut proof_tree = ProofTree::new(format!("check_fn_in_impl({:?})", ii_fn.id), None, vec![]);
-
-    proof_tree.children.push(
-        super::fns::check_fn(program, env, &impl_assumptions, ii_fn, crate_id).check_proven()?,
-    );
-
-    let (
-        env,
+judgment_fn! {
+    /// Validate that the declared safety of an impl matches the one from the trait declaration.
+    fn check_safety_matches(
+        trait_decl: Trait,
+        trait_impl: TraitImpl,
+    ) => () {
+        debug(trait_decl, trait_impl)
         (
-            FnBoundData {
-                input_args: ii_input_args,
-                output_ty: ii_output_ty,
-                where_clauses: ii_where_clauses,
-                body: _,
-            },
-            FnBoundData {
-                input_args: ti_input_args,
-                output_ty: ti_output_ty,
-                where_clauses: ti_where_clauses,
-                body: _,
-            },
-        ),
-    ) = env.instantiate_universally(&merge_binders(&ii_fn.binder, &ti_fn.binder)?);
-
-    proof_tree.children.push(super::prove_goal(
-        program,
-        &env,
-        (&impl_assumptions, &ti_where_clauses),
-        &ii_where_clauses,
-    )?);
-
-    if ii_input_args.len() != ti_input_args.len() {
-        bail!(
-            "impl has {} function arguments but trait has {} function arguments",
-            ii_input_args.len(),
-            ti_input_args.len()
+            (if trait_decl.safety == trait_impl.safety)
+            ---- ("safety matches")
+            (check_safety_matches(trait_decl, trait_impl) => ())
         )
     }
-
-    for (ii_input_arg, ti_input_arg) in ii_input_args.iter().zip(&ti_input_args) {
-        proof_tree.children.push(super::prove_goal(
-            program,
-            &env,
-            (&impl_assumptions, &ii_where_clauses),
-            Relation::sub(&ti_input_arg.ty, &ii_input_arg.ty),
-        )?);
-    }
-
-    // Check that the impl's declared return type is a subtype of what the trait declared:
-    //
-    // OK
-    //
-    // ```rust
-    // trait Foo {
-    //     fn bar<'a>(&'a self, input: &u32) -> &'a u32;
-    // }
-    //
-    // impl Foo for MyType {
-    //     fn bar(&self, input: &u32) -> &'static u32 {} // <-- subtype, ok
-    // }
-    // ```
-    //
-    // NOT OK
-    //
-    // ```rust
-    // trait Foo {
-    //     fn bar<'a>(&'a self, input: &u32) -> &'a u32;
-    // }
-    //
-    // impl Foo for MyType {
-    //     fn bar<'b>(&self, input: &'b u32) -> &'b u32 {} // <-- not sutype, not ok
-    // }
-    // ```
-
-    proof_tree.children.push(super::prove_goal(
-        program,
-        &env,
-        (&impl_assumptions, &ii_where_clauses),
-        Relation::sub(ii_output_ty, ti_output_ty),
-    )?);
-
-    Ok(proof_tree)
 }
 
-#[context("check_associated_ty_value({impl_value:?})")]
-fn check_associated_ty_value(
-    program: &Program,
-    impl_env: &Env,
-    impl_assumptions: impl ToWcs,
-    trait_items: &[TraitItem],
-    impl_value: &AssociatedTyValue,
-) -> Fallible<ProofTree> {
-    let impl_assumptions: Wcs = impl_assumptions.to_wcs();
+judgment_fn! {
+    fn check_trait_impl_item(
+        program: Program,
+        env: Env,
+        assumptions: Wcs,
+        trait_items: Vec<TraitItem>,
+        impl_item: ImplItem,
+        crate_id: CrateId,
+    ) => () {
+        debug(program, env, assumptions, impl_item, crate_id)
 
-    assert!(
-        impl_env.only_universal_variables()
-            && impl_env.encloses((&impl_assumptions, trait_items, impl_value))
-    );
-
-    let AssociatedTyValue { id, binder } = impl_value;
-
-    let trait_associated_ty = match trait_items
-        .iter()
-        .downcasted::<AssociatedTy>()
-        .find(|trait_associated_ty| trait_associated_ty.id == *id)
-    {
-        Some(trait_associated_ty) => trait_associated_ty,
-        None => bail!("no associated type `{:?}` in the trait", id),
-    };
-
-    let (
-        env,
         (
-            AssociatedTyValueBoundData {
-                where_clauses: ii_where_clauses,
-                ty: ii_ty,
-            },
-            AssociatedTyBoundData {
-                ensures: ti_ensures,
-                where_clauses: ti_where_clauses,
-            },
-        ),
-    ) = impl_env.instantiate_universally(&merge_binders(binder, &trait_associated_ty.binder)?);
+            (check_fn_in_impl(program, env, assumptions, trait_items, v, crate_id) => ())
+            ---- ("fn in impl")
+            (check_trait_impl_item(program, env, assumptions, trait_items, ImplItem::Fn(v), crate_id) => ())
+        )
 
-    let mut proof_tree = ProofTree::new(
-        format!("check_associated_ty_value({:?})", impl_value.id),
-        None,
-        vec![],
-    );
+        (
+            (check_associated_ty_value(program, env, assumptions, trait_items, v) => ())
+            ---- ("associated ty value")
+            (check_trait_impl_item(program, env, assumptions, trait_items, ImplItem::AssociatedTyValue(v), crate_id) => ())
+        )
+    }
+}
 
-    proof_tree
-        .children
-        .push(super::where_clauses::prove_where_clauses_well_formed(
-            program,
-            &env,
-            (&impl_assumptions, &ii_where_clauses),
-            &ii_where_clauses,
-        )?);
+judgment_fn! {
+    fn check_fn_in_impl(
+        program: Program,
+        env: Env,
+        impl_assumptions: Wcs,
+        trait_items: Vec<TraitItem>,
+        ii_fn: Fn,
+        crate_id: CrateId,
+    ) => () {
+        debug(program, env, impl_assumptions, ii_fn, crate_id)
+        (
+            // Find the corresponding function from the trait
+            (if let Some(ti_fn) = trait_items
+                .iter()
+                .downcasted::<Fn>()
+                .find(|trait_f| trait_f.id == ii_fn.id))
 
-    proof_tree.children.push(super::prove_goal(
-        program,
-        &env,
-        (&impl_assumptions, &ti_where_clauses),
-        &ii_where_clauses,
-    )?);
+            // Check the fn itself
+            (super::fns::check_fn(program, env, impl_assumptions, ii_fn, crate_id) => ())
 
-    proof_tree.children.push(super::prove_goal(
-        program,
-        &env,
-        (&impl_assumptions, &ii_where_clauses),
-        ii_ty.well_formed(),
-    )?);
+            // Merge binders and instantiate universally
+            (let (env, (ii_bound, ti_bound)) = env.instantiate_universally(&merge_binders(&ii_fn.binder, &ti_fn.binder)?))
+            (let FnBoundData { input_args: ii_input_args, output_ty: ii_output_ty, where_clauses: ii_where_clauses, body: _ } = ii_bound)
+            (let FnBoundData { input_args: ti_input_args, output_ty: ti_output_ty, where_clauses: ti_where_clauses, body: _ } = ti_bound)
 
-    let ensures: Wcs = ti_ensures.iter().map(|e| e.to_wc(&ii_ty)).collect();
-    proof_tree.children.push(super::prove_goal(
-        program,
-        &env,
-        (&impl_assumptions, &ii_where_clauses),
-        ensures,
-    )?);
+            // Prove impl where-clauses follow from trait where-clauses
+            (super::prove_goal(program, &env, (&impl_assumptions, &ti_where_clauses), &ii_where_clauses) => ())
 
-    Ok(proof_tree)
+            // Check argument count matches
+            (if ii_input_args.len() == ti_input_args.len())
+
+            // Check each argument: trait arg is subtype of impl arg (contravariance)
+            (for_all(pair in ii_input_args.iter().zip(ti_input_args.iter()))
+                (let (ii_input_arg, ti_input_arg) = pair)
+                (super::prove_goal(program, &env, (&impl_assumptions, &ii_where_clauses), Relation::sub(&ti_input_arg.ty, &ii_input_arg.ty)) => ()))
+
+            // Check return type: impl return is subtype of trait return (covariance)
+            (super::prove_goal(program, &env, (&impl_assumptions, &ii_where_clauses), Relation::sub(ii_output_ty, ti_output_ty)) => ())
+
+            ---- ("check_fn_in_impl")
+            (check_fn_in_impl(program, env, impl_assumptions, trait_items, ii_fn, crate_id) => ())
+        )
+    }
+}
+
+judgment_fn! {
+    fn check_associated_ty_value(
+        program: Program,
+        impl_env: Env,
+        impl_assumptions: Wcs,
+        trait_items: Vec<TraitItem>,
+        impl_value: AssociatedTyValue,
+    ) => () {
+        debug(program, impl_env, impl_assumptions, impl_value)
+        (
+            (let AssociatedTyValue { id, binder } = &impl_value)
+
+            // Find the corresponding associated type from the trait
+            (if let Some(trait_associated_ty) = trait_items
+                .iter()
+                .downcasted::<AssociatedTy>()
+                .find(|trait_associated_ty| trait_associated_ty.id == *id))
+
+            // Merge binders and instantiate universally
+            (let (env, (ii_bound, ti_bound)) = impl_env.instantiate_universally(&merge_binders(binder, &trait_associated_ty.binder)?))
+            (let AssociatedTyValueBoundData { where_clauses: ii_where_clauses, ty: ii_ty } = ii_bound)
+            (let AssociatedTyBoundData { ensures: ti_ensures, where_clauses: ti_where_clauses } = ti_bound)
+
+            // Prove impl where-clauses are well-formed
+            (super::where_clauses::prove_where_clauses_well_formed(program, &env, (&impl_assumptions, &ii_where_clauses), &ii_where_clauses) => ())
+
+            // Prove impl where-clauses follow from trait where-clauses
+            (super::prove_goal(program, &env, (&impl_assumptions, &ti_where_clauses), &ii_where_clauses) => ())
+
+            // Prove the impl type is well-formed
+            (super::prove_goal(program, &env, (&impl_assumptions, &ii_where_clauses), ii_ty.well_formed()) => ())
+
+            // Prove the ensures clauses
+            (let ensures: Wcs = ti_ensures.iter().map(|e| e.to_wc(&ii_ty)).collect())
+            (super::prove_goal(program, &env, (&impl_assumptions, &ii_where_clauses), ensures) => ())
+
+            ---- ("check_associated_ty_value")
+            (check_associated_ty_value(program, impl_env, impl_assumptions, trait_items, impl_value) => ())
+        )
+    }
 }
 
 /// Given a binder from some impl item `I` and a binder from the corresponding trait item `T`,

--- a/src/test/coherence_overlap.rs
+++ b/src/test/coherence_overlap.rs
@@ -81,11 +81,8 @@ fn T_where_Foo_not_u32_impls() {
         ]
 
         expect_test::expect![[r#"
-            the rule "trait impl" at (mod.rs) failed because
-              check_trait_impl(impl <ty> Foo for ^ty0_0 where ^ty0_0 : Foo { })
-
-              Caused by:
-                  failed to prove {! Foo(!ty_1)} given {Foo(!ty_1)}, got [Constraints { env: Env { variables: [!ty_1], bias: Soundness, pending: [], allow_pending_outlives: false }, known_true: false, substitution: {} }]"#]]
+            the rule "check_trait_impl" at (impls.rs) failed because
+              failed to prove {! Foo(!ty_1)} given {Foo(!ty_1)}, got [Constraints { env: Env { variables: [!ty_1], bias: Soundness, pending: [], allow_pending_outlives: false }, known_true: false, substitution: {} }]"#]]
     )
 }
 

--- a/src/test/decl_safety.rs
+++ b/src/test/decl_safety.rs
@@ -88,11 +88,8 @@ fn unsafe_trait_mismatch() {
         ]
 
         expect_test::expect![[r#"
-            the rule "trait impl" at (mod.rs) failed because
-              check_trait_impl(impl Foo for u32 { })
-
-              Caused by:
-                  the trait `Foo` requires an `unsafe impl` declaration"#]]
+            the rule "safety matches" at (impls.rs) failed because
+              condition evaluated to false: `trait_decl.safety == trait_impl.safety`"#]]
     )
 }
 
@@ -107,10 +104,7 @@ fn safe_trait_mismatch() {
         ]
 
         expect_test::expect![[r#"
-            the rule "trait impl" at (mod.rs) failed because
-              check_trait_impl(unsafe impl Foo for u32 { })
-
-              Caused by:
-                  implementing the trait `Foo` is not unsafe"#]]
+            the rule "safety matches" at (impls.rs) failed because
+              condition evaluated to false: `trait_decl.safety == trait_impl.safety`"#]]
     )
 }


### PR DESCRIPTION
## What does this PR do?
This PR Converts  `check_trait_impl `and its related helpers in `impls.rs` from regular Rust functions to `judgment_fn! macros`. Each `proof_tree.children.push(...)` becomes a premise, and the macro handles proof tree construction automatically.
Functions converted: `check_trait_impl`, `check_safety_matches`, `check_trait_impl_item`, `check_fn_in_impl`, `check_associated_ty_value`. `merge_binders` stays as regular Rust per the tracking issue.

Updated test snapshots in `coherence_overlap.rs` and `decl_safety.rs` where error messages changed from custom `bail!` text to generic judgment failure output.

Closes #290 


## Disclosure and PR context

**AI tools used:** 
Claude Code  and ChatGPT was used for research, which  helped with  the codebase exploration,  and eventually understanding the `judgment_fn! `pattern

**Confidence level:** 
I Feel good about it . I  followed the existing patterns and all tests pass. 

**Review depth:** 
I  read and understand all changes. Went through each function step by step

**Testing:**
All tests pass with `cargo test --all`. 3 test snapshots updated via `UPDATE_EXPECT=1`
**Questions for mentors:** 
None 
