### PR TITLE
Lower the lifetimes introduced by an `exists` statement to Rust

### DIFF
--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -70,10 +70,29 @@ impl RustBuilder {
         })
     }
 
+    /// Lowers an `exists` statement. The newly introduced lifetimes
+    /// e.g. `'r0`, are all treated as anonymous lifetimes `'_`.
+    /// ```rust,ignore
+    /// exists<'r0> {
+    ///   let v2: &'r0 u32 = v1;
+    ///   return v2;
+    /// }
+    /// ```
+    /// becomes:
+    /// ```rust,ignore
+    /// {
+    ///   let v2: &'_ u32 = v1;
+    ///   return v2;
+    /// }
+    /// ```
     fn lower_exists_stmt(&mut self, binder: &Binder<Block>) -> Fallible<syntax::Stmt> {
-        self.with_binder(binder, |term, pp| {
-            Ok(syntax::Stmt::Block(pp.lower_block(term)?))
-        })
+        let term = binder.peek();
+        self.ctx.push_anonymous(binder.kinds());
+
+        let result = syntax::Stmt::Block(self.lower_block(term)?);
+
+        self.ctx.pop();
+        Ok(result)
     }
 
     pub fn lower_expr(&mut self, expr: &Expr) -> Fallible<syntax::Expr> {

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -62,7 +62,7 @@ impl RustBuilder {
         init: Option<&Init>,
     ) -> Fallible<syntax::Stmt> {
         Ok(syntax::Stmt::Let {
-            // TODO: is there a way to knwo, if the variable must be mutable or not?
+            // TODO: is there a way to know, if the variable must be mutable or not?
             mutable: true,
             name: id.deref().clone(),
             ty: self.lower_ty(ty)?,
@@ -70,28 +70,13 @@ impl RustBuilder {
         })
     }
 
-    /// Lowers an `exists` statement. The newly introduced lifetimes
-    /// e.g. `'r0`, are all treated as anonymous lifetimes `'_`.
-    /// ```rust,ignore
-    /// exists<'r0> {
-    ///   let v2: &'r0 u32 = v1;
-    ///   return v2;
-    /// }
-    /// ```
-    /// becomes:
-    /// ```rust,ignore
-    /// {
-    ///   let v2: &'_ u32 = v1;
-    ///   return v2;
-    /// }
-    /// ```
     fn lower_exists_stmt(&mut self, binder: &Binder<Block>) -> Fallible<syntax::Stmt> {
-        let term = binder.peek();
-        self.ctx.push_anonymous(binder.kinds());
+        let subst = self.existential_substitution(binder);
+        let term = binder
+            .instantiate_with(&subst)
+            .expect("suitable substitution");
 
-        let result = syntax::Stmt::Block(self.lower_block(term)?);
-
-        self.ctx.pop();
+        let result = syntax::Stmt::Block(self.lower_block(&term)?);
         Ok(result)
     }
 
@@ -246,6 +231,32 @@ fn foo() -> () {
         break 'a;
     }
 }"#
+        );
+    }
+
+    #[test]
+    fn omited_existential_lifetimes() {
+        crate::assert_rust!(
+            [
+                crate Foo {
+                    fn foo() -> u32 {
+                        exists<'r0, 'r1> {
+                            let v1: u32 = 0 _ u32;
+                            let v2: &mut 'r0 u32 = &mut 'r1 v1;
+                            return *v2;
+                        }
+                    }
+                }
+            ],
+            r#"
+fn foo() -> u32 {
+    {
+        let mut v1: u32 = 0_u32;
+        let mut v2: &mut u32 = &mut v1;
+        return *v2;
+    }
+}
+"#
         );
     }
 }

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -71,6 +71,7 @@ impl RustBuilder {
     }
 
     fn lower_exists_stmt(&mut self, binder: &Binder<Block>) -> Fallible<syntax::Stmt> {
+        // TODO: Check again, after codegen is merged, if "erased" lifetimes could work here.
         let subst = self.existential_substitution(binder);
         let term = binder
             .instantiate_with(&subst)

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -1,53 +1,35 @@
 use std::ops::Deref;
 
-use crate::grammar::{Fallible, Fn, FnBody, InputArg, MaybeFnBody, ParameterKind, Ty, WhereClause};
+use crate::grammar::{Fallible, Fn, FnBody, InputArg, MaybeFnBody};
 use crate::prove::prove::Safety;
 
 use super::{syntax, RustBuilder};
 
 impl RustBuilder {
     pub fn lower_fn(&mut self, function: &Fn) -> Fallible<syntax::FunctionItem> {
-        self.with_binder(&function.binder, |term, pp| {
-            let generics = pp.lower_generics_for_fn(
-                function.binder.kinds(),
-                &term.where_clauses,
-                &term.input_args,
-            )?;
-            let params = term
-                .input_args
-                .iter()
-                .map(|arg| pp.lower_fn_param(arg))
-                .collect::<Result<Vec<_>, _>>()?;
-            let return_ty = pp.lower_ty(&term.output_ty)?;
-            let body = pp.lower_fn_body(&term.body)?;
+        self.with_binder(
+            &function.binder,
+            false,
+            |term| &term.where_clauses,
+            |term, generics, pp| {
+                let params = term
+                    .input_args
+                    .iter()
+                    .map(|arg| pp.lower_fn_param(arg))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let return_ty = pp.lower_ty(&term.output_ty)?;
+                let body = pp.lower_fn_body(&term.body)?;
 
-            Ok(syntax::FunctionItem {
-                is_unsafe: matches!(function.safety, Safety::Unsafe),
-                name: function.id.deref().clone(),
-                generics,
-                params,
-                return_ty,
-                body,
-            })
-        })
-    }
-
-    fn lower_generics_for_fn(
-        &mut self,
-        binder_kinds: &[ParameterKind],
-        where_clauses: &[WhereClause],
-        input_args: &[InputArg],
-    ) -> Fallible<syntax::Generics> {
-        let mut generics = self.lower_generics_for_binder(binder_kinds, where_clauses, false)?;
-
-        for arg in input_args {
-            if let Ty::Variable(var) = &arg.ty {
-                let name = self.core_variable_to_string(var)?;
-                Self::push_type_param_if_missing(&mut generics.params, name);
-            }
-        }
-
-        Ok(generics)
+                Ok(syntax::FunctionItem {
+                    is_unsafe: matches!(function.safety, Safety::Unsafe),
+                    name: function.id.deref().clone(),
+                    generics,
+                    params,
+                    return_ty,
+                    body,
+                })
+            },
+        )
     }
 
     fn lower_fn_param(&mut self, arg: &InputArg) -> Fallible<syntax::FnParam> {
@@ -114,7 +96,7 @@ fn run(mut p1: i32, mut p2: i32) -> i32 {
                 }
             ],
             r#"
-fn run<T1>(mut p1: T1) -> T1 {
+fn run<T0>(mut p1: T0) -> T0 {
     panic!("Trusted Fn Body")
 }
 "#
@@ -150,7 +132,7 @@ fn run<T1>(mut p1: T1) -> T1 where T1: Bar {
                 }
             ],
             r#"
-fn run<const N1: i32>() -> i32 {
+fn run<const N0: i32>() -> i32 {
     panic!("Trusted Fn Body")
 }
 "#

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -1,8 +1,6 @@
 use std::ops::Deref;
 
-use crate::grammar::{
-    Fallible, Fn, FnBody, InputArg, MaybeFnBody, ParameterKind, TyData, WhereClause,
-};
+use crate::grammar::{Fallible, Fn, FnBody, InputArg, MaybeFnBody, ParameterKind, Ty, WhereClause};
 use crate::prove::prove::Safety;
 
 use super::{syntax, RustBuilder};
@@ -43,7 +41,7 @@ impl RustBuilder {
         let mut generics = self.lower_generics_for_binder(binder_kinds, where_clauses, false)?;
 
         for arg in input_args {
-            if let TyData::Variable(var) = &arg.ty {
+            if let Ty::Variable(var) = &arg.ty {
                 let name = self.core_variable_to_string(var)?;
                 Self::push_type_param_if_missing(&mut generics.params, name);
             }

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     grammar::{
         AdtItem, Binder, Crate, CrateItem, Crates, Fallible, FeatureGate, FeatureGateName,
-        ParameterKind, TyData, Variable, WhereClause, WhereClauseData,
+        ParameterKind, Ty, Variable, WhereClause, WhereClauseData,
     },
     rust::Fold,
 };
@@ -295,7 +295,7 @@ impl RustBuilder {
         for wc in where_clauses {
             match wc.data() {
                 WhereClauseData::IsImplemented(ty, _, _) => {
-                    if let TyData::Variable(var) = ty {
+                    if let Ty::Variable(var) = ty {
                         let name = self.core_variable_to_string(&var)?;
                         // If the `where` clause referes to a type
                         // variable from an outer binder, that

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -29,7 +29,7 @@ pub fn check_workspace(
 
     let output = std::process::Command::new("cargo")
         .env("RUSTFLAGS", "-A warnings")
-        .args(["check", "--manifest-path", &root_toml])
+        .args(["check", "--workspace", "--manifest-path", &root_toml])
         .output()?;
     Ok(output)
 }
@@ -76,7 +76,7 @@ pub fn create_workspace(crates: &Crates, root_directory: &std::path::Path) -> Fa
         .ok_or_else(|| anyhow::anyhow!("Could not convert location to a &str"))?;
 
     std::process::Command::new("cargo")
-        .args(["fmt", "--manifest-path", location])
+        .args(["fmt", "--all", "--manifest-path", location])
         .spawn()?;
 
     Ok(location.to_string())
@@ -135,6 +135,19 @@ impl NameContext {
         self.variable_names.insert(0, Vec::new());
         for kind in kinds {
             let name = self.fresh_name(kind);
+            self.variable_names[0].push(name);
+        }
+    }
+
+    pub fn push_anonymous(&mut self, kinds: &[ParameterKind]) {
+        self.variable_names.insert(0, Vec::new());
+        for kind in kinds {
+            let name = if matches!(kind, ParameterKind::Lt) {
+                "'_".to_owned()
+            } else {
+                self.fresh_name(kind)
+            };
+            self.used.insert(name.clone());
             self.variable_names[0].push(name);
         }
     }

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -1,14 +1,12 @@
 use crate::{
     grammar::{
-        AdtItem, Binder, Crate, CrateItem, Crates, Fallible, FeatureGate, FeatureGateName,
-        ParameterKind, Ty, Variable, WhereClause, WhereClauseData,
+        AdtItem, Binder, BoundVar, Crate, CrateItem, Crates, ExistentialVar, Fallible, FeatureGate,
+        FeatureGateName, ParameterKind, Ty, UniversalVar, VarIndex, Variable, WhereClause,
+        WhereClauseData,
     },
     rust::Fold,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    ops::Deref,
-};
+use std::{collections::HashMap, ops::Deref};
 
 mod expr;
 mod fns;
@@ -82,129 +80,114 @@ pub fn create_workspace(crates: &Crates, root_directory: &std::path::Path) -> Fa
     Ok(location.to_string())
 }
 
-type Stack<T> = Vec<T>;
-
-#[derive(Debug, Default)]
-pub struct NameContext {
-    variable_names: Stack<Vec<String>>,
-    used: HashSet<String>,
-}
-
-impl NameContext {
-    pub fn core_variable_to_string(&self, variable: &Variable) -> Fallible<String> {
-        match variable {
-            Variable::BoundVar(core_bound_var) => {
-                let var_index = core_bound_var.var_index.index;
-                let binder_index = core_bound_var
-                    .debruijn
-                    .ok_or_else(|| anyhow::anyhow!("binder was opened"))?
-                    .index;
-
-                self.variable_names
-                    .get(binder_index)
-                    .and_then(|vars| vars.get(var_index))
-                    .cloned()
-                    .ok_or_else(|| anyhow::anyhow!("unbound variable {core_bound_var:?}"))
-            }
-            Variable::UniversalVar(v) => {
-                Ok(self.free_variable_name(true, v.kind, v.var_index.index))
-            }
-            Variable::ExistentialVar(v) => {
-                Ok(self.free_variable_name(false, v.kind, v.var_index.index))
-            }
-        }
-    }
-
-    pub fn current_names(&self) -> Fallible<&[String]> {
-        self.variable_names
-            .first()
-            .map(|v| v.as_slice())
-            .ok_or_else(|| anyhow::anyhow!("no active binder frame"))
-    }
-
-    pub fn pop(&mut self) {
-        if let Some(names) = self.variable_names.first().cloned() {
-            self.variable_names.remove(0);
-            for name in names {
-                self.used.remove(&name);
-            }
-        }
-    }
-
-    pub fn push(&mut self, kinds: &[ParameterKind]) {
-        self.variable_names.insert(0, Vec::new());
-        for kind in kinds {
-            let name = self.fresh_name(kind);
-            self.variable_names[0].push(name);
-        }
-    }
-
-    pub fn push_anonymous(&mut self, kinds: &[ParameterKind]) {
-        self.variable_names.insert(0, Vec::new());
-        for kind in kinds {
-            let name = if matches!(kind, ParameterKind::Lt) {
-                "'_".to_owned()
-            } else {
-                self.fresh_name(kind)
-            };
-            self.used.insert(name.clone());
-            self.variable_names[0].push(name);
-        }
-    }
-
-    fn fresh_name(&mut self, kind: &ParameterKind) -> String {
-        let prefix = match kind {
-            ParameterKind::Ty => "T",
-            ParameterKind::Lt => "'a",
-            ParameterKind::Const => "N",
-        };
-
-        for i in 1.. {
-            let name = format!("{prefix}{i}");
-            if self.used.insert(name.clone()) {
-                return name;
-            }
-        }
-
-        unreachable!("fresh name generation should always terminate")
-    }
-
-    fn free_variable_name(&self, universal: bool, kind: ParameterKind, var_index: usize) -> String {
-        let suffix = var_index + 1;
-        let prefix = match (universal, kind) {
-            (true, ParameterKind::Ty) => "U",
-            (true, ParameterKind::Lt) => "'u",
-            (true, ParameterKind::Const) => "CU",
-            (false, ParameterKind::Ty) => "E",
-            (false, ParameterKind::Lt) => "'e",
-            (false, ParameterKind::Const) => "CE",
-        };
-        format!("{prefix}{suffix}")
-    }
-}
-
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct RustBuilder {
-    ctx: NameContext,
+    counter: VarIndex,
+}
+
+impl Default for RustBuilder {
+    fn default() -> Self {
+        Self {
+            counter: VarIndex { index: 0 },
+        }
+    }
 }
 
 impl RustBuilder {
     pub fn with_binder<T: Fold, R>(
         &mut self,
-        binder: &Binder<T>,
-        mut op: impl FnMut(&T, &mut RustBuilder) -> Fallible<R>,
+        b: &Binder<T>,
+        is_trait: bool,
+        g: impl Fn(&T) -> &Vec<WhereClause>,
+        mut op: impl FnMut(T, syntax::Generics, &mut RustBuilder) -> Fallible<R>,
     ) -> Fallible<R> {
-        let term = binder.peek();
-        self.ctx.push(binder.kinds());
+        let subst = self.bounded_substitution(b);
+        let term = b.instantiate_with(&subst).expect("suitable substitution");
 
-        let result = op(term, self);
+        let names = subst
+            .into_iter()
+            .map(|var| format!("{}{}", self.kind_to_string(&var.kind), var.var_index.index))
+            .collect::<Vec<_>>();
+        let generics =
+            self.lower_generics_for_binder(b.kinds(), g(&term), names.as_slice(), is_trait)?;
 
-        self.ctx.pop();
+        let result = op(term, generics, self);
         result
     }
 
-    pub fn core_variable_to_string(&self, core_variable: &Variable) -> Fallible<String> {
-        self.ctx.core_variable_to_string(core_variable)
+    pub fn core_variable_to_string(&self, variable: &Variable) -> Fallible<String> {
+        let index = match variable {
+            Variable::UniversalVar(universal_var) => universal_var.var_index,
+            Variable::ExistentialVar(existential_var) => existential_var.var_index,
+            Variable::BoundVar(bound_var) => {
+                if bound_var.debruijn.is_some() {
+                    anyhow::bail!("binder is not open")
+                }
+                bound_var.var_index
+            }
+        }
+        .index;
+        let kind = self.kind_to_string(&variable.kind());
+        Ok(format!("{kind}{index}"))
+    }
+
+    fn kind_to_string(&self, kind: &ParameterKind) -> &'static str {
+        match kind {
+            ParameterKind::Ty => "T",
+            ParameterKind::Lt => "'a",
+            ParameterKind::Const => "N",
+        }
+    }
+
+    pub fn substitution<T, V>(
+        &mut self,
+        b: &Binder<T>,
+        v: impl Fn(ParameterKind, VarIndex) -> V,
+    ) -> Vec<V>
+    where
+        T: Fold,
+    {
+        let subst = self.fresh_substitution(b.kinds(), v);
+        subst
+    }
+
+    pub fn bounded_substitution<T>(&mut self, b: &Binder<T>) -> Vec<BoundVar>
+    where
+        T: Fold,
+    {
+        self.substitution(b, |kind, var_index| BoundVar {
+            debruijn: None,
+            kind,
+            var_index,
+        })
+    }
+
+    pub fn existential_substitution<T>(&mut self, b: &Binder<T>) -> Vec<ExistentialVar>
+    where
+        T: Fold,
+    {
+        self.substitution(b, |kind, var_index| ExistentialVar { kind, var_index })
+    }
+
+    pub fn universal_substitution<T>(&mut self, b: &Binder<T>) -> Vec<UniversalVar>
+    where
+        T: Fold,
+    {
+        self.substitution(b, |kind, var_index| UniversalVar { kind, var_index })
+    }
+
+    fn fresh_substitution<V>(
+        &mut self,
+        kinds: &[ParameterKind],
+        v: impl Fn(ParameterKind, VarIndex) -> V,
+    ) -> Vec<V> {
+        let fresh_index = self.counter;
+        self.counter = self.counter + kinds.len();
+        kinds
+            .iter()
+            .zip(0..)
+            .map(|(&kind, offset)| v(kind, fresh_index + offset))
+            .collect()
     }
 
     pub fn build_crates(&mut self, crates: &Crates) -> Fallible<HashMap<String, String>> {
@@ -271,10 +254,9 @@ impl RustBuilder {
         &mut self,
         binder_kinds: &[ParameterKind],
         where_clauses: &[WhereClause],
+        names: &[String],
         skip_first: bool,
     ) -> Fallible<syntax::Generics> {
-        let names = self.ctx.current_names()?;
-
         if names.len() != binder_kinds.len() {
             anyhow::bail!(
                 "binder metadata mismatch: {} names but {} kinds",

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -94,11 +94,39 @@ impl Default for RustBuilder {
 }
 
 impl RustBuilder {
+    /// Applies the operation `op` to the term contained within the binder `b`.
+    ///
+    /// The binder is instantiated with a fresh set of bound variables. Since a
+    /// binder introduces new generic variables, those variables are lowered at
+    /// this point and provided to the caller via the `syntax::Generics` argument
+    /// passed to `op`.
+    ///
+    /// The function `g` is used to extract the relevant `&[WhereClause]` clauses from the
+    /// instantiated term.
+    ///
+    /// When lowering generics for a trait declaration, `is_trait` must be set to
+    /// `true`. In this case, the implicit first generic parameter represents
+    /// `Self` and is therefore not treated as a regular generic parameter.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use formality_rust::grammar::{AdtId, Binder, Struct, StructBoundData, Fallible};
+    /// # use formality_rust::to_rust::{RustBuilder, syntax::StructItem};
+    /// fn lower_struct(term: Struct) -> Fallible<StructItem> {
+    ///     let mut pp = RustBuilder::default();
+    ///     pp.with_binder(
+    ///         &term.binder,
+    ///         true,
+    ///         |term| &term.where_clauses,
+    ///         |term, generics, pp| todo!(),
+    ///     )
+    /// }
+    /// ```
     pub fn with_binder<T: Fold, R>(
         &mut self,
         b: &Binder<T>,
         is_trait: bool,
-        g: impl Fn(&T) -> &Vec<WhereClause>,
+        g: impl Fn(&T) -> &[WhereClause],
         mut op: impl FnMut(T, syntax::Generics, &mut RustBuilder) -> Fallible<R>,
     ) -> Fallible<R> {
         let subst = self.bounded_substitution(b);
@@ -139,6 +167,12 @@ impl RustBuilder {
         }
     }
 
+    /// Creates a substitution for the binder `b` using freshly generated
+    /// variables.
+    ///
+    /// For each parameter introduced by the binder, a fresh variable is created
+    /// by invoking the generator function `v`. The resulting substitution can be
+    /// used to instantiate the binder.
     pub fn substitution<T, V>(
         &mut self,
         b: &Binder<T>,
@@ -151,6 +185,12 @@ impl RustBuilder {
         subst
     }
 
+    /// Creates a substitution that replaces the variables introduced by the
+    /// binder `b` with fresh bound variables.
+    ///
+    /// Each binder parameter is mapped to a new [`BoundVar`] with a fresh
+    /// variable index. The resulting substitution can be used to instantiate
+    /// the binder without capturing existing variables.
     pub fn bounded_substitution<T>(&mut self, b: &Binder<T>) -> Vec<BoundVar>
     where
         T: Fold,
@@ -162,6 +202,12 @@ impl RustBuilder {
         })
     }
 
+    /// Creates a substitution that replaces the variables introduced by the
+    /// binder `b` with fresh existential variables.
+    ///
+    /// Each binder parameter is mapped to a new [`ExistentialVar`] with a fresh
+    /// variable index. The resulting substitution can be used to instantiate
+    /// the binder without capturing existing variables.
     pub fn existential_substitution<T>(&mut self, b: &Binder<T>) -> Vec<ExistentialVar>
     where
         T: Fold,
@@ -169,6 +215,12 @@ impl RustBuilder {
         self.substitution(b, |kind, var_index| ExistentialVar { kind, var_index })
     }
 
+    /// Creates a substitution that replaces the variables introduced by the
+    /// binder `b` with fresh universal variables.
+    ///
+    /// Each binder parameter is mapped to a new [`UniversalVar`] with a fresh
+    /// variable index. The resulting substitution can be used to instantiate
+    /// the binder without capturing existing variables.
     pub fn universal_substitution<T>(&mut self, b: &Binder<T>) -> Vec<UniversalVar>
     where
         T: Fold,
@@ -176,6 +228,11 @@ impl RustBuilder {
         self.substitution(b, |kind, var_index| UniversalVar { kind, var_index })
     }
 
+    /// Creates a fresh substitution for the given parameter kinds.
+    ///
+    /// For each entry in `kinds`, this function generates a fresh variable index
+    /// and invokes the callback `v` with the corresponding `ParameterKind` and
+    /// index. The collected results form the substitution in binder order.
     fn fresh_substitution<V>(
         &mut self,
         kinds: &[ParameterKind],

--- a/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
+++ b/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
@@ -6,38 +6,44 @@ use super::{syntax, RustBuilder};
 
 impl RustBuilder {
     pub fn lower_struct(&mut self, strukt: &Struct) -> Fallible<syntax::StructItem> {
-        self.with_binder(&strukt.binder, |term, pp| {
-            let generics =
-                pp.lower_generics_for_binder(strukt.binder.kinds(), &term.where_clauses, false)?;
-            let fields = term
-                .fields
-                .iter()
-                .map(|field| pp.lower_named_struct_field(field))
-                .collect::<Result<Vec<_>, _>>()?;
+        self.with_binder(
+            &strukt.binder,
+            false,
+            |term| &term.where_clauses,
+            |term, generics, pp| {
+                let fields = term
+                    .fields
+                    .iter()
+                    .map(|field| pp.lower_named_struct_field(field))
+                    .collect::<Result<Vec<_>, _>>()?;
 
-            Ok(syntax::StructItem {
-                name: strukt.id.deref().clone(),
-                generics,
-                fields,
-            })
-        })
+                Ok(syntax::StructItem {
+                    name: strukt.id.deref().clone(),
+                    generics,
+                    fields,
+                })
+            },
+        )
     }
 
     pub fn lower_enum(&mut self, e: &Enum) -> Fallible<syntax::EnumItem> {
-        self.with_binder(&e.binder, |term, pp| {
-            let generics =
-                pp.lower_generics_for_binder(e.binder.kinds(), &term.where_clauses, false)?;
-            let variants = term
-                .variants
-                .iter()
-                .map(|variant| pp.lower_variant(variant))
-                .collect::<Result<Vec<_>, _>>()?;
-            Ok(syntax::EnumItem {
-                name: e.id.deref().clone(),
-                generics,
-                variants,
-            })
-        })
+        self.with_binder(
+            &e.binder,
+            false,
+            |term| &term.where_clauses,
+            |term, generics, pp| {
+                let variants = term
+                    .variants
+                    .iter()
+                    .map(|variant| pp.lower_variant(variant))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(syntax::EnumItem {
+                    name: e.id.deref().clone(),
+                    generics,
+                    variants,
+                })
+            },
+        )
     }
 
     fn lower_variant(&mut self, variant: &Variant) -> Fallible<syntax::EnumVariant> {

--- a/crates/formality-rust/src/to_rust/syntax.rs
+++ b/crates/formality-rust/src/to_rust/syntax.rs
@@ -84,9 +84,9 @@ pub struct Generics {
     /// by `impl` blocks.
     ///
     /// # Example
-    /// ```rust,ignore
-    /// struct<T> Foo {
-    ///     /* */
+    /// ```rust,no_run
+    /// struct Foo<T> {
+    ///     bar: T
     /// }
     /// ```
     pub params: Vec<GenericParam>,
@@ -128,9 +128,9 @@ impl Generics {
 /// Represents the generic parameters declared on an item.
 ///
 /// # Example
-/// ```rust,ignore
+/// ```rust,no_run
 /// struct Foo<T> {
-///     /* */
+///     bar: T
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -153,8 +153,9 @@ impl Display for GenericParam {
 /// Represents a concrete argument supplied for a generic parameter.
 ///
 /// # Example
-/// ```rust,ignore
-/// let foo = Foo::<u32> { /* */ }
+/// ```rust,no_run
+/// # struct Foo<T> { bar: T }
+/// let foo = Foo::<u32> { bar: 0 };
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GenericArg {

--- a/crates/formality-rust/src/to_rust/traits_and_impls.rs
+++ b/crates/formality-rust/src/to_rust/traits_and_impls.rs
@@ -11,150 +11,158 @@ use super::{syntax, RustBuilder};
 impl RustBuilder {
     pub fn lower_trait(&mut self, t: &Trait) -> Fallible<syntax::TraitItem> {
         // NOTE: Is this right with explicit binder?
-        self.with_binder(&t.binder.explicit_binder, |term, pp| {
-            let generics = pp.lower_generics_for_binder(
-                t.binder.explicit_binder.kinds(),
-                &term.where_clauses,
-                true,
-            )?;
-
-            let mut items = Vec::new();
-            for item in &term.trait_items {
-                match item {
-                    TraitItem::Fn(f) => items.push(syntax::TraitMember::Function(pp.lower_fn(f)?)),
-                    TraitItem::AssociatedTy(assoc_ty) => items.push(
-                        syntax::TraitMember::AssociatedType(pp.lower_assoc_ty(assoc_ty)?),
-                    ),
+        self.with_binder(
+            &t.binder.explicit_binder,
+            true,
+            |term| &term.where_clauses,
+            |term, generics, pp| {
+                let mut items = Vec::new();
+                for item in &term.trait_items {
+                    match item {
+                        TraitItem::Fn(f) => {
+                            items.push(syntax::TraitMember::Function(pp.lower_fn(f)?))
+                        }
+                        TraitItem::AssociatedTy(assoc_ty) => items.push(
+                            syntax::TraitMember::AssociatedType(pp.lower_assoc_ty(assoc_ty)?),
+                        ),
+                    }
                 }
-            }
 
-            Ok(syntax::TraitItem {
-                is_unsafe: matches!(t.safety, Safety::Unsafe),
-                name: t.id.deref().clone(),
-                generics,
-                items,
-            })
-        })
+                Ok(syntax::TraitItem {
+                    is_unsafe: matches!(t.safety, Safety::Unsafe),
+                    name: t.id.deref().clone(),
+                    generics,
+                    items,
+                })
+            },
+        )
     }
 
     pub fn lower_trait_impl(&mut self, trait_impl: &TraitImpl) -> Fallible<syntax::ImplItem> {
-        self.with_binder(&trait_impl.binder, |term, pp| {
-            let mut items = Vec::new();
-            for item in &term.impl_items {
-                match item {
-                    ImplItem::Fn(f) => items.push(syntax::ImplMember::Function(pp.lower_fn(f)?)),
-                    ImplItem::AssociatedTyValue(v) => {
-                        items.push(syntax::ImplMember::AssociatedTypeValue(
-                            pp.lower_assoc_ty_value(v)?,
-                        ));
+        self.with_binder(
+            &trait_impl.binder,
+            false,
+            |term| &term.where_clauses,
+            |term, generics, pp| {
+                let mut items = Vec::new();
+                for item in &term.impl_items {
+                    match item {
+                        ImplItem::Fn(f) => {
+                            items.push(syntax::ImplMember::Function(pp.lower_fn(f)?))
+                        }
+                        ImplItem::AssociatedTyValue(v) => {
+                            items.push(syntax::ImplMember::AssociatedTypeValue(
+                                pp.lower_assoc_ty_value(v)?,
+                            ));
+                        }
                     }
                 }
-            }
 
-            let generics = pp.lower_generics_for_binder(
-                trait_impl.binder.kinds(),
-                &term.where_clauses,
-                false,
-            )?;
-            let trait_args = term
-                .trait_parameters
-                .iter()
-                .map(|arg| pp.lower_generic_arg(arg))
-                .collect::<Result<Vec<_>, _>>()?;
-            let self_ty = pp.lower_ty(&term.self_ty)?;
+                let trait_args = term
+                    .trait_parameters
+                    .iter()
+                    .map(|arg| pp.lower_generic_arg(arg))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let self_ty = pp.lower_ty(&term.self_ty)?;
 
-            Ok(syntax::ImplItem {
-                is_unsafe: matches!(trait_impl.safety, Safety::Unsafe),
-                generics,
-                trait_name: term.trait_id.deref().clone(),
-                trait_args,
-                self_ty,
-                items,
-            })
-        })
+                Ok(syntax::ImplItem {
+                    is_unsafe: matches!(trait_impl.safety, Safety::Unsafe),
+                    generics,
+                    trait_name: term.trait_id.deref().clone(),
+                    trait_args,
+                    self_ty,
+                    items,
+                })
+            },
+        )
     }
 
     pub fn lower_neg_trait_impl(
         &mut self,
         neg_trait_impl: &NegTraitImpl,
     ) -> Fallible<syntax::NegImplItem> {
-        self.with_binder(&neg_trait_impl.binder, |term, pp| {
-            let generics = pp.lower_generics_for_binder(
-                neg_trait_impl.binder.kinds(),
-                &term.where_clauses,
-                false,
-            )?;
-            let trait_args = term
-                .trait_parameters
-                .iter()
-                .map(|arg| pp.lower_generic_arg(arg))
-                .collect::<Result<Vec<_>, _>>()?;
-            let self_ty = pp.lower_ty(&term.self_ty)?;
-            let where_clauses = pp.lower_where_clauses(&term.where_clauses)?;
+        self.with_binder(
+            &neg_trait_impl.binder,
+            false,
+            |term| &term.where_clauses,
+            |term, generics, pp| {
+                let trait_args = term
+                    .trait_parameters
+                    .iter()
+                    .map(|arg| pp.lower_generic_arg(arg))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let self_ty = pp.lower_ty(&term.self_ty)?;
+                let where_clauses = pp.lower_where_clauses(&term.where_clauses)?;
 
-            Ok(syntax::NegImplItem {
-                is_unsafe: matches!(neg_trait_impl.safety, Safety::Unsafe),
-                generics,
-                trait_name: term.trait_id.deref().clone(),
-                trait_args,
-                self_ty,
-                where_clauses,
-            })
-        })
+                Ok(syntax::NegImplItem {
+                    is_unsafe: matches!(neg_trait_impl.safety, Safety::Unsafe),
+                    generics,
+                    trait_name: term.trait_id.deref().clone(),
+                    trait_args,
+                    self_ty,
+                    where_clauses,
+                })
+            },
+        )
     }
 
     fn lower_assoc_ty(&mut self, assoc_ty: &AssociatedTy) -> Fallible<syntax::AssociatedTypeItem> {
-        self.with_binder(&assoc_ty.binder, |term, pp| {
-            let mut bounds = Vec::new();
-            for ensure in &term.ensures {
-                match ensure.data() {
-                    WhereBoundData::IsImplemented(trait_id, parameters) => {
-                        bounds.push(syntax::TypeBound::Trait {
-                            trait_name: trait_id.deref().clone(),
-                            args: parameters
-                                .iter()
-                                .map(|arg| pp.lower_generic_arg(arg))
-                                .collect::<Result<Vec<_>, _>>()?,
-                        });
-                    }
-                    WhereBoundData::Outlives(_) => {
-                        anyhow::bail!(
-                            "lowering associated type outlives bounds is not implemented yet"
-                        )
-                    }
-                    WhereBoundData::ForAll(_) => {
-                        anyhow::bail!(
-                            "lowering associated type `for` bounds is not implemented yet"
-                        )
+        self.with_binder(
+            &assoc_ty.binder,
+            false,
+            |term| &term.where_clauses,
+            |term, generics, pp| {
+                let mut bounds = Vec::new();
+                for ensure in &term.ensures {
+                    match ensure.data() {
+                        WhereBoundData::IsImplemented(trait_id, parameters) => {
+                            bounds.push(syntax::TypeBound::Trait {
+                                trait_name: trait_id.deref().clone(),
+                                args: parameters
+                                    .iter()
+                                    .map(|arg| pp.lower_generic_arg(arg))
+                                    .collect::<Result<Vec<_>, _>>()?,
+                            });
+                        }
+                        WhereBoundData::Outlives(_) => {
+                            anyhow::bail!(
+                                "lowering associated type outlives bounds is not implemented yet"
+                            )
+                        }
+                        WhereBoundData::ForAll(_) => {
+                            anyhow::bail!(
+                                "lowering associated type `for` bounds is not implemented yet"
+                            )
+                        }
                     }
                 }
-            }
 
-            let generics =
-                pp.lower_generics_for_binder(assoc_ty.binder.kinds(), &term.where_clauses, false)?;
-
-            Ok(syntax::AssociatedTypeItem {
-                name: assoc_ty.id.deref().clone(),
-                generics,
-                bounds,
-            })
-        })
+                Ok(syntax::AssociatedTypeItem {
+                    name: assoc_ty.id.deref().clone(),
+                    generics,
+                    bounds,
+                })
+            },
+        )
     }
 
     fn lower_assoc_ty_value(
         &mut self,
         assoc_ty: &AssociatedTyValue,
     ) -> Fallible<syntax::AssociatedTypeValueItem> {
-        self.with_binder(&assoc_ty.binder, |term, pp| {
-            let generics =
-                pp.lower_generics_for_binder(assoc_ty.binder.kinds(), &term.where_clauses, false)?;
-            let ty = pp.lower_ty(&term.ty)?;
-            Ok(syntax::AssociatedTypeValueItem {
-                name: assoc_ty.id.deref().clone(),
-                generics,
-                ty,
-            })
-        })
+        self.with_binder(
+            &assoc_ty.binder,
+            false,
+            |term| &term.where_clauses,
+            |term, generics, pp| {
+                let ty = pp.lower_ty(&term.ty)?;
+                Ok(syntax::AssociatedTypeValueItem {
+                    name: assoc_ty.id.deref().clone(),
+                    generics,
+                    ty,
+                })
+            },
+        )
     }
 }
 
@@ -212,7 +220,7 @@ trait Write {
             ],
             r#"
 trait Write {
-    type Error<T2, T3>: Sized + Bar where T2: Read, T3: Write;
+    type Error<T1, T2>: Sized + Bar where T1: Read, T2: Write;
     fn test() -> i32;
 }
 "#
@@ -242,13 +250,13 @@ trait Bar<T2> where T2: Baz { }
             [
                 crate Foo {
                     trait Baz<T, K> { }
-                    trait Bar<T> where T: Baz<i32, u8> {}
+                    trait Bar<V> where V: Baz<i32, u8> {}
                 }
             ],
             "
-trait Baz<T2, T3> { }
+trait Baz<T1, T2> { }
 
-trait Bar<T2> where T2: Baz<i32, u8> { }
+trait Bar<T4> where T4: Baz<i32, u8> { }
 "
         );
     }
@@ -304,16 +312,16 @@ trait Bar<T2> where T2: Baz {
                 }
             ],
             r#"
-trait Bar<T2> {
-    fn run() -> T2;
+trait Bar<T1> {
+    fn run() -> T1;
 }
 
 trait Bur { }
 
 struct Baz {}
 
-impl<T1> Bar<T1> for Baz where T1: Bur {
-    fn run() -> T1 {
+impl<T3> Bar<T3> for Baz where T3: Bur {
+    fn run() -> T3 {
         panic!("Trusted Fn Body")
     }
 }"#

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use crate::grammar::{
     Const, ConstData, Fallible, Lt, LtData, Parameter, Parameters, PtrKind, RefKind, RigidName,
-    RigidTy, ScalarId, ScalarValue, Ty, TyData,
+    RigidTy, ScalarId, ScalarValue, Ty,
 };
 
 use super::{syntax, RustBuilder};
@@ -54,12 +54,12 @@ impl RustBuilder {
 
     pub fn lower_ty(&mut self, ty: &Ty) -> Fallible<syntax::Type> {
         match ty {
-            TyData::RigidTy(rigid_ty) => self.lower_rigid_ty(&rigid_ty),
-            TyData::AliasTy(_) => todo!("lowering alias types is not implemented yet"),
-            TyData::PredicateTy(_) => {
+            Ty::RigidTy(rigid_ty) => self.lower_rigid_ty(&rigid_ty),
+            Ty::AliasTy(_) => todo!("lowering alias types is not implemented yet"),
+            Ty::PredicateTy(_) => {
                 todo!("lowering predicate types is not implemented yet")
             }
-            TyData::Variable(core_variable) => Ok(syntax::Type::Path {
+            Ty::Variable(core_variable) => Ok(syntax::Type::Path {
                 name: self.core_variable_to_string(&core_variable)?,
                 args: Vec::new(),
             }),

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use crate::grammar::{
     Const, ConstData, Fallible, Lt, LtData, Parameter, Parameters, PtrKind, RefKind, RigidName,
-    RigidTy, ScalarId, ScalarValue, Ty,
+    RigidTy, ScalarId, ScalarValue, Ty, Variable,
 };
 
 use super::{syntax, RustBuilder};
@@ -116,7 +116,7 @@ impl RustBuilder {
         let lifetime = parameters
             .first()
             .and_then(|p| match p {
-                Parameter::Lt(lt) => Some(lt),
+                Parameter::Lt(lt) => Some(lt.deref().clone()),
                 _ => None,
             })
             .ok_or_else(|| anyhow::anyhow!("reference type is missing lifetime argument"))?;
@@ -129,11 +129,14 @@ impl RustBuilder {
             })
             .ok_or_else(|| anyhow::anyhow!("reference type is missing pointee type argument"))?;
 
-        let lifetime = self.lower_lt(lifetime)?;
+        let lifetime = match &lifetime {
+            Lt::Variable(Variable::ExistentialVar(_)) => None,
+            _ => Some(self.lower_lt(&lifetime)?),
+        };
         let pointee = self.lower_ty(pointee)?;
 
         Ok(syntax::Type::Ref {
-            lifetime: Some(lifetime),
+            lifetime,
             mutable: matches!(ref_kind, RefKind::Mut),
             ty: Box::new(pointee),
         })
@@ -213,98 +216,53 @@ impl RustBuilder {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        grammar::{AdtId, BoundVar, DebruijnIndex, ParameterKind, VarIndex, Variable},
-        to_rust::NameContext,
-    };
+    use crate::grammar::{AdtId, BoundVar, ExistentialVar, VarIndex, Variable};
 
     use super::*;
 
-    fn create_ty() -> Variable {
+    fn create_ty(index: usize) -> Variable {
         Variable::BoundVar(BoundVar {
-            debruijn: Some(DebruijnIndex { index: 0 }),
-            var_index: VarIndex { index: 0 },
+            debruijn: None,
+            var_index: VarIndex { index },
             kind: crate::grammar::ParameterKind::Ty,
         })
     }
 
-    fn create_lt() -> Variable {
+    fn create_lt(index: usize) -> Variable {
         Variable::BoundVar(BoundVar {
-            debruijn: Some(DebruijnIndex { index: 0 }),
-            var_index: VarIndex { index: 0 },
+            debruijn: None,
+            var_index: VarIndex { index },
             kind: crate::grammar::ParameterKind::Lt,
         })
     }
 
-    fn create_const() -> Variable {
+    fn create_const(index: usize) -> Variable {
         Variable::BoundVar(BoundVar {
-            debruijn: Some(DebruijnIndex { index: 0 }),
-            var_index: VarIndex { index: 0 },
+            debruijn: None,
+            var_index: VarIndex { index },
             kind: crate::grammar::ParameterKind::Const,
         })
     }
 
     #[test]
     fn pretty_print_type_variables() {
-        let mut ctx = NameContext::default();
-
-        ctx.push(&[ParameterKind::Ty]);
-        let ty1 = create_ty();
-
-        assert_eq!("T1", ctx.core_variable_to_string(&ty1).unwrap());
-
-        {
-            ctx.push(&[ParameterKind::Ty]);
-            let ty1 = ty1.shift_in();
-            let ty2 = create_ty();
-            assert_eq!("T1", ctx.core_variable_to_string(&ty1).unwrap());
-            assert_eq!("T2", ctx.core_variable_to_string(&ty2).unwrap());
-            ctx.pop();
-        }
-
-        assert_eq!("T1", ctx.core_variable_to_string(&ty1).unwrap());
+        let b = RustBuilder::default();
+        let ty1 = create_ty(1);
+        assert_eq!("T1", b.core_variable_to_string(&ty1).unwrap());
     }
 
     #[test]
     fn pretty_print_life_time_variables() {
-        let mut ctx = NameContext::default();
-
-        ctx.push(&[ParameterKind::Lt]);
-        let lt1 = create_lt();
-
-        assert_eq!("'a1", ctx.core_variable_to_string(&lt1).unwrap());
-
-        {
-            ctx.push(&[ParameterKind::Lt]);
-            let lt1 = lt1.shift_in();
-            let lt2 = create_lt();
-            assert_eq!("'a1", ctx.core_variable_to_string(&lt1).unwrap());
-            assert_eq!("'a2", ctx.core_variable_to_string(&lt2).unwrap());
-            ctx.pop();
-        }
-
-        assert_eq!("'a1", ctx.core_variable_to_string(&lt1).unwrap());
+        let b = RustBuilder::default();
+        let lt1 = create_lt(1);
+        assert_eq!("'a1", b.core_variable_to_string(&lt1).unwrap());
     }
 
     #[test]
     fn pretty_print_const_variables() {
-        let mut ctx = NameContext::default();
-
-        ctx.push(&[ParameterKind::Const]);
-        let const1 = create_const();
-
-        assert_eq!("N1", ctx.core_variable_to_string(&const1).unwrap());
-
-        {
-            ctx.push(&[ParameterKind::Const]);
-            let const1 = const1.shift_in();
-            let const2 = create_const();
-            assert_eq!("N1", ctx.core_variable_to_string(&const1).unwrap());
-            assert_eq!("N2", ctx.core_variable_to_string(&const2).unwrap());
-            ctx.pop();
-        }
-
-        assert_eq!("N1", ctx.core_variable_to_string(&const1).unwrap());
+        let b = RustBuilder::default();
+        let const1 = create_const(1);
+        assert_eq!("N1", b.core_variable_to_string(&const1).unwrap());
     }
 
     #[test]
@@ -332,14 +290,12 @@ mod test {
     }
 
     #[test]
-    fn pretty_print_ref() {
+    fn pretty_print_shared_ref() {
         let mut pp = RustBuilder::default();
-        pp.ctx.push(&[ParameterKind::Lt]);
-
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Ref(RefKind::Shared),
             parameters: vec![
-                Parameter::Lt(Lt::Variable(create_lt()).into()),
+                Parameter::Lt(Lt::Variable(create_lt(1)).into()),
                 Parameter::Ty(
                     Ty::RigidTy(RigidTy {
                         name: RigidName::ScalarId(ScalarId::U8),
@@ -351,11 +307,15 @@ mod test {
         });
         let t = pp.lower_ty(&ty).unwrap().to_string();
         assert_eq!("&'a1 u8", t);
+    }
 
+    #[test]
+    fn pretty_print_mutable_ref() {
+        let mut pp = RustBuilder::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Ref(RefKind::Mut),
             parameters: vec![
-                Parameter::Lt(Lt::Variable(create_lt()).into()),
+                Parameter::Lt(Lt::Variable(create_lt(1)).into()),
                 Parameter::Ty(
                     Ty::RigidTy(RigidTy {
                         name: RigidName::ScalarId(ScalarId::U8),
@@ -367,7 +327,11 @@ mod test {
         });
         let t = pp.lower_ty(&ty).unwrap().to_string();
         assert_eq!("&'a1 mut u8", t);
+    }
 
+    #[test]
+    fn pretty_print_mutable_static_ref() {
+        let mut pp = RustBuilder::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Ref(RefKind::Mut),
             parameters: vec![
@@ -386,10 +350,34 @@ mod test {
     }
 
     #[test]
+    fn pretty_print_existential_ref() {
+        let mut pp = RustBuilder::default();
+        let ty = Ty::RigidTy(RigidTy {
+            name: RigidName::Ref(RefKind::Mut),
+            parameters: vec![
+                Parameter::Lt(
+                    Lt::Variable(Variable::ExistentialVar(ExistentialVar {
+                        kind: crate::grammar::ParameterKind::Lt,
+                        var_index: VarIndex { index: 0 },
+                    }))
+                    .into(),
+                ),
+                Parameter::Ty(
+                    Ty::RigidTy(RigidTy {
+                        name: RigidName::ScalarId(ScalarId::U8),
+                        parameters: Vec::new(),
+                    })
+                    .into(),
+                ),
+            ],
+        });
+        let t = pp.lower_ty(&ty).unwrap().to_string();
+        assert_eq!("&mut u8", t);
+    }
+
+    #[test]
     fn pretty_print_raw_ptr() {
         let mut pp = RustBuilder::default();
-        pp.ctx.push(&[ParameterKind::Lt]);
-
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Raw(PtrKind::Const),
             parameters: vec![Parameter::Ty(


### PR DESCRIPTION
## What does this PR do?

Lowers an `exists` statement. The newly introduced lifetimes e.g. `'r0`, are all treated as anonymous lifetimes `'_`.

```rust,ignore
exists<'r0> {
  let v2: &'r0 u32 = v1;
  return v2;
}
```
becomes:
```rust,ignore
{
  let v2: &'_ u32 = v1;
  return v2;
}
```
<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* No AI used.

**Confidence level.**

* It seems reasonable to me, I'd like to know what others think



**Questions for reviewers.**

* Is using `'_` for an existential variable the right choice?

</details>
