### PR TITLE
docs: add formality_rust section

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -11,3 +11,6 @@
   - [Collections](./formality_core/collections.md)
   - [Judgment functions and inference rules](./formality_core/judgment_fn.md)
   - [FAQ and troubleshooting](./formality_core/faq.md)
+- [`formality_rust`: the Rust model](./formality_rust.md)
+  - [Borrow checking](./formality_rust/borrow_check.md)
+  - [Coherence checking](./formality_rust/coherence.md)

--- a/book/src/formality_rust.md
+++ b/book/src/formality_rust.md
@@ -1,0 +1,36 @@
+# `formality_rust`: the Rust model
+
+`formality_rust` is the Rust-specific layer of a-mir-formality. It is organized into three main subsystems:
+
+* `grammar/` defines Rust-specific terms
+* `check/` runs semantic checking
+* `prove/` discharges logical obligations
+
+## `grammar/`
+
+The `grammar` module defines the Rust terms used by the model: crates, items, types, where-clauses, trait references, and the MIR-like expression language used in function bodies.
+
+## `check/`
+
+The main checking entry point is `check_all_crates`.
+
+* inserts an empty `core` crate if the first crate is not `core`
+* checks every prefix of the crate list
+* treats the last crate in each prefix as the current crate
+
+Within a crate, checking rejects duplicate item names, checks each crate item, and then runs coherence checking.
+
+## `prove/`
+
+The `prove` module answers Rust-specific goals such as where-clauses, equality, subtyping, and outlives. Checking code calls into `prove` whenever it needs to establish those facts.
+
+## Pipeline
+
+At a high level, checking a Rust program looks like this:
+
+```text
+Crates
+  -> check_all_crates
+  -> item checking / borrow checking
+  -> prove obligations as needed
+```

--- a/book/src/formality_rust/borrow_check.md
+++ b/book/src/formality_rust/borrow_check.md
@@ -1,0 +1,53 @@
+# Borrow checking
+
+Borrow checking lives under `check/borrow_check/`. Its top-level judgment is `borrow_check`, which checks that the loans issued while executing a basic block are respected.
+
+## `borrow_check`
+
+At the top level, borrow checking works over:
+
+* a `TypeckEnv`
+* a set of assumptions
+* a `FlowState`
+* a `Block`
+
+`borrow_check` delegates to `borrow_check_block`, which walks the block and updates the flow state statement by statement.
+
+## `FlowState`
+
+`FlowState` is the flow-sensitive state threaded through borrow checking. It contains:
+
+* `scopes`
+* `current`
+* `breaks`
+* `continues`
+
+Its `current` field is a `PointFlowState`, which tracks:
+
+* `loans_live`
+* `outlives`
+
+## Loans
+
+A `Loan` represents a borrow produced by an expression like `&'a place`. It records:
+
+* the lifetime of the borrow
+* the borrowed place
+* the borrow kind
+
+Borrow checking adds loans to the current flow state and checks later accesses against the live loans.
+
+## Liveness
+
+The borrow checker computes liveness with `LivePlaces` and the `LiveBefore` trait.
+
+This is used to determine which places must be valid before a statement or expression, including at `break` and `continue` targets.
+
+## Outlives
+
+Borrow checking also accumulates pending outlives constraints, represented as `PendingOutlives { a, b }`.
+
+The `outlives.rs` code verifies these constraints:
+
+* existential variables succeed trivially
+* universal variables must be justified by the assumptions

--- a/book/src/formality_rust/coherence.md
+++ b/book/src/formality_rust/coherence.md
@@ -1,0 +1,28 @@
+# Coherence checking
+
+Coherence checking lives in `check/coherence.rs` and runs as part of crate checking.
+
+At a high level, `check_coherence`:
+
+* rejects duplicate impls in the current crate
+* checks the current crate's impls for overlap against all impls in the program
+* runs orphan checking for positive impls in the current crate
+* runs orphan checking for negative impls in the current crate
+
+## Orphan checking
+
+`orphan_check` and `orphan_check_neg` instantiate the impl binder universally and prove that the trait reference is local under the impl's where-clauses.
+
+## Duplicate impls
+
+`ensure_no_duplicate_impls` rejects duplicate positive impls in the current crate before overlap checking runs.
+
+## Overlap checking
+
+`overlap_check_impl` compares two impls of the same trait.
+
+It first skips identical impls and impls for different traits. For matching trait ids, it tries to prove that the impls cannot both apply. If that fails, it reports the impls as overlapping.
+
+## Negative impls
+
+Negative impls participate in coherence through orphan checking.


### PR DESCRIPTION
## What does this PR do?
This PR add a section in docs for formality_rust  which includes borrow_check and coherence as its sub sections.



<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

<!-- The use of AI tooling for a-mir-formality is permitted. We require disclosure to help calibrate our reviews. -->

<!-- Remove the items that do not apply. -->

No AI tools used .
 
**Confidence level.**

<!-- Remove the items that do not apply. -->

* It seems reasonable to me, I'd like to know what others think

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->
None

</details>
