### PR TITLE
Flatten Ty, Lt, Const Arc wrappers into enums, moving Arc to use sites in Parameter

### DIFF
--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -1020,7 +1020,7 @@ judgment_fn! {
                 // If `'0: T` then `'0` must hold for entire fn body...
                 Parameter::Ty(_) => false,
 
-                Parameter::Lt(lt) => match &**lt {
+                Parameter::Lt(lt) => match lt.as_ref() {
                     // If `'0: 'static` then `'0` must hold for entire fn body...
                     Lt::Static => false,
 

--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -759,13 +759,13 @@ judgment_fn! {
         debug(env, assumptions, state, place)
 
         (
-            (if let TyData::RigidTy(RigidTy { name: RigidName::ScalarId(_), .. }) = place.ty.data())
+            (if let Ty::RigidTy(RigidTy { name: RigidName::ScalarId(_), .. }) = &place.ty)
             ------------------------------------------------------------ ("scalar-copy")
             (access_kind_for_place_use(_env, _assumptions, state, _place) => (AccessKind::Read, state))
         )
 
         (
-            (if let TyData::RigidTy(RigidTy { name: RigidName::Ref(RefKind::Shared), .. }) = place.ty.data())
+            (if let Ty::RigidTy(RigidTy { name: RigidName::Ref(RefKind::Shared), .. }) = &place.ty)
             ------------------------------------------------------------ ("shared-ref-copy")
             (access_kind_for_place_use(_env, _assumptions, state, _place) => (AccessKind::Read, state))
         )

--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -7,8 +7,8 @@ use crate::check::borrow_check::typed_place_expression::{
 
 use crate::grammar::expr::{Block, Expr, ExprData, Init, PlaceExpr, PlaceExprData, Stmt};
 use crate::grammar::{
-    AliasTy, FieldName, Fn, Lt, Parameter, RefKind, Relation, RigidName, RigidTy, ScalarId,
-    Struct, StructBoundData, Ty, TyData, ValueId, Variable, Wcs, WhereClause,
+    AliasTy, FieldName, Fn, Lt, Parameter, RefKind, Relation, RigidName, RigidTy, ScalarId, Struct,
+    StructBoundData, Ty, TyData, ValueId, Variable, Wcs, WhereClause,
 };
 use crate::grammar::{FnBoundData, PredicateTy};
 use crate::prove::prove::Safety;

--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -7,7 +7,7 @@ use crate::check::borrow_check::typed_place_expression::{
 
 use crate::grammar::expr::{Block, Expr, ExprData, Init, PlaceExpr, PlaceExprData, Stmt};
 use crate::grammar::{
-    AliasTy, FieldName, Fn, Lt, LtData, Parameter, RefKind, Relation, RigidName, RigidTy, ScalarId,
+    AliasTy, FieldName, Fn, Lt, Parameter, RefKind, Relation, RigidName, RigidTy, ScalarId,
     Struct, StructBoundData, Ty, TyData, ValueId, Variable, Wcs, WhereClause,
 };
 use crate::grammar::{FnBoundData, PredicateTy};
@@ -1020,17 +1020,17 @@ judgment_fn! {
                 // If `'0: T` then `'0` must hold for entire fn body...
                 Parameter::Ty(_) => false,
 
-                Parameter::Lt(lt) => match lt.data() {
+                Parameter::Lt(lt) => match &**lt {
                     // If `'0: 'static` then `'0` must hold for entire fn body...
-                    LtData::Static => false,
+                    Lt::Static => false,
 
                     // If `'0: 'a` for some lifetime parameter `'a`, then `'0` must hold for entire fn body...
-                    LtData::Variable(Variable::UniversalVar(_)) => false,
+                    Lt::Variable(Variable::UniversalVar(_)) => false,
 
                     // If `'0: '1`, that's fine.
-                    LtData::Variable(Variable::ExistentialVar(_)) => true,
+                    Lt::Variable(Variable::ExistentialVar(_)) => true,
 
-                    LtData::Variable(Variable::BoundVar(_)) => panic!("cannot outlive a bound var"),
+                    Lt::Variable(Variable::BoundVar(_)) => panic!("cannot outlive a bound var"),
                 },
 
                 // Not really clear what this would mean

--- a/crates/formality-rust/src/grammar/consts.rs
+++ b/crates/formality-rust/src/grammar/consts.rs
@@ -2,36 +2,10 @@ use crate::grammar::expr::Block;
 use crate::grammar::{ParameterKind, Parameters, RigidName, ScalarId};
 
 use super::{Parameter, Variable};
-use formality_core::{cast_impl, term, DowncastTo, Upcast, UpcastFrom};
-use std::sync::Arc;
+use formality_core::{cast_impl, term};
 
 #[term]
-#[cast]
-#[customize(constructors)] // FIXME(#219): figure out upcasts with arc or special-case
-pub struct Const {
-    data: Arc<ConstData>,
-}
-impl Const {
-    pub fn data(&self) -> &ConstData {
-        &self.data
-    }
-
-    pub fn new(data: impl Upcast<ConstData>) -> Self {
-        Self {
-            data: Arc::new(data.upcast()),
-        }
-    }
-
-    pub fn as_variable(&self) -> Option<Variable> {
-        match self.data() {
-            ConstData::Variable(v) => Some(v.clone()),
-            _ => None,
-        }
-    }
-}
-
-#[term]
-pub enum ConstData {
+pub enum Const {
     // Sort of equivalent to `ValTreeKind::Branch`
     #[cast]
     RigidValue(RigidConstData),
@@ -48,6 +22,9 @@ pub enum ConstData {
     #[variable(ParameterKind::Const)]
     Variable(Variable),
 }
+
+/// Temporary alias for migration.
+pub type ConstData = Const;
 
 #[term]
 pub enum ScalarValue {
@@ -100,19 +77,5 @@ pub struct RigidConstData {
     pub values: Vec<Const>,
 }
 
-impl DowncastTo<ConstData> for Const {
-    fn downcast_to(&self) -> Option<ConstData> {
-        Some(self.data().clone())
-    }
-}
-
-impl UpcastFrom<ConstData> for Const {
-    fn upcast_from(term: ConstData) -> Self {
-        Const {
-            data: Arc::new(term),
-        }
-    }
-}
-
-cast_impl!((ConstData) <: (Const) <: (Parameter));
-cast_impl!((ScalarValue) <: (ConstData) <: (Const));
+cast_impl!((ScalarValue) <: (Const) <: (Parameter));
+cast_impl!((RigidConstData) <: (Const) <: (Parameter));

--- a/crates/formality-rust/src/grammar/expr/codegen.rs
+++ b/crates/formality-rust/src/grammar/expr/codegen.rs
@@ -158,8 +158,8 @@ impl ExprBuilder<'_> {
     }
 
     fn minirust_ty(&mut self, ty: &Ty) -> Fallible<lang::Type> {
-        match ty.data() {
-            TyData::RigidTy(rigid_ty) => match &rigid_ty.name {
+        match ty {
+            Ty::RigidTy(rigid_ty) => match &rigid_ty.name {
                 RigidName::AdtId(adt_id) => {
                     unimplemented!("adts")
                 }

--- a/crates/formality-rust/src/grammar/kinded.rs
+++ b/crates/formality-rust/src/grammar/kinded.rs
@@ -1,6 +1,6 @@
 use formality_core::Upcast;
 
-use super::{BoundVar, Lt, LtData, ParameterKind, Ty, TyData};
+use super::{BoundVar, Lt, ParameterKind, Ty};
 
 /// Trait implemented by the various kinds of generic parameters.
 /// Used in some of the fluent APIs for creating binders to select
@@ -12,14 +12,14 @@ pub trait Kinded {
 impl Kinded for Ty {
     fn instantiate() -> (Vec<BoundVar>, Self) {
         let bvar = BoundVar::fresh(ParameterKind::Ty);
-        (vec![bvar], TyData::Variable(bvar.upcast()).upcast())
+        (vec![bvar], Ty::Variable(bvar.upcast()))
     }
 }
 
 impl Kinded for Lt {
     fn instantiate() -> (Vec<BoundVar>, Self) {
         let bvar = BoundVar::fresh(ParameterKind::Lt);
-        (vec![bvar], LtData::Variable(bvar.upcast()).upcast())
+        (vec![bvar], Lt::Variable(bvar.upcast()))
     }
 }
 

--- a/crates/formality-rust/src/grammar/ty.rs
+++ b/crates/formality-rust/src/grammar/ty.rs
@@ -32,7 +32,7 @@ impl Ty {
     }
 
     pub fn to_parameter(&self) -> Parameter {
-        Parameter::Ty(Arc::new(self.clone()))
+        self.clone().upcast()
     }
 
     pub fn rigid(name: impl Upcast<RigidName>, parameters: impl Upcast<Vec<Parameter>>) -> Self {
@@ -344,51 +344,10 @@ impl DowncastTo<Variable> for Parameter {
     }
 }
 
-// Manual Ty/Lt/Const <-> Parameter casts (since Parameter holds Arc<Ty> etc.)
-impl UpcastFrom<Ty> for Parameter {
-    fn upcast_from(v: Ty) -> Self {
-        Parameter::Ty(Arc::new(v))
-    }
-}
-
-impl DowncastTo<Ty> for Parameter {
-    fn downcast_to(&self) -> Option<Ty> {
-        match self {
-            Parameter::Ty(v) => Some((**v).clone()),
-            _ => None,
-        }
-    }
-}
-
-impl UpcastFrom<Lt> for Parameter {
-    fn upcast_from(v: Lt) -> Self {
-        Parameter::Lt(Arc::new(v))
-    }
-}
-
-impl DowncastTo<Lt> for Parameter {
-    fn downcast_to(&self) -> Option<Lt> {
-        match self {
-            Parameter::Lt(v) => Some((**v).clone()),
-            _ => None,
-        }
-    }
-}
-
-impl UpcastFrom<Const> for Parameter {
-    fn upcast_from(v: Const) -> Self {
-        Parameter::Const(Arc::new(v))
-    }
-}
-
-impl DowncastTo<Const> for Parameter {
-    fn downcast_to(&self) -> Option<Const> {
-        match self {
-            Parameter::Const(v) => Some((**v).clone()),
-            _ => None,
-        }
-    }
-}
+// Ty/Lt/Const <-> Parameter casts via the Arc<T> <-> T impls provided by #[term]
+cast_impl!((Ty) <: (Arc<Ty>) <: (Parameter));
+cast_impl!((Lt) <: (Arc<Lt>) <: (Parameter));
+cast_impl!((Const) <: (Arc<Const>) <: (Parameter));
 
 // Transitive casts
 cast_impl!((RigidTy) <: (Ty) <: (Parameter));

--- a/crates/formality-rust/src/grammar/ty.rs
+++ b/crates/formality-rust/src/grammar/ty.rs
@@ -12,36 +12,27 @@ use super::{
 };
 
 #[term]
-#[cast]
-#[customize(constructors)] // FIXME(#219): figure out upcasts with arc or special-case
-pub struct Ty {
-    data: Arc<TyData>,
+pub enum Ty {
+    #[cast]
+    RigidTy(RigidTy),
+    #[cast]
+    AliasTy(AliasTy),
+    #[cast]
+    PredicateTy(PredicateTy),
+    #[variable(ParameterKind::Ty)]
+    Variable(Variable),
 }
 
+/// Temporary alias for migration -- allows `TyData::Variant` to still compile.
+pub type TyData = Ty;
+
 impl Ty {
-    pub fn new(data: impl Upcast<TyData>) -> Self {
-        Ty {
-            data: Arc::new(data.upcast()),
-        }
-    }
-
-    pub fn data(&self) -> &TyData {
-        &self.data
-    }
-
     pub fn never() -> Self {
         RigidTy::new(RigidName::Never, ()).upcast()
     }
 
     pub fn to_parameter(&self) -> Parameter {
-        Parameter::Ty(self.clone())
-    }
-
-    pub fn as_variable(&self) -> Option<Variable> {
-        match self.data() {
-            TyData::Variable(v) => Some(*v),
-            _ => None,
-        }
+        Parameter::Ty(Arc::new(self.clone()))
     }
 
     pub fn rigid(name: impl Upcast<RigidName>, parameters: impl Upcast<Vec<Parameter>>) -> Self {
@@ -90,7 +81,7 @@ impl Ty {
     }
 
     pub fn get_adt_id(&self) -> Option<AdtId> {
-        if let TyData::RigidTy(rigid_ty) = self.data() {
+        if let Ty::RigidTy(rigid_ty) = self {
             if let RigidName::AdtId(ref adt_id) = rigid_ty.name {
                 return Some(adt_id.clone());
             };
@@ -100,38 +91,6 @@ impl Ty {
 
     pub fn unit() -> Self {
         Ty::rigid(RigidName::Tuple(0), ())
-    }
-}
-
-impl UpcastFrom<TyData> for Ty {
-    fn upcast_from(v: TyData) -> Self {
-        Ty::new(v)
-    }
-}
-
-impl DowncastTo<TyData> for Ty {
-    fn downcast_to(&self) -> Option<TyData> {
-        Some(self.data().clone())
-    }
-}
-
-// NB: TyData doesn't implement Fold; you fold types, not TyData,
-// because variables might not map to the same variant.
-#[term]
-pub enum TyData {
-    #[cast]
-    RigidTy(RigidTy),
-    #[cast]
-    AliasTy(AliasTy),
-    #[cast]
-    PredicateTy(PredicateTy),
-    #[variable(ParameterKind::Ty)]
-    Variable(Variable),
-}
-
-impl UpcastFrom<Ty> for TyData {
-    fn upcast_from(term: Ty) -> Self {
-        term.data().clone()
     }
 }
 
@@ -295,17 +254,17 @@ pub struct AssociatedTyName {
 
 #[term]
 pub enum PredicateTy {
-    ForAll(Binder<Ty>),
+    ForAll(Binder<Arc<Ty>>),
 }
 
 #[term]
 pub enum Parameter {
     #[cast]
-    Ty(Ty),
+    Ty(Arc<Ty>),
     #[cast]
-    Lt(Lt),
+    Lt(Arc<Lt>),
     #[cast]
-    Const(Const),
+    Const(Arc<Const>),
 }
 
 impl Parameter {
@@ -323,9 +282,9 @@ impl Parameter {
 
     pub fn as_variable(&self) -> Option<Variable> {
         match self {
-            Parameter::Ty(v) => v.as_variable(),
-            Parameter::Lt(v) => v.as_variable(),
-            Parameter::Const(v) => v.as_variable(),
+            Parameter::Ty(v) => v.as_variable().copied(),
+            Parameter::Lt(v) => v.as_variable().copied(),
+            Parameter::Const(v) => v.as_variable().copied(),
         }
     }
 }
@@ -352,49 +311,7 @@ pub enum Variance {
 }
 
 #[term]
-#[cast]
-#[customize(constructors)] // FIXME(#219): figure out upcasts with arc or special-case
-pub struct Lt {
-    data: Arc<LtData>,
-}
-
-impl Lt {
-    pub fn new(data: impl Upcast<LtData>) -> Self {
-        Lt {
-            data: Arc::new(data.upcast()),
-        }
-    }
-
-    pub fn data(&self) -> &LtData {
-        &self.data
-    }
-
-    pub fn as_variable(&self) -> Option<Variable> {
-        match self.data() {
-            LtData::Variable(v) => Some(*v),
-            _ => None,
-        }
-    }
-
-    pub fn static_() -> Self {
-        LtData::Static.upcast()
-    }
-}
-
-impl UpcastFrom<LtData> for Lt {
-    fn upcast_from(v: LtData) -> Self {
-        Lt::new(v)
-    }
-}
-
-impl DowncastTo<LtData> for Lt {
-    fn downcast_to(&self) -> Option<LtData> {
-        Some(self.data().clone())
-    }
-}
-
-#[term]
-pub enum LtData {
+pub enum Lt {
     #[grammar('static)]
     Static,
 
@@ -402,12 +319,21 @@ pub enum LtData {
     Variable(Variable),
 }
 
+/// Temporary alias for migration.
+pub type LtData = Lt;
+
+impl Lt {
+    pub fn static_() -> Self {
+        Lt::Static
+    }
+}
+
 impl UpcastFrom<Variable> for Parameter {
     fn upcast_from(v: Variable) -> Parameter {
         match v.kind() {
-            ParameterKind::Lt => Lt::new(v).upcast(),
-            ParameterKind::Ty => Ty::new(v).upcast(),
-            ParameterKind::Const => Const::new(v).upcast(),
+            ParameterKind::Lt => Lt::Variable(v.upcast()).upcast(),
+            ParameterKind::Ty => Ty::Variable(v.upcast()).upcast(),
+            ParameterKind::Const => Const::Variable(v.upcast()).upcast(),
         }
     }
 }
@@ -418,30 +344,66 @@ impl DowncastTo<Variable> for Parameter {
     }
 }
 
-cast_impl!((RigidTy) <: (TyData) <: (Ty));
-cast_impl!((AliasTy) <: (TyData) <: (Ty));
-cast_impl!((ScalarId) <: (TyData) <: (Ty));
-cast_impl!((PredicateTy) <: (TyData) <: (Ty));
+// Manual Ty/Lt/Const <-> Parameter casts (since Parameter holds Arc<Ty> etc.)
+impl UpcastFrom<Ty> for Parameter {
+    fn upcast_from(v: Ty) -> Self {
+        Parameter::Ty(Arc::new(v))
+    }
+}
+
+impl DowncastTo<Ty> for Parameter {
+    fn downcast_to(&self) -> Option<Ty> {
+        match self {
+            Parameter::Ty(v) => Some((**v).clone()),
+            _ => None,
+        }
+    }
+}
+
+impl UpcastFrom<Lt> for Parameter {
+    fn upcast_from(v: Lt) -> Self {
+        Parameter::Lt(Arc::new(v))
+    }
+}
+
+impl DowncastTo<Lt> for Parameter {
+    fn downcast_to(&self) -> Option<Lt> {
+        match self {
+            Parameter::Lt(v) => Some((**v).clone()),
+            _ => None,
+        }
+    }
+}
+
+impl UpcastFrom<Const> for Parameter {
+    fn upcast_from(v: Const) -> Self {
+        Parameter::Const(Arc::new(v))
+    }
+}
+
+impl DowncastTo<Const> for Parameter {
+    fn downcast_to(&self) -> Option<Const> {
+        match self {
+            Parameter::Const(v) => Some((**v).clone()),
+            _ => None,
+        }
+    }
+}
+
+// Transitive casts
 cast_impl!((RigidTy) <: (Ty) <: (Parameter));
 cast_impl!((AliasTy) <: (Ty) <: (Parameter));
 cast_impl!((ScalarId) <: (Ty) <: (Parameter));
 cast_impl!((PredicateTy) <: (Ty) <: (Parameter));
-cast_impl!((TyData) <: (Ty) <: (Parameter));
-cast_impl!((Variable) <: (TyData) <: (Ty));
-cast_impl!((UniversalVar) <: (Variable) <: (TyData));
-cast_impl!((ExistentialVar) <: (Variable) <: (TyData));
-cast_impl!((BoundVar) <: (Variable) <: (TyData));
-cast_impl!((ScalarId) <: (RigidTy) <: (TyData));
+cast_impl!((ScalarId) <: (RigidTy) <: (Ty));
+// Variable -> Ty/Lt transitive casts
 cast_impl!((UniversalVar) <: (Variable) <: (Ty));
 cast_impl!((ExistentialVar) <: (Variable) <: (Ty));
 cast_impl!((BoundVar) <: (Variable) <: (Ty));
+cast_impl!((UniversalVar) <: (Variable) <: (Lt));
+cast_impl!((ExistentialVar) <: (Variable) <: (Lt));
+cast_impl!((BoundVar) <: (Variable) <: (Lt));
+// Variable -> Parameter transitive casts
 cast_impl!((UniversalVar) <: (Variable) <: (Parameter));
 cast_impl!((ExistentialVar) <: (Variable) <: (Parameter));
 cast_impl!((BoundVar) <: (Variable) <: (Parameter));
-cast_impl!((ExistentialVar) <: (Variable) <: (LtData));
-cast_impl!((UniversalVar) <: (Variable) <: (LtData));
-cast_impl!((BoundVar) <: (Variable) <: (LtData));
-cast_impl!((UniversalVar) <: (LtData) <: (Lt));
-cast_impl!((ExistentialVar) <: (LtData) <: (Lt));
-cast_impl!((BoundVar) <: (LtData) <: (Lt));
-cast_impl!((LtData) <: (Lt) <: (Parameter));

--- a/crates/formality-rust/src/prove/prove/test/expanding.rs
+++ b/crates/formality-rust/src/prove/prove/test/expanding.rs
@@ -20,5 +20,5 @@ fn decls() -> Program {
 /// There is no U that is equal to all T.
 #[test]
 fn expanding() {
-    test_prove(decls(), term("exists<T> {} => {Debug(T)}")).assert_ok(expect!["{Constraints { env: Env { variables: [?ty_0], bias: Soundness, pending: [], allow_pending_outlives: false }, known_true: false, substitution: {} }}"]);
+    test_prove(decls(), term("exists<T> {} => {Debug(T)}")).assert_ok(expect!["{Constraints { env: Env { variables: [?ty_1], bias: Soundness, pending: [], allow_pending_outlives: false }, known_true: false, substitution: {} }}"]);
 }

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -34,18 +34,14 @@ fn test_parse_rust_like_trait_impl_syntax() {
                                     ],
                                     term: TraitImplBoundData {
                                         trait_id: PartialEq,
-                                        self_ty: Ty {
-                                            data: Variable(
-                                                ^ty0_1,
-                                            ),
-                                        },
+                                        self_ty: Variable(
+                                            ^ty0_1,
+                                        ),
                                         trait_parameters: [
                                             Ty(
-                                                Ty {
-                                                    data: Variable(
-                                                        ^ty0_0,
-                                                    ),
-                                                },
+                                                Variable(
+                                                    ^ty0_0,
+                                                ),
                                             ),
                                         ],
                                         where_clauses: [],
@@ -129,11 +125,9 @@ fn test_parse_rust_like_struct_syntax() {
                                                     name: Id(
                                                         a,
                                                     ),
-                                                    ty: Ty {
-                                                        data: Variable(
-                                                            ^ty0_0,
-                                                        ),
-                                                    },
+                                                    ty: Variable(
+                                                        ^ty0_0,
+                                                    ),
                                                 },
                                             ],
                                         },
@@ -173,11 +167,9 @@ fn test_parse_trusted_fn() {
                                     kinds: [],
                                     term: FnBoundData {
                                         input_args: [],
-                                        output_ty: Ty {
-                                            data: RigidTy(
-                                                (),
-                                            ),
-                                        },
+                                        output_ty: RigidTy(
+                                            (),
+                                        ),
                                         where_clauses: [],
                                         body: FnBody(
                                             TrustedFnBody,


### PR DESCRIPTION
## What does this PR do?

Experiment for #318: Flattens `Ty`/`TyData`, `Lt`/`LtData`, `Const`/`ConstData` Arc-wrapper structs into direct enums, moving `Arc` to use sites in `Parameter` (i.e., `Parameter::Ty(Arc<Ty>)` instead of wrapping Arc inside each type).

This is the first PR in a series, starting with the core types to validate the approach before tackling the rest:

- [x] **PR 1 (this PR):** `Ty`, `Lt`, `Const`
- [ ] **PR 2:** `Wc`/`WcData` (recursive — `ForAll` and `Implies` variants need `Arc`)
- [ ] **PR 3:** `WhereClause`/`WhereClauseData`, `WhereBound`/`WhereBoundData`
- [ ] **PR 4:** `Expr`/`ExprData`, `PlaceExpr`/`PlaceExprData` (heaviest blast radius)

### Test plan
- [x] `cargo build` compiles cleanly (only pre-existing warnings)
- [x] `cargo test --all` — all 269 tests pass
- [x] `cargo fmt --all -- --check` passes

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* The AI tool authored large parts of the code

**Confidence level.**

* Early draft, want feedback

**Questions for reviewers.**

- Is the temporary `pub type TyData = Ty;` alias the right migration strategy, or should we do a full rename of all `TyData::` references to `Ty::` in this PR?
- For `PredicateTy::ForAll(Binder<Arc<Ty>>)`, is `Arc` the right indirection here, or would `Box` be more appropriate since it's not a shared reference?

</details>
