### PR TITLE
Reject moves of borrowed places

### DIFF
--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -433,7 +433,8 @@ judgment_fn! {
 
         (
             (borrow_check_place_expr(env, assumptions, state, place) => (place, state))
-            (access_permitted(env, assumptions, state, Access::new(AccessKind::Read, place), places_live_on_exit) => state)
+            (access_kind_for_place_use(env, assumptions, state, place) => (access_kind, state))
+            (access_permitted(env, assumptions, state, Access::new(access_kind, place), places_live_on_exit) => state)
             // FIXME(#296): also need to track that the place has been moved from
             (prove_place_is_movable(env, assumptions, state, place) => state)
             ------------------------------------------------------------ ("place")
@@ -741,6 +742,37 @@ judgment_fn! {
             (loan_cannot_outlive_universal_regions(env, assumptions, &state.current.outlives, &loan) => ())
             ------------------------------------------------------------ ("loan is dead")
             (access_permitted_by_loan(env, assumptions, state, loan, access, places_live_after_access) => state)
+        )
+    }
+}
+
+judgment_fn! {
+    /// Determine whether evaluating a place reads from it or moves from it.
+    /// Known Copy places behave like reads for loan checking everything else
+    /// is treated as a move so overlapping live loans can reject it.
+    fn access_kind_for_place_use(
+        env: TypeckEnv,
+        assumptions: Wcs,
+        state: FlowState,
+        place: TypedPlaceExpr,
+    ) => (AccessKind, FlowState) {
+        debug(env, assumptions, state, place)
+
+        (
+            (if let TyData::RigidTy(RigidTy { name: RigidName::ScalarId(_), .. }) = place.ty.data())
+            ------------------------------------------------------------ ("scalar-copy")
+            (access_kind_for_place_use(_env, _assumptions, state, _place) => (AccessKind::Read, state))
+        )
+
+        (
+            (if let TyData::RigidTy(RigidTy { name: RigidName::Ref(RefKind::Shared), .. }) = place.ty.data())
+            ------------------------------------------------------------ ("shared-ref-copy")
+            (access_kind_for_place_use(_env, _assumptions, state, _place) => (AccessKind::Read, state))
+        )
+
+        (
+            ------------------------------------------------------------ ("move")
+            (access_kind_for_place_use(_env, _assumptions, state, _place) => (AccessKind::Move, state))
         )
     }
 }

--- a/src/test/borrowck.rs
+++ b/src/test/borrowck.rs
@@ -483,7 +483,6 @@ fn move_out_of_mut_ref() {
 /// }
 /// ```
 #[test]
-#[ignore = "needs move-out-of-borrowed check (#298)"]
 fn move_out_of_borrowed_place() {
     crate::assert_err!(
         [
@@ -503,7 +502,16 @@ fn move_out_of_borrowed_place() {
             }
         ]
 
-        expect_test::expect![[""]]
+        expect_test::expect![[r#"
+            the rule "borrow of disjoint places" at (nll.rs) failed because
+              condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
+                &loan.place = x : Datum
+                &access.place = x : Datum
+
+            the rule "loan_cannot_outlive" at (nll.rs) failed because
+              condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+                outlived_by_loan = {?lt_1, ?lt_2}
+                &lifetime.upcast() = ?lt_1"#]]
     )
 }
 
@@ -1846,6 +1854,16 @@ fn struct_construction_with_borrowed_local() {
         }
     ]
     expect_test::expect![[r#"
+        the rule "borrow of disjoint places" at (nll.rs) failed because
+          condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
+            &loan.place = v1 : u32
+            &access.place = v1 : u32
+
+        the rule "loan_cannot_outlive" at (nll.rs) failed because
+          condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
+            outlived_by_loan = {?lt_1, ?lt_2}
+            &lifetime.upcast() = ?lt_1
+
         the rule "borrow of disjoint places" at (nll.rs) failed because
           condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
             &loan.place = v1 : u32


### PR DESCRIPTION
## What does this PR do?
This PR treat non-Copy place uses as moves for loan checking while keeping known Copy places as reads so overlapping live loans reject moves out of borrowed places as mentioned in https://github.com/rust-lang/a-mir-formality/issues/298

e.g., closes #298

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

 * No AI tools used .

**Confidence level.**
* It seems reasonable to me, I'd like to know what others think

**Questions for reviewers.** None


