### PR TITLE
formality-macros: Unpack groups until first non-trivial token sequence

### DIFF
--- a/crates/formality-macros/src/lib.rs
+++ b/crates/formality-macros/src/lib.rs
@@ -1,4 +1,4 @@
-use proc_macro::{Span, TokenStream};
+use proc_macro::TokenStream;
 use quote::quote;
 use spec::FormalitySpec;
 // use syn::DeriveInput;
@@ -63,22 +63,36 @@ pub fn test(args: TokenStream, input: TokenStream) -> TokenStream {
 
 /// Invoked like `respan!(X (Y...))` -- produces `Y...` with span from `X`.
 #[proc_macro]
-pub fn respan(t: TokenStream) -> TokenStream {
-    let mut t = t.into_iter();
-    let dummy = t.next().unwrap();
-    let stream = t.next().unwrap();
+pub fn respan(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    respan_impl(stream.into()).into()
+}
+
+fn respan_impl(mut stream: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    let (dummy, stream) = loop {
+        let mut t = stream.into_iter();
+        let dummy = t.next().unwrap();
+        match dummy {
+            proc_macro2::TokenTree::Group(ref g) => {
+                if let Some(rest) = t.next() {
+                    break (dummy, rest);
+                }
+                stream = g.stream();
+            }
+            _ => break (dummy, t.next().expect("rest")),
+        }
+    };
     return match stream {
-        proc_macro::TokenTree::Group(g) => set_span(pick_span(dummy), g.stream()),
+        proc_macro2::TokenTree::Group(g) => set_span(pick_span(dummy), g.stream()),
         _ => unreachable!(),
     };
 
-    fn pick_span(dummy: proc_macro::TokenTree) -> Span {
+    fn pick_span(dummy: proc_macro2::TokenTree) -> proc_macro2::Span {
         match dummy {
             // Careful! The compiler creates groups for fragments
             // (e.g., $x:expr) that have the span of the macro that parsed them.
             // We want the span of the fragment's contents in that case.
-            proc_macro::TokenTree::Group(g)
-                if g.delimiter() == proc_macro::Delimiter::None && !g.stream().is_empty() =>
+            proc_macro2::TokenTree::Group(g)
+                if g.delimiter() == proc_macro2::Delimiter::None && !g.stream().is_empty() =>
             {
                 g.stream().into_iter().next().unwrap().span()
             }
@@ -86,15 +100,18 @@ pub fn respan(t: TokenStream) -> TokenStream {
         }
     }
 
-    fn set_span(span: Span, tokens: TokenStream) -> TokenStream {
+    fn set_span(
+        span: proc_macro2::Span,
+        tokens: proc_macro2::TokenStream,
+    ) -> proc_macro2::TokenStream {
         tokens
             .into_iter()
             .map(|token| match token {
-                proc_macro::TokenTree::Group(group) => {
+                proc_macro2::TokenTree::Group(group) => {
                     let mut fixed =
-                        proc_macro::Group::new(group.delimiter(), set_span(span, group.stream()));
+                        proc_macro2::Group::new(group.delimiter(), set_span(span, group.stream()));
                     fixed.set_span(span);
-                    proc_macro::TokenTree::Group(fixed)
+                    proc_macro2::TokenTree::Group(fixed)
                 }
                 mut token => {
                     token.set_span(span);
@@ -102,5 +119,38 @@ pub fn respan(t: TokenStream) -> TokenStream {
                 }
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::respan_impl;
+    use quote::quote;
+
+    #[test]
+    fn test_respan_unpacking() {
+        let input = quote! { X (a + b) };
+        let output = respan_impl(input);
+        assert_eq!(output.to_string(), "a + b");
+
+        let input_wrapped = quote! { (X (a + b)) };
+        let output_wrapped = respan_impl(input_wrapped);
+        assert_eq!(output_wrapped.to_string(), "a + b");
+    }
+
+    #[test]
+    fn test_respan_span_manipulation() {
+        let input = quote! { X (a) };
+        let mut t = input.clone().into_iter();
+        let dummy = t.next().unwrap();
+        let dummy_span = dummy.span();
+
+        let output = respan_impl(input);
+        let mut out_t = output.into_iter();
+        let a = out_t.next().unwrap();
+        let a_span = a.span();
+
+        // Verify that the span of `a` has been updated to match `X`.
+        assert_eq!(format!("{:?}", a_span), format!("{:?}", dummy_span));
     }
 }


### PR DESCRIPTION
This is originally a fix on rust-analyzer incorrectly leaving the surrounding brackets, causing macro panics, but I figured that this is a good syntactical extension anyway.

## What does this PR do?

*No issue number yet*

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

<!-- The use of AI tooling for a-mir-formality is permitted. We require disclosure to help calibrate our reviews. -->

<!-- Remove the items that do not apply. -->

* I used an AI tool for research, autocomplete, or in other minimal ways agent

**Confidence level.**

<!-- Remove the items that do not apply. -->

* I am very happy with it

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
