### PR TITLE
Use `formality-rust` versions of Core types and traits

### DIFF
--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -1,9 +1,10 @@
-use crate::grammar::{
-    AdtItem, Binder, Crate, CrateItem, Crates, Fallible, FeatureGate, FeatureGateName,
-    ParameterKind, TyData, WhereClause, WhereClauseData,
+use crate::{
+    grammar::{
+        AdtItem, Binder, Crate, CrateItem, Crates, Fallible, FeatureGate, FeatureGateName,
+        ParameterKind, TyData, Variable, WhereClause, WhereClauseData,
+    },
+    rust::Fold,
 };
-use formality_core::{fold::CoreFold, variable::CoreVariable};
-
 use std::{
     collections::{HashMap, HashSet},
     ops::Deref,
@@ -90,12 +91,9 @@ pub struct NameContext {
 }
 
 impl NameContext {
-    pub fn core_variable_to_string(
-        &self,
-        variable: &CoreVariable<crate::FormalityLang>,
-    ) -> Fallible<String> {
+    pub fn core_variable_to_string(&self, variable: &Variable) -> Fallible<String> {
         match variable {
-            CoreVariable::BoundVar(core_bound_var) => {
+            Variable::BoundVar(core_bound_var) => {
                 let var_index = core_bound_var.var_index.index;
                 let binder_index = core_bound_var
                     .debruijn
@@ -108,10 +106,10 @@ impl NameContext {
                     .cloned()
                     .ok_or_else(|| anyhow::anyhow!("unbound variable {core_bound_var:?}"))
             }
-            CoreVariable::UniversalVar(v) => {
+            Variable::UniversalVar(v) => {
                 Ok(self.free_variable_name(true, v.kind, v.var_index.index))
             }
-            CoreVariable::ExistentialVar(v) => {
+            Variable::ExistentialVar(v) => {
                 Ok(self.free_variable_name(false, v.kind, v.var_index.index))
             }
         }
@@ -178,7 +176,7 @@ pub struct RustBuilder {
 }
 
 impl RustBuilder {
-    pub fn with_binder<T: CoreFold<crate::FormalityLang, Output = T>, R>(
+    pub fn with_binder<T: Fold, R>(
         &mut self,
         binder: &Binder<T>,
         mut op: impl FnMut(&T, &mut RustBuilder) -> Fallible<R>,
@@ -192,10 +190,7 @@ impl RustBuilder {
         result
     }
 
-    pub fn core_variable_to_string(
-        &self,
-        core_variable: &CoreVariable<crate::FormalityLang>,
-    ) -> Fallible<String> {
+    pub fn core_variable_to_string(&self, core_variable: &Variable) -> Fallible<String> {
         self.ctx.core_variable_to_string(core_variable)
     }
 

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -213,33 +213,31 @@ impl RustBuilder {
 
 #[cfg(test)]
 mod test {
-    use formality_core::variable::{CoreBoundVar, CoreVariable, DebruijnIndex, VarIndex};
-
     use crate::{
-        grammar::{AdtId, ParameterKind},
+        grammar::{AdtId, BoundVar, DebruijnIndex, ParameterKind, VarIndex, Variable},
         to_rust::NameContext,
     };
 
     use super::*;
 
-    fn create_ty() -> CoreVariable<crate::FormalityLang> {
-        CoreVariable::BoundVar(CoreBoundVar {
+    fn create_ty() -> Variable {
+        Variable::BoundVar(BoundVar {
             debruijn: Some(DebruijnIndex { index: 0 }),
             var_index: VarIndex { index: 0 },
             kind: crate::grammar::ParameterKind::Ty,
         })
     }
 
-    fn create_lt() -> CoreVariable<crate::FormalityLang> {
-        CoreVariable::BoundVar(CoreBoundVar {
+    fn create_lt() -> Variable {
+        Variable::BoundVar(BoundVar {
             debruijn: Some(DebruijnIndex { index: 0 }),
             var_index: VarIndex { index: 0 },
             kind: crate::grammar::ParameterKind::Lt,
         })
     }
 
-    fn create_const() -> CoreVariable<crate::FormalityLang> {
-        CoreVariable::BoundVar(CoreBoundVar {
+    fn create_const() -> Variable {
+        Variable::BoundVar(BoundVar {
             debruijn: Some(DebruijnIndex { index: 0 }),
             var_index: VarIndex { index: 0 },
             kind: crate::grammar::ParameterKind::Const,


### PR DESCRIPTION
## What does this PR do?

Use the `formality-rust` versions of core types (e.g. `Variable` instead of `CoreVariable`).

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

No AI used.

</details>
