### PR TITLE
Add link to the `a-mir-formality` book

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,15 @@ This repository is an early-stage experimental project that aims to be a complet
 Presuming these experiments bear fruit, the intention is to bring this model into Rust as an RFC
 and develop it as an official part of the language definition.
 
-## Docs
-
-Check out the [a-mir-formality Book](https://rust-lang.github.io/a-mir-formality/intro.html) for an overview and introduction to `a-mir-formality`.
-
 ## Quickstart guide
 
 Like any Rust project:
 
 * Clone
 * `cargo test --all`
+
+## Documentation
+Check out [a-mir-formality book](https://rust-lang.github.io/a-mir-formality/intro.html) for an overview and introduction to `a-mir-formality`.
 
 ## Layers of formality
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository is an early-stage experimental project that aims to be a complet
 Presuming these experiments bear fruit, the intention is to bring this model into Rust as an RFC
 and develop it as an official part of the language definition.
 
+## Docs
+
+Check out the [a-mir-formality Book](https://rust-lang.github.io/a-mir-formality/intro.html) for an overview and introduction to `a-mir-formality`.
+
 ## Quickstart guide
 
 Like any Rust project:


### PR DESCRIPTION
## What does this PR do?

Adds link to the `a-mir-formality` book in the README.md for better discoverability of some docs.

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

No AI used.

</details>
