### PR TITLE
Fix: well-formedness assumptions for existential variables

### DIFF
--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -281,6 +281,13 @@ judgment_fn! {
         (
             // Existential variables: open the binder and check the inner block
             (let (env, subst, block) = env.instantiate_existentially(binder))
+            (let wf_assumptions: Wcs = subst.iter().fold(Wcs::default(), |acc, v| {
+                let p: Parameter = v.upcast();
+                let r: Relation = p.well_formed();
+                let w: Wcs = r.upcast();
+                (acc, w).upcast()
+            }))
+            (let assumptions: Wcs = (assumptions, wf_assumptions).upcast())
             (borrow_check_block(env, assumptions, state, block, places_live_on_exit) => state)
             (let state = state.pop_subst(&env.env, subst))
             ------------------------------------------------------------ ("exists")

--- a/src/test/borrowck.rs
+++ b/src/test/borrowck.rs
@@ -931,7 +931,10 @@ fn undeclared_universal_region_relationship() {
             }
         ]
 
-        expect_test::expect!["crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_0, b: !lt_1, assumptions: {}, env: Env { variables: [!lt_0, !lt_1], bias: Soundness, pending: [], allow_pending_outlives: false } }"]
+        expect_test::expect![[r#"
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: !lt_1 : !lt_2, via: @ wf(?lt_0), assumptions: {@ wf(?lt_0)}, env: Env { variables: [!lt_1, !lt_2, ?lt_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
+
+            crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_1, b: !lt_2, assumptions: {@ wf(?lt_0)}, env: Env { variables: [!lt_1, !lt_2, ?lt_0], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]]
     )
 }
 
@@ -1895,7 +1898,9 @@ fn struct_with_mutable_reference_locks_local() {
                 }
             }
         ]
-        // FIXME(#304) -- This does not look like the error message we expect.
-        expect_test::expect!["crates/formality-rust/src/prove/prove/prove/prove_wf.rs:14:1: no applicable rules for prove_wf { goal: ?lt_0, assumptions: {}, env: Env { variables: [?lt_0], bias: Soundness, pending: [], allow_pending_outlives: true } }"]
+        expect_test::expect![[r#"
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: @ wf(Wrapper<?lt_0>), via: @ wf(?lt_0), assumptions: {@ wf(?lt_0)}, env: Env { variables: [?lt_0], bias: Soundness, pending: [], allow_pending_outlives: true } }
+
+            crates/formality-rust/src/prove/prove/prove/prove_wf.rs:14:1: no applicable rules for prove_wf { goal: ?lt_0, assumptions: {@ wf(?lt_0)}, env: Env { variables: [?lt_0], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]]
     )
 }


### PR DESCRIPTION
## What does this PR do?

closes PR #304 

This PR resolves the well-formedness (WF) check failure in the NLL borrow checker that was identified during the work on #282.
Previously, it had no assumptions regarding WF of these variables (_fresh existential lifetime_), causing prove_wf to fail with "no applicable rules" before even it hit borrow checker

### Traceability

0. Zulip discussion about test and wf assumption inception -> [#t-types/formality > &#91;GFI&#93; Expand test coverage for Expr variants formality#265 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/402470-t-types.2Fformality/topic/.5BGFI.5D.20Expand.20test.20coverage.20for.20Expr.20variants.20formality.23265/near/582856965)

1. In the PR #282 -> test `struct_with_mutable_reference_locks_local` encountered an ambigious parse Err [[Code block](https://github.com/rust-lang/a-mir-formality/pull/282/changes#diff-8808332714b76180e9f23145b85aa243adeccc4c987378d2c13342afe6be5b40R1293)]

2. PlaceExpr ambiguity precedence levels also occured in the same test, PR #331 resolved it.

3. Possibility of ripple effect in the attempt to solve WF #309 


<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

- I used AI tool for mapping DSL syntax, .fold() and upcast() understanding and conciseness of code (verbosity of code reduction)

<!-- The use of AI tooling for a-mir-formality is permitted. We require disclosure to help calibrate our reviews. -->

<!-- Remove the items that do not apply. -->

**Confidence level.**

<!-- Remove the items that do not apply. -->


* I am very happy with it, as I followed suggestion provided by @nikomatsakis and it took decent amount of time to understand exact fix and problem.

**Questions for reviewers.**
@nikomatsakis  Does it meet the direction that you were trying to provide here #309?
An err appearing right now is expected one? Because I didn't understood it correctly as compared to other errors in the codebase (at least basic intepretation of an err). 

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
