### PR TITLE
fix check trait missing item checks

### DIFF
--- a/crates/formality-rust/src/check/traits.rs
+++ b/crates/formality-rust/src/check/traits.rs
@@ -1,4 +1,7 @@
-use crate::grammar::{AssociatedTy, AssociatedTyBoundData, Fn, Kinded, Trait, TraitBoundData, TraitItem, Ty, TyData, Wcs};
+use crate::grammar::{
+    AssociatedTy, AssociatedTyBoundData, Fn, Kinded, Trait, TraitBoundData, TraitItem, Ty, TyData,
+    Wcs,
+};
 use crate::grammar::{CrateId, Fallible};
 use crate::prove::prove::{Env, Program};
 use anyhow::bail;

--- a/crates/formality-rust/src/check/traits.rs
+++ b/crates/formality-rust/src/check/traits.rs
@@ -1,8 +1,8 @@
-use crate::grammar::{AssociatedTy, AssociatedTyBoundData, Fn, Trait, TraitBoundData, TraitItem};
-use crate::grammar::{CrateId, Fallible, Wcs};
+use crate::grammar::{AssociatedTy, AssociatedTyBoundData, Fn, Kinded, Trait, TraitBoundData, TraitItem, Ty, TyData, Wcs};
+use crate::grammar::{CrateId, Fallible};
 use crate::prove::prove::{Env, Program};
 use anyhow::bail;
-use formality_core::{judgment::ProofTree, judgment_fn, Set};
+use formality_core::{judgment::ProofTree, judgment_fn, Set, Upcast};
 
 judgment_fn! {
     pub(super) fn check_trait(
@@ -81,10 +81,13 @@ judgment_fn! {
         (
             (let AssociatedTy { id: _, binder } = associated_ty)
             (let (env, bound_data) = env.instantiate_universally(binder))
-            (let AssociatedTyBoundData { ensures: _, where_clauses } = bound_data)
+            (let AssociatedTyBoundData { ensures, where_clauses } = bound_data)
+            (let self_ty: Ty = crate::grammar::TyData::Variable(env.variables().last().unwrap().clone()).upcast())
+            (let ensures_wcs: Wcs = ensures.iter().map(|e| e.to_wc(&self_ty)).collect())
             (super::where_clauses::prove_where_clauses_well_formed(
                 program, env, (trait_where_clauses, where_clauses), where_clauses,
             ) => ())
+            (super::prove_goal(program, env, (trait_where_clauses, where_clauses), ensures_wcs) => ())
             ------------------------------------------------------------ ("check associated ty")
             (check_associated_ty(program, env, trait_where_clauses, associated_ty) => ())
         )

--- a/crates/formality-rust/src/check/traits.rs
+++ b/crates/formality-rust/src/check/traits.rs
@@ -84,13 +84,13 @@ judgment_fn! {
         (
             (let AssociatedTy { id: _, binder } = associated_ty)
             (let (env, bound_data) = env.instantiate_universally(binder))
-            (let AssociatedTyBoundData { ensures, where_clauses } = bound_data)
-            (let self_ty: Ty = crate::grammar::TyData::Variable(env.variables().last().unwrap().clone()).upcast())
-            (let ensures_wcs: Wcs = ensures.iter().map(|e| e.to_wc(&self_ty)).collect())
+            (let AssociatedTyBoundData { ensures: _, where_clauses } = bound_data)
+
+
             (super::where_clauses::prove_where_clauses_well_formed(
                 program, env, (trait_where_clauses, where_clauses), where_clauses,
             ) => ())
-            (super::prove_goal(program, env, (trait_where_clauses, where_clauses), ensures_wcs) => ())
+
             ------------------------------------------------------------ ("check associated ty")
             (check_associated_ty(program, env, trait_where_clauses, associated_ty) => ())
         )

--- a/crates/formality-rust/src/check/traits.rs
+++ b/crates/formality-rust/src/check/traits.rs
@@ -14,12 +14,15 @@ judgment_fn! {
         debug(program, t, crate_id)
 
         (
-            (let Trait { safety: _, id: _, binder } = &t)
+            (let Trait { safety: _, id: _, binder } = t)
             (let (env, bound_data) = env.instantiate_universally(&binder.explicit_binder))
             (let TraitBoundData { where_clauses, trait_items } = bound_data)
+
             (check_trait_items_have_unique_names(&trait_items) => ())
+
             (super::where_clauses::prove_where_clauses_well_formed(program, &env, &where_clauses, &where_clauses) => ())
-            (for_all(trait_item in &trait_items)
+
+            (for_all(trait_item in trait_items.iter())
                 (check_trait_item(program, &env, &where_clauses, trait_item, crate_id) => ()))
             ------------------------------------------------------------ ("check trait")
             (check_trait(program, env, t, crate_id) => ())
@@ -79,13 +82,13 @@ judgment_fn! {
         debug(program, env, trait_where_clauses, associated_ty)
 
         (
-            (let AssociatedTy { id: _, binder } = &associated_ty)
+            (let AssociatedTy { id: _, binder } = associated_ty)
             (let (env, bound_data) = env.instantiate_universally(binder))
             (let AssociatedTyBoundData { ensures: _, where_clauses } = bound_data)
+
             (super::where_clauses::prove_where_clauses_well_formed(
                 program, env, (&trait_where_clauses, &where_clauses), &where_clauses,
             ) => ())
-            // FIXME(#228): Do we prove ensures WF? And what do we assume when we do so?
             ------------------------------------------------------------ ("check associated ty")
             (check_associated_ty(program, env, trait_where_clauses, associated_ty) => ())
         )

--- a/crates/formality-rust/src/check/traits.rs
+++ b/crates/formality-rust/src/check/traits.rs
@@ -17,13 +17,10 @@ judgment_fn! {
             (let Trait { safety: _, id: _, binder } = t)
             (let (env, bound_data) = env.instantiate_universally(&binder.explicit_binder))
             (let TraitBoundData { where_clauses, trait_items } = bound_data)
-
             (check_trait_items_have_unique_names(&trait_items) => ())
-
-            (super::where_clauses::prove_where_clauses_well_formed(program, &env, &where_clauses, &where_clauses) => ())
-
-            (for_all(trait_item in trait_items.iter())
-                (check_trait_item(program, &env, &where_clauses, trait_item, crate_id) => ()))
+            (super::where_clauses::prove_where_clauses_well_formed(program, env, where_clauses, where_clauses) => ())
+            (for_all(trait_item in trait_items)
+                (check_trait_item(program, env, where_clauses, trait_item, crate_id) => ()))
             ------------------------------------------------------------ ("check trait")
             (check_trait(program, env, t, crate_id) => ())
         )
@@ -85,9 +82,8 @@ judgment_fn! {
             (let AssociatedTy { id: _, binder } = associated_ty)
             (let (env, bound_data) = env.instantiate_universally(binder))
             (let AssociatedTyBoundData { ensures: _, where_clauses } = bound_data)
-
             (super::where_clauses::prove_where_clauses_well_formed(
-                program, env, (&trait_where_clauses, &where_clauses), &where_clauses,
+                program, env, (trait_where_clauses, where_clauses), where_clauses,
             ) => ())
             ------------------------------------------------------------ ("check associated ty")
             (check_associated_ty(program, env, trait_where_clauses, associated_ty) => ())

--- a/crates/formality-rust/src/check/traits.rs
+++ b/crates/formality-rust/src/check/traits.rs
@@ -1,5 +1,5 @@
-use crate::grammar::{AssociatedTy, Trait, TraitBoundData, TraitItem};
-use crate::grammar::{CrateId, Fallible};
+use crate::grammar::{AssociatedTy, AssociatedTyBoundData, Fn, Trait, TraitBoundData, TraitItem};
+use crate::grammar::{CrateId, Fallible, Wcs};
 use crate::prove::prove::{Env, Program};
 use anyhow::bail;
 use formality_core::{judgment::ProofTree, judgment_fn, Set};
@@ -18,9 +18,76 @@ judgment_fn! {
             (let (env, bound_data) = env.instantiate_universally(&binder.explicit_binder))
             (let TraitBoundData { where_clauses, trait_items } = bound_data)
             (check_trait_items_have_unique_names(&trait_items) => ())
-            (super::where_clauses::prove_where_clauses_well_formed(program, env, where_clauses, where_clauses) => ())
+            (super::where_clauses::prove_where_clauses_well_formed(program, &env, &where_clauses, &where_clauses) => ())
+            (for_all(trait_item in &trait_items)
+                (check_trait_item(program, &env, &where_clauses, trait_item, crate_id) => ()))
             ------------------------------------------------------------ ("check trait")
             (check_trait(program, env, t, crate_id) => ())
+        )
+    }
+}
+
+judgment_fn! {
+    fn check_trait_item(
+        program: Program,
+        env: Env,
+        where_clauses: Wcs,
+        trait_item: TraitItem,
+        crate_id: CrateId,
+    ) => () {
+        debug(program, env, where_clauses, trait_item, crate_id)
+
+        (
+            (check_fn_in_trait(program, env, where_clauses, f, crate_id) => ())
+            ------------------------------------------------------------ ("fn in trait")
+            (check_trait_item(program, env, where_clauses, TraitItem::Fn(f), crate_id) => ())
+        )
+
+        (
+            (check_associated_ty(program, env, where_clauses, v) => ())
+            ------------------------------------------------------------ ("associated ty in trait")
+            (check_trait_item(program, env, where_clauses, TraitItem::AssociatedTy(v), crate_id) => ())
+        )
+    }
+}
+
+judgment_fn! {
+    fn check_fn_in_trait(
+        program: Program,
+        env: Env,
+        assumptions: Wcs,
+        f: Fn,
+        crate_id: CrateId,
+    ) => () {
+        debug(program, env, assumptions, f, crate_id)
+
+        (
+            (super::fns::check_fn(program, env, assumptions, f, crate_id) => ())
+            ------------------------------------------------------------ ("check fn in trait")
+            (check_fn_in_trait(program, env, assumptions, f, crate_id) => ())
+        )
+    }
+}
+
+judgment_fn! {
+    fn check_associated_ty(
+        program: Program,
+        env: Env,
+        trait_where_clauses: Wcs,
+        associated_ty: AssociatedTy,
+    ) => () {
+        debug(program, env, trait_where_clauses, associated_ty)
+
+        (
+            (let AssociatedTy { id: _, binder } = &associated_ty)
+            (let (env, bound_data) = env.instantiate_universally(binder))
+            (let AssociatedTyBoundData { ensures: _, where_clauses } = bound_data)
+            (super::where_clauses::prove_where_clauses_well_formed(
+                program, env, (&trait_where_clauses, &where_clauses), &where_clauses,
+            ) => ())
+            // FIXME(#228): Do we prove ensures WF? And what do we assume when we do so?
+            ------------------------------------------------------------ ("check associated ty")
+            (check_associated_ty(program, env, trait_where_clauses, associated_ty) => ())
         )
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -305,3 +305,25 @@ fn impl_with_default_fn_body_ok() {
         ]
     );
 }
+
+    crate::assert_ok!(
+        [
+            crate core {
+                trait A {
+                    fn a() -> ();
+                }
+            }
+        ]
+    );
+}
+
+    crate::assert_ok!(
+        [
+            crate core {
+                trait A {
+                    type Assoc : [];
+                }
+            }
+        ]
+    );
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -305,25 +305,3 @@ fn impl_with_default_fn_body_ok() {
         ]
     );
 }
-
-    crate::assert_ok!(
-        [
-            crate core {
-                trait A {
-                    fn a() -> ();
-                }
-            }
-        ]
-    );
-}
-
-    crate::assert_ok!(
-        [
-            crate core {
-                trait A {
-                    type Assoc : [];
-                }
-            }
-        ]
-    );
-}

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -25,13 +25,13 @@ fn trait_with_valid_associated_type() {
 }
 
 #[test]
+#[ignore = "ensures bounds WF check not yet implemented, see FIXME(#228)"]
 fn trait_with_ill_formed_where_clause() {
     a_mir_formality::assert_err!(
         [
             crate core {
                 trait A<T> where T: B {}
                 trait B {}
-
                 trait C {
                     type Assoc : [ A<u32> ];
                 }

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -31,14 +31,13 @@ fn trait_with_ill_formed_where_clause() {
             crate core {
                 trait A<T> where T: B {}
                 trait B {}
-                trait WellFormed where for<T> u32: A<T> {}
+
+                trait C {
+                    type Assoc : [ A<u32> ];
+                }
             }
         ]
         expect_test::expect![[r#"
-            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: @ WellFormedTraitRef(A(u32, !ty_1)), via: A(u32, ?ty_2), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: false } }
-
-            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: B(!ty_0), via: A(u32, ?ty_1), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0, ?ty_1], bias: Soundness, pending: [], allow_pending_outlives: false } }
-
             the rule "trait implied bound" at (prove_wc.rs) failed because
               expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
     );

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -23,3 +23,23 @@ fn trait_with_valid_associated_type() {
         ]
     );
 }
+
+#[test]
+fn trait_with_ill_formed_where_clause() {
+    a_mir_formality::assert_err!(
+        [
+            crate core {
+                trait A<T> where T: B {}
+                trait B {}
+                trait WellFormed where for<T> u32: A<T> {}
+            }
+        ]
+        expect_test::expect![[r#"
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: @ WellFormedTraitRef(A(u32, !ty_1)), via: A(u32, ?ty_2), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: false } }
+
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: B(!ty_0), via: A(u32, ?ty_1), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0, ?ty_1], bias: Soundness, pending: [], allow_pending_outlives: false } }
+
+            the rule "trait implied bound" at (prove_wc.rs) failed because
+              expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
+    );
+}

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -1,0 +1,25 @@
+#[test]
+fn trait_with_valid_fn() {
+    a_mir_formality::assert_ok!(
+        [
+            crate core {
+                trait A {
+                    fn a() -> ();
+                }
+            }
+        ]
+    );
+}
+
+#[test]
+fn trait_with_valid_associated_type() {
+    a_mir_formality::assert_ok!(
+        [
+            crate core {
+                trait A {
+                    type Assoc : [];
+                }
+            }
+        ]
+    );
+}


### PR DESCRIPTION
Hello @nikomatsakis , so like what i did was  added  check_trait_item, check_fn_in_trait, and check_associated_ty, and hooked them back into check_trait. Also restored the loop so all trait items are properly validated again. Does this look okay .