### PR TITLE
add rust-analyzer to toolchain file and choose working nightly version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-12-01"
-components = ["rustfmt"]
+channel = "nightly-2025-11-24"
+components = ["rustfmt", "rust-analyzer"]


### PR DESCRIPTION
fixes the errors rust-analyzer was displaying for judgement functions on my side. Would appreciate some testing from other people especially non-nix users.