### PR TITLE
Use boolean literals instead of digit

### DIFF
--- a/crates/formality-rust/src/grammar/expr/mod.rs
+++ b/crates/formality-rust/src/grammar/expr/mod.rs
@@ -132,6 +132,7 @@ pub enum ExprData {
     ///
     /// A scalar literal.
     #[grammar($value _ $ty)]
+    #[reject(_, ScalarId::Bool)]
     Literal { value: usize, ty: ScalarId },
 
     /// `true`

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 
-use crate::rust::term;
+use crate::rust::{term, try_term};
 use formality_macros::test;
 
-use crate::grammar::expr::PlaceExpr;
-use crate::grammar::Crates;
+use crate::grammar::expr::{ExprData, PlaceExpr};
+use crate::grammar::{Crates, Fallible, ScalarId};
 
 #[test]
 fn test_parse_rust_like_trait_impl_syntax() {
@@ -295,4 +295,25 @@ fn test_place_expr_deref_with_field_chain() {
         }
     "#]]
     .assert_debug_eq(&p);
+}
+
+#[test]
+fn test_parse_literals() {
+    let expr_data: Fallible<ExprData> = try_term("0 _ bool");
+    assert!(expr_data.is_err());
+
+    let expr_data: ExprData = try_term("0 _ u8").unwrap();
+    assert!(matches!(
+        expr_data,
+        ExprData::Literal {
+            value: 0,
+            ty: ScalarId::U8
+        }
+    ));
+
+    let expr_data: ExprData = try_term("false").unwrap();
+    assert!(matches!(expr_data, ExprData::False));
+
+    let expr_data: ExprData = try_term("true").unwrap();
+    assert!(matches!(expr_data, ExprData::True));
 }

--- a/src/test/mir_typeck.rs
+++ b/src/test/mir_typeck.rs
@@ -30,7 +30,7 @@ fn test_assign_constant() {
                     let v7: i32 = 5 _ i32;
                     let v8: i64 = 5 _ i64;
                     let v9: isize = 5 _ isize;
-                    let v10: bool = 0 _ bool;
+                    let v10: bool = false;
                     return 5 _ u8;
                 }
             }
@@ -156,7 +156,7 @@ fn if_else_different_return_types() {
                     if b {
                         return 1 _ u32;
                     } else {
-                        return 0 _ bool;
+                        return false;
                     }
                 }
             }
@@ -247,7 +247,7 @@ fn test_struct() {
                 }
 
                 fn foo (v1: u32) -> u32 {
-                    let v2: Dummy = Dummy { value: 1 _ u32, is_true: 0 _ bool };
+                    let v2: Dummy = Dummy { value: 1 _ u32, is_true: false };
                     v2.value = 2 _ u32;
                     return v1;
                 }
@@ -704,7 +704,7 @@ fn test_struct_wrong_type_in_initialisation() {
                 }
 
                 fn foo (v1: u32) -> u32 {
-                    let v2: Dummy = Dummy { value: 0 _ bool };
+                    let v2: Dummy = Dummy { value: false };
                     return v1;
                 }
             }
@@ -726,7 +726,7 @@ fn test_non_adt_ty_for_struct() {
         [
             crate Foo {
                 fn foo (v1: u32) -> u32 {
-                    let v2: u32 = Nonexistent { value: 0 _ bool };
+                    let v2: u32 = Nonexistent { value: false };
                     return v1;
                 }
             }


### PR DESCRIPTION
## What does this PR do?

Replaces `0 _ bool` with `false` in test cases. This simplifies the conversion to Rust as no special case is needed.

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* No AI used.

**Confidence level.**

* I am very happy with it


**Questions for reviewers.**

Was there a specific reason to use `0 _ bool`?

</details>
