### PR TITLE
grammar: resolve PlaceExpr ambiguity with precedence levels

### DIFF
--- a/crates/formality-rust/src/grammar/expr/mod.rs
+++ b/crates/formality-rust/src/grammar/expr/mod.rs
@@ -266,6 +266,7 @@ pub enum PlaceExprData {
     #[precedence(10)]
     // == PR #331 -END =====
     #[grammar($prefix . $field_name)]
+    #[reject(PlaceExprData::Deref { .. }, _)]
     Field {
         prefix: PlaceExpr,
         field_name: FieldName,

--- a/crates/formality-rust/src/grammar/expr/mod.rs
+++ b/crates/formality-rust/src/grammar/expr/mod.rs
@@ -241,8 +241,13 @@ pub enum PlaceExprData {
     /// `* expr`
     ///
     /// Dereference. Like `Var`, place vs value depends on context.
+    // ==== Related to PR #331 - START ==
+    // Config A (Inverted): #[precedence(10)]
+    // Config B (Standard): #[precedence(1)]  <-- CURRENTLY ACTIVE
+    // Config C (Extreme):  #[precedence(1)]
+    #[precedence(1)]
+    /// == PR #331 -END =====
     #[grammar(* $prefix)]
-    #[precedence(1, left)]
     Deref { prefix: PlaceExpr },
 
     /// `( expr )`
@@ -254,8 +259,13 @@ pub enum PlaceExprData {
     /// `expr . field`
     ///
     /// Field projection. Like `Var`, place vs value depends on context.
+    // ==== Related to PR #331 - START ==
+    // Config A (Inverted): #[precedence(1)]
+    // Config B (Standard): #[precedence(2)]  <-- CURRENTLY ACTIVE
+    // Config C (Extreme):  #[precedence(10)]
+    #[precedence(10)]
+    // == PR #331 -END =====
     #[grammar($prefix . $field_name)]
-    #[precedence(2, left)]
     Field {
         prefix: PlaceExpr,
         field_name: FieldName,

--- a/crates/formality-rust/src/grammar/expr/mod.rs
+++ b/crates/formality-rust/src/grammar/expr/mod.rs
@@ -242,6 +242,7 @@ pub enum PlaceExprData {
     ///
     /// Dereference. Like `Var`, place vs value depends on context.
     #[grammar(* $prefix)]
+    #[precedence(1, left)]
     Deref { prefix: PlaceExpr },
 
     /// `( expr )`
@@ -254,6 +255,7 @@ pub enum PlaceExprData {
     ///
     /// Field projection. Like `Var`, place vs value depends on context.
     #[grammar($prefix . $field_name)]
+    #[precedence(2, left)]
     Field {
         prefix: PlaceExpr,
         field_name: FieldName,

--- a/crates/formality-rust/src/grammar/expr/mod.rs
+++ b/crates/formality-rust/src/grammar/expr/mod.rs
@@ -241,12 +241,6 @@ pub enum PlaceExprData {
     /// `* expr`
     ///
     /// Dereference. Like `Var`, place vs value depends on context.
-    // ==== Related to PR #331 - START ==
-    // Config A (Inverted): #[precedence(10)]
-    // Config B (Standard): #[precedence(1)]  <-- CURRENTLY ACTIVE
-    // Config C (Extreme):  #[precedence(1)]
-    #[precedence(1)]
-    /// == PR #331 -END =====
     #[grammar(* $prefix)]
     Deref { prefix: PlaceExpr },
 
@@ -259,12 +253,6 @@ pub enum PlaceExprData {
     /// `expr . field`
     ///
     /// Field projection. Like `Var`, place vs value depends on context.
-    // ==== Related to PR #331 - START ==
-    // Config A (Inverted): #[precedence(1)]
-    // Config B (Standard): #[precedence(2)]  <-- CURRENTLY ACTIVE
-    // Config C (Extreme):  #[precedence(10)]
-    #[precedence(10)]
-    // == PR #331 -END =====
     #[grammar($prefix . $field_name)]
     #[reject(PlaceExprData::Deref { .. }, _)]
     Field {

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -189,6 +189,7 @@ fn test_parse_trusted_fn() {
 
 // 1. THE FAILING TEST (Demonstrates the bug)
 #[test]
+#[ignore]
 fn test_place_expr_ambiguity_deref_vs_field() {
     // BUG: Under Config B (Deref=1, Field=2), this panics with an ambiguity error.
     // It should parse as Deref( Field(p, f) ) because field binds tighter.
@@ -260,6 +261,7 @@ fn test_place_expr_field_left_associativity() {
 
 // 4. THE CHAIN TEST (Proves the bug cascades)
 #[test]
+#[ignore]
 fn test_place_expr_deref_with_field_chain() {
     // This will also panic under Config B, as it inherits the *p.f ambiguity.
     // It should parse as Deref( Field( Field(p, f), g ) )

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -189,7 +189,6 @@ fn test_parse_trusted_fn() {
 
 // 1. THE FAILING TEST (Demonstrates the bug)
 #[test]
-#[ignore]
 fn test_place_expr_ambiguity_deref_vs_field() {
     // BUG: Under Config B (Deref=1, Field=2), this panics with an ambiguity error.
     // It should parse as Deref( Field(p, f) ) because field binds tighter.
@@ -261,7 +260,6 @@ fn test_place_expr_field_left_associativity() {
 
 // 4. THE CHAIN TEST (Proves the bug cascades)
 #[test]
-#[ignore]
 fn test_place_expr_deref_with_field_chain() {
     // This will also panic under Config B, as it inherits the *p.f ambiguity.
     // It should parse as Deref( Field( Field(p, f), g ) )

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -4,6 +4,7 @@ use crate::rust::term;
 use formality_macros::test;
 
 use crate::grammar::Crates;
+use crate::grammar::expr::PlaceExpr;
 
 #[test]
 fn test_parse_rust_like_trait_impl_syntax() {
@@ -184,4 +185,82 @@ fn test_parse_trusted_fn() {
         }
     "#]]
     .assert_debug_eq(&r);
+}
+
+// 1. THE FAILING TEST (Demonstrates the bug)
+#[test]
+fn test_place_expr_ambiguity_deref_vs_field() {
+    // BUG: Under Config B (Deref=1, Field=2), this panics with an ambiguity error.
+    // It should parse as Deref( Field(p, f) ) because field binds tighter.
+    // Under Config A (Deref=10, Field=1), it parses but gives the wrong AST: Field(Deref(p, f)).
+    let p: PlaceExpr = term("*p.f");
+    expect_test::expect![[r#""#]].assert_debug_eq(&p);
+}
+
+// 2. THE BASELINE TEST (Proves parens bypass the bug)
+#[test]
+fn test_place_expr_parens_override() {
+    // This works perfectly and proves that explicit parens resolve the ambiguity.
+    // It correctly parses as Field( Deref(p), f ).
+    let p: PlaceExpr = term("(*p).f");
+    expect_test::expect![[r#"
+        PlaceExpr {
+            data: Field {
+                prefix: PlaceExpr {
+                    data: Parens(
+                        PlaceExpr {
+                            data: Deref {
+                                prefix: PlaceExpr {
+                                    data: Var(
+                                        p,
+                                    ),
+                                },
+                            },
+                        },
+                    ),
+                },
+                field_name: Id(
+                    f,
+                ),
+            },
+        }
+    "#]].assert_debug_eq(&p);
+}
+
+// 3. THE INFIX TEST (Proves associativity works for fields alone)
+#[test]
+fn test_place_expr_field_left_associativity() {
+    // This works perfectly, proving the parser handles chained infix operators.
+    // It parses as Field( Field(p, f), g ).
+    let p: PlaceExpr = term("p.f.g");
+    expect_test::expect![[r#"
+        PlaceExpr {
+            data: Field {
+                prefix: PlaceExpr {
+                    data: Field {
+                        prefix: PlaceExpr {
+                            data: Var(
+                                p,
+                            ),
+                        },
+                        field_name: Id(
+                            f,
+                        ),
+                    },
+                },
+                field_name: Id(
+                    g,
+                ),
+            },
+        }
+    "#]].assert_debug_eq(&p);
+}
+
+// 4. THE CHAIN TEST (Proves the bug cascades)
+#[test]
+fn test_place_expr_deref_with_field_chain() {
+    // This will also panic under Config B, as it inherits the *p.f ambiguity.
+    // It should parse as Deref( Field( Field(p, f), g ) )
+    let p: PlaceExpr = term("*p.f.g");
+    expect_test::expect![[r#""#]].assert_debug_eq(&p);
 }

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -3,8 +3,8 @@
 use crate::rust::term;
 use formality_macros::test;
 
-use crate::grammar::Crates;
 use crate::grammar::expr::PlaceExpr;
+use crate::grammar::Crates;
 
 #[test]
 fn test_parse_rust_like_trait_impl_syntax() {
@@ -224,7 +224,8 @@ fn test_place_expr_parens_override() {
                 ),
             },
         }
-    "#]].assert_debug_eq(&p);
+    "#]]
+    .assert_debug_eq(&p);
 }
 
 // 3. THE INFIX TEST (Proves associativity works for fields alone)
@@ -253,7 +254,8 @@ fn test_place_expr_field_left_associativity() {
                 ),
             },
         }
-    "#]].assert_debug_eq(&p);
+    "#]]
+    .assert_debug_eq(&p);
 }
 
 // 4. THE CHAIN TEST (Proves the bug cascades)

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -194,7 +194,24 @@ fn test_place_expr_ambiguity_deref_vs_field() {
     // It should parse as Deref( Field(p, f) ) because field binds tighter.
     // Under Config A (Deref=10, Field=1), it parses but gives the wrong AST: Field(Deref(p, f)).
     let p: PlaceExpr = term("*p.f");
-    expect_test::expect![[r#""#]].assert_debug_eq(&p);
+    expect_test::expect![[r#"
+        PlaceExpr {
+            data: Deref {
+                prefix: PlaceExpr {
+                    data: Field {
+                        prefix: PlaceExpr {
+                            data: Var(
+                                p,
+                            ),
+                        },
+                        field_name: Id(
+                            f,
+                        ),
+                    },
+                },
+            },
+        }
+    "#]].assert_debug_eq(&p);
 }
 
 // 2. THE BASELINE TEST (Proves parens bypass the bug)
@@ -264,5 +281,29 @@ fn test_place_expr_deref_with_field_chain() {
     // This will also panic under Config B, as it inherits the *p.f ambiguity.
     // It should parse as Deref( Field( Field(p, f), g ) )
     let p: PlaceExpr = term("*p.f.g");
-    expect_test::expect![[r#""#]].assert_debug_eq(&p);
+    expect_test::expect![[r#"
+        PlaceExpr {
+            data: Deref {
+                prefix: PlaceExpr {
+                    data: Field {
+                        prefix: PlaceExpr {
+                            data: Field {
+                                prefix: PlaceExpr {
+                                    data: Var(
+                                        p,
+                                    ),
+                                },
+                                field_name: Id(
+                                    f,
+                                ),
+                            },
+                        },
+                        field_name: Id(
+                            g,
+                        ),
+                    },
+                },
+            },
+        }
+    "#]].assert_debug_eq(&p);
 }

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -187,12 +187,8 @@ fn test_parse_trusted_fn() {
     .assert_debug_eq(&r);
 }
 
-// 1. THE FAILING TEST (Demonstrates the bug)
 #[test]
 fn test_place_expr_ambiguity_deref_vs_field() {
-    // BUG: Under Config B (Deref=1, Field=2), this panics with an ambiguity error.
-    // It should parse as Deref( Field(p, f) ) because field binds tighter.
-    // Under Config A (Deref=10, Field=1), it parses but gives the wrong AST: Field(Deref(p, f)).
     let p: PlaceExpr = term("*p.f");
     expect_test::expect![[r#"
         PlaceExpr {
@@ -211,14 +207,12 @@ fn test_place_expr_ambiguity_deref_vs_field() {
                 },
             },
         }
-    "#]].assert_debug_eq(&p);
+    "#]]
+    .assert_debug_eq(&p);
 }
 
-// 2. THE BASELINE TEST (Proves parens bypass the bug)
 #[test]
 fn test_place_expr_parens_override() {
-    // This works perfectly and proves that explicit parens resolve the ambiguity.
-    // It correctly parses as Field( Deref(p), f ).
     let p: PlaceExpr = term("(*p).f");
     expect_test::expect![[r#"
         PlaceExpr {
@@ -245,11 +239,8 @@ fn test_place_expr_parens_override() {
     .assert_debug_eq(&p);
 }
 
-// 3. THE INFIX TEST (Proves associativity works for fields alone)
 #[test]
 fn test_place_expr_field_left_associativity() {
-    // This works perfectly, proving the parser handles chained infix operators.
-    // It parses as Field( Field(p, f), g ).
     let p: PlaceExpr = term("p.f.g");
     expect_test::expect![[r#"
         PlaceExpr {
@@ -275,11 +266,8 @@ fn test_place_expr_field_left_associativity() {
     .assert_debug_eq(&p);
 }
 
-// 4. THE CHAIN TEST (Proves the bug cascades)
 #[test]
 fn test_place_expr_deref_with_field_chain() {
-    // This will also panic under Config B, as it inherits the *p.f ambiguity.
-    // It should parse as Deref( Field( Field(p, f), g ) )
     let p: PlaceExpr = term("*p.f.g");
     expect_test::expect![[r#"
         PlaceExpr {
@@ -305,5 +293,6 @@ fn test_place_expr_deref_with_field_chain() {
                 },
             },
         }
-    "#]].assert_debug_eq(&p);
+    "#]]
+    .assert_debug_eq(&p);
 }


### PR DESCRIPTION
## What does this PR do?

Closes #334 

This PR attempts to resolve the `*p.f` ambiguity. After testing, I've found that the `#[precedence]` attribute does not behave as expected for mixed prefix (`*`) and infix (`.`) operators. Resulting -> The parser currently cannot distinguish between *(w.value) and  (*w).value

### Background Research
I reviewed the parser implementation in `formality-core`:
* [parser.rs](https://github.com/rust-lang/a-mir-formality/blob/56e5c2a9b41375cf7c89a4b8d3605b662895ecec/crates/formality-core/src/parse/parser.rs#L46-L51) / [precedence.rs](https://github.com/rust-lang/a-mir-formality/blob/main/crates/formality-macros/src/precedence.rs#L63): Precedence is designed so higher numbers = tighter binding.
* [left_associative.rs](https://github.com/rust-lang/a-mir-formality/blob/56e5c2a9b41375cf7c89a4b8d3605b662895ecec/tests/parser-torture-tests/left_associative.rs#L108): This works perfectly for **infix binary operators** (e.g., `Add(1)` vs `Mul(2)`).

_I've tried to understand above code blocks mentioned in above files and this files (most of it went right above my head )_, also checked [grammar.rs](https://github.com/rust-lang/a-mir-formality/blob/56e5c2a9b41375cf7c89a4b8d3605b662895ecec/examples/formality-eg/grammar.rs#L79), [right_associative](https://github.com/rust-lang/a-mir-formality/blob/56e5c2a9b41375cf7c89a4b8d3605b662895ecec/tests/parser-torture-tests/right_associative.rs#L84)

However this issue is counterintuitive to me because of simple thought PEMDAS & predence,  associativity rules, so mixing a prefix operator (`Deref`) and an infix operator (`Field`) across separate variants, the parser fails.

### Experimental Configurations
I tested the following configurations.

| Config | Deref Priority | Field Priority | Result | Analysis |
| :--- | :--- | :--- | :--- | :--- |
| **A (Inverted)** | 10 | 1 | ✅ Parses (No Panic) | **Semantically Wrong**: Produces `Field(Deref(p), f)` instead of `Deref(Field(p, f))`. Proves the attribute is read, but forces the wrong tree. |
| **B (Standard)** | 1 | 2 | ❌ Ambiguity Panic | Identifies both interpretations but refuses to choose, despite Field having higher precedence. |
| **C (Extreme)** | 1 | 10 | ❌ Ambiguity Panic | Even a massive gap fails to force the parser to commit to `Deref(Field)`. |

<details>

<summary>Disclosure questions</summary>

**AI disclosure.**

I did not use AI for implementing the test cases. Although I used it to trace the logic in the codebase, an attempt to understand the grammar as well as core part, formating PR, and commenting in code part so that it will easy to review/test and saves time. 

<!-- The use of AI tooling for a-mir-formality is permitted. We require disclosure to help calibrate our reviews. -->

<!-- Remove the items that do not apply. -->

**Confidence level.**

<!-- Remove the items that do not apply. -->

* I am very happy with it


**Questions for reviewers.**
Is this a known limitation? Because you already said the same thing on [Zulip]([#t-types/formality > &#91;GFI&#93; Expand test coverage for Expr variants formality#265 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/402470-t-types.2Fformality/topic/.5BGFI.5D.20Expand.20test.20coverage.20for.20Expr.20variants.20formality.23265/near/582973350))
<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
