### PR TITLE
Lower named blocks and fix mutability of function parameters

### DIFF
--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -205,8 +205,28 @@ mod test {
 fn foo() -> u32 {
     let mut x: u32;
     return x;
-}
-"#
+}"#
+        );
+    }
+
+    #[test]
+    fn fn_with_named_block() {
+        crate::assert_rust!(
+            [
+                crate Foo {
+                    fn foo() -> () {
+                        'a: {
+                            break 'a;
+                        }
+                    }
+                }
+            ],
+            r#"
+fn foo() -> () {
+    'a: {
+        break 'a;
+    }
+}"#
         );
     }
 }

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -9,12 +9,13 @@ use super::{syntax, RustBuilder};
 
 impl RustBuilder {
     pub fn lower_block(&mut self, block: &Block) -> Fallible<syntax::Block> {
+        let label = block.label.as_ref().map(|l| l.id.as_str().to_owned());
         let stmts = block
             .stmts
             .iter()
             .map(|stmt| self.lower_stmt(stmt))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(syntax::Block { stmts })
+        Ok(syntax::Block { label, stmts })
     }
 
     fn lower_stmt(&mut self, stmt: &Stmt) -> Fallible<syntax::Stmt> {

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -54,6 +54,8 @@ impl RustBuilder {
 
     fn lower_fn_param(&mut self, arg: &InputArg) -> Fallible<syntax::FnParam> {
         Ok(syntax::FnParam {
+            // TODO: Is there a way to know if a variable must be mutable?
+            mutable: true,
             name: arg.id.deref().clone(),
             ty: self.lower_ty(&arg.ty)?,
         })

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -100,7 +100,7 @@ fn run() -> i32 {
                 }
             ],
             r#"
-fn run(p1: i32, p2: i32) -> i32 {
+fn run(mut p1: i32, mut p2: i32) -> i32 {
     panic!("Trusted Fn Body")
 }
 "#
@@ -116,7 +116,7 @@ fn run(p1: i32, p2: i32) -> i32 {
                 }
             ],
             r#"
-fn run<T1>(p1: T1) -> T1 {
+fn run<T1>(mut p1: T1) -> T1 {
     panic!("Trusted Fn Body")
 }
 "#
@@ -135,7 +135,7 @@ fn run<T1>(p1: T1) -> T1 {
             r#"
 trait Bar { }
 
-fn run<T1>(p1: T1) -> T1 where T1: Bar {
+fn run<T1>(mut p1: T1) -> T1 where T1: Bar {
     panic!("Trusted Fn Body")
 }
 "#

--- a/crates/formality-rust/src/to_rust/syntax.rs
+++ b/crates/formality-rust/src/to_rust/syntax.rs
@@ -425,6 +425,7 @@ pub enum VariantFields {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FnParam {
+    pub mutable: bool,
     pub name: String,
     pub ty: Type,
 }
@@ -461,6 +462,9 @@ impl Pretty for FunctionItem {
         for (index, param) in self.params.iter().enumerate() {
             if index > 0 {
                 f.write_str(", ")?;
+            }
+            if param.mutable {
+                f.write_str("mut ")?;
             }
             write!(f, "{}: {}", param.name, param.ty)?;
         }
@@ -678,11 +682,16 @@ impl Pretty for NegImplItem {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Block {
+    pub label: Option<String>,
     pub stmts: Vec<Stmt>,
 }
 
 impl Pretty for Block {
     fn fmt_pretty(&self, f: &mut Formatter<'_>, indent: usize) -> fmt::Result {
+        if let Some(label) = &self.label {
+            f.write_str(label)?;
+            f.write_str(": ")?;
+        }
         f.write_char('{')?;
 
         if !self.stmts.is_empty() {

--- a/src/test/functions.rs
+++ b/src/test/functions.rs
@@ -8,19 +8,19 @@ fn ok() {
         [
             crate Foo {
                 // fn simple_fn() {}
-                fn simple_fn() -> () trusted;
+                fn simple_fn() -> () { trusted }
 
                 // fn one_arg<T>(_: T) {}
-                fn one_arg<T>(v0: T) -> () trusted;
+                fn one_arg<T>(v0: T) -> () { trusted }
 
                 // fn one_ret<T>(_: T) {}
-                fn one_ret<T>() -> T trusted;
+                fn one_ret<T>() -> T { trusted }
 
                 // fn arg_ret<T, U>(_: T) -> U {}
-                fn arg_ret<T, U>(v0: T) -> U trusted;
+                fn arg_ret<T, U>(v0: T) -> U { trusted }
 
                 // fn multi_arg_ret<T, Y, U, I>(_: T, _: Y) -> (U, I) {}
-                fn multi_arg_ret<T, Y, U, I>(v0: T, v1: Y) -> (U, I) trusted;
+                fn multi_arg_ret<T, Y, U, I>(v0: T, v1: Y) -> (U, I) { trusted }
             }
         ]
     )
@@ -36,7 +36,7 @@ fn lifetime() {
                 fn one_lt_arg<'a, T>(v0: &'a T) -> ()
                 where
                     T: 'a, // FIXME(#202): Implied bounds should not have to be explicit
-                {trusted}
+                { trusted }
             }
         ]
     )

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -233,9 +233,9 @@ fn crate_with_duplicate_item_names() {
     crate::assert_err!(
         [
             crate core {
-                fn a() -> () trusted;
+                fn a() -> () { trusted }
 
-                fn a() -> () trusted;
+                fn a() -> () { trusted }
             }
         ]
 
@@ -250,7 +250,7 @@ fn crate_with_duplicate_item_names() {
             crate core {
                 trait a {}
 
-                fn a() -> () trusted;
+                fn a() -> () { trusted }
             }
         ]
     );


### PR DESCRIPTION
## What does this PR do?

Adds labels (e.g. `'outer:`) to blocks when converting from formality to Rust and fixes mutability issue in function parameters.
Further, update test cases to use `{ trusted }` instead of `trusted`.

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* No AI used

**Confidence level.**

* I am very happy with it


**Questions for reviewers.**

* None

</details>
