### PR TITLE
Flatten WhereClause/WhereClauseData and WhereBound/WhereBoundData into single enums

### DIFF
--- a/crates/formality-rust/src/grammar/traits_and_impls.rs
+++ b/crates/formality-rust/src/grammar/traits_and_impls.rs
@@ -124,64 +124,8 @@ pub struct AssociatedTyValueBoundData {
     pub ty: Ty,
 }
 
-#[term($data)]
-pub struct WhereClause {
-    pub data: Arc<WhereClauseData>,
-}
-
-impl WhereClause {
-    pub fn data(&self) -> &WhereClauseData {
-        &self.data
-    }
-
-    pub fn invert(&self) -> Option<Wc> {
-        match self.data() {
-            WhereClauseData::IsImplemented(self_ty, trait_id, parameters) => Some(
-                Predicate::not_implemented(trait_id.with(self_ty, parameters)),
-            )
-            .upcast(),
-            WhereClauseData::AliasEq(_, _) => None,
-            WhereClauseData::Outlives(_, _) => None,
-            WhereClauseData::ForAll(binder) => {
-                let (vars, where_clause) = binder.open();
-                let wc = where_clause.invert()?;
-                Some(Wc::for_all(Binder::new(&vars, wc)))
-            }
-            WhereClauseData::TypeOfConst(_, _) => None,
-        }
-    }
-
-    pub fn well_formed(&self) -> Wcs {
-        match self.data() {
-            WhereClauseData::IsImplemented(self_ty, trait_id, parameters) => {
-                Predicate::well_formed_trait_ref(trait_id.with(self_ty, parameters)).upcast()
-            }
-            WhereClauseData::AliasEq(alias_ty, ty) => {
-                [Relation::well_formed(alias_ty), Relation::well_formed(ty)]
-                    .into_iter()
-                    .collect()
-            }
-            WhereClauseData::Outlives(a, b) => [Relation::well_formed(a), Relation::well_formed(b)]
-                .into_iter()
-                .collect(),
-            WhereClauseData::ForAll(binder) => {
-                let (vars, body) = binder.open();
-                body.well_formed()
-                    .into_iter()
-                    .map(|wc| Wc::for_all(Binder::new(&vars, wc)))
-                    .collect()
-            }
-            WhereClauseData::TypeOfConst(ct, ty) => {
-                [Relation::well_formed(ct), Relation::well_formed(ty)]
-                    .into_iter()
-                    .collect()
-            }
-        }
-    }
-}
-
 #[term]
-pub enum WhereClauseData {
+pub enum WhereClause {
     #[grammar($v0 : $v1 $<?v2>)]
     IsImplemented(Ty, TraitId, Vec<Parameter>),
 
@@ -192,25 +136,64 @@ pub enum WhereClauseData {
     Outlives(Parameter, Lt),
 
     #[grammar(for $v0)]
-    ForAll(Binder<WhereClause>),
+    ForAll(Arc<Binder<WhereClause>>),
 
     #[grammar(type_of_const $v0 is $v1)]
     TypeOfConst(Const, Ty),
 }
 
-#[term($data)]
-pub struct WhereBound {
-    pub data: Arc<WhereBoundData>,
-}
+/// Temporary alias for migration -- allows `WhereClauseData::Variant` to still compile.
+pub type WhereClauseData = WhereClause;
 
-impl WhereBound {
-    pub fn data(&self) -> &WhereBoundData {
-        &self.data
+impl WhereClause {
+    pub fn invert(&self) -> Option<Wc> {
+        match self {
+            WhereClause::IsImplemented(self_ty, trait_id, parameters) => Some(
+                Predicate::not_implemented(trait_id.with(self_ty, parameters)),
+            )
+            .upcast(),
+            WhereClause::AliasEq(_, _) => None,
+            WhereClause::Outlives(_, _) => None,
+            WhereClause::ForAll(binder) => {
+                let (vars, where_clause) = binder.open();
+                let wc = where_clause.invert()?;
+                Some(Wc::for_all(Binder::new(&vars, wc)))
+            }
+            WhereClause::TypeOfConst(_, _) => None,
+        }
+    }
+
+    pub fn well_formed(&self) -> Wcs {
+        match self {
+            WhereClause::IsImplemented(self_ty, trait_id, parameters) => {
+                Predicate::well_formed_trait_ref(trait_id.with(self_ty, parameters)).upcast()
+            }
+            WhereClause::AliasEq(alias_ty, ty) => {
+                [Relation::well_formed(alias_ty), Relation::well_formed(ty)]
+                    .into_iter()
+                    .collect()
+            }
+            WhereClause::Outlives(a, b) => [Relation::well_formed(a), Relation::well_formed(b)]
+                .into_iter()
+                .collect(),
+            WhereClause::ForAll(binder) => {
+                let (vars, body) = binder.open();
+                body.well_formed()
+                    .into_iter()
+                    .map(|wc| Wc::for_all(Binder::new(&vars, wc)))
+                    .collect()
+            }
+            WhereClause::TypeOfConst(ct, ty) => {
+                [Relation::well_formed(ct), Relation::well_formed(ty)]
+                    .into_iter()
+                    .collect()
+            }
+        }
     }
 }
 
 #[term]
-pub enum WhereBoundData {
+pub enum WhereBound {
     #[grammar($v0 $<?v1>)]
     IsImplemented(TraitId, Vec<Parameter>),
 
@@ -218,5 +201,8 @@ pub enum WhereBoundData {
     Outlives(Lt),
 
     #[grammar(for $v0)]
-    ForAll(Binder<WhereBound>),
+    ForAll(Arc<Binder<WhereBound>>),
 }
+
+/// Temporary alias for migration -- allows `WhereBoundData::Variant` to still compile.
+pub type WhereBoundData = WhereBound;

--- a/crates/formality-rust/src/prove.rs
+++ b/crates/formality-rust/src/prove.rs
@@ -1,4 +1,4 @@
-use crate::grammar::{Crates, WhereBound, WhereBoundData, WhereClause, WhereClauseData};
+use crate::grammar::{Crates, WhereBound, WhereClause};
 use formality_core::Upcast;
 pub mod prove;
 use crate::grammar::{Binder, Predicate, Relation, Ty, Wc, Wcs};
@@ -90,22 +90,22 @@ impl ToWcs for [WhereClause] {
 
 impl ToWcs for WhereClause {
     fn to_wcs(&self) -> Wcs {
-        match self.data() {
-            WhereClauseData::IsImplemented(self_ty, trait_id, parameters) => {
+        match self {
+            WhereClause::IsImplemented(self_ty, trait_id, parameters) => {
                 trait_id.with(self_ty, parameters).upcast()
             }
-            WhereClauseData::AliasEq(alias_ty, ty) => {
+            WhereClause::AliasEq(alias_ty, ty) => {
                 Predicate::AliasEq(alias_ty.clone(), ty.clone()).upcast()
             }
-            WhereClauseData::Outlives(a, b) => Relation::outlives(a, b).upcast(),
-            WhereClauseData::ForAll(binder) => {
+            WhereClause::Outlives(a, b) => Relation::outlives(a, b).upcast(),
+            WhereClause::ForAll(binder) => {
                 let (vars, wc) = binder.open();
                 wc.to_wcs()
                     .into_iter()
                     .map(|wc| Wc::for_all(Binder::new(&vars, wc)))
                     .collect()
             }
-            WhereClauseData::TypeOfConst(ct, ty) => {
+            WhereClause::TypeOfConst(ct, ty) => {
                 Predicate::ConstHasType(ct.clone(), ty.clone()).upcast()
             }
         }
@@ -116,12 +116,12 @@ impl WhereBound {
     pub fn to_wc(&self, self_ty: impl Upcast<Ty>) -> Wc {
         let self_ty: Ty = self_ty.upcast();
 
-        match self.data() {
-            WhereBoundData::IsImplemented(trait_id, parameters) => {
+        match self {
+            WhereBound::IsImplemented(trait_id, parameters) => {
                 trait_id.with(self_ty, parameters).upcast()
             }
-            WhereBoundData::Outlives(lt) => Relation::outlives(self_ty, lt).upcast(),
-            WhereBoundData::ForAll(binder) => {
+            WhereBound::Outlives(lt) => Relation::outlives(self_ty, lt).upcast(),
+            WhereBound::ForAll(binder) => {
                 let (vars, bound) = binder.open();
                 Wc::for_all(Binder::new(&vars, bound.to_wc(self_ty)))
             }

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -332,7 +332,7 @@ impl RustBuilder {
             .collect();
 
         for wc in where_clauses {
-            match wc.data() {
+            match wc {
                 WhereClauseData::IsImplemented(ty, _, _) => {
                     if let Ty::Variable(var) = ty {
                         let name = self.core_variable_to_string(&var)?;
@@ -392,7 +392,7 @@ impl RustBuilder {
         let mut preds = Vec::new();
 
         for wc in where_clauses {
-            match wc.data() {
+            match wc {
                 WhereClauseData::IsImplemented(ty, trait_id, params) => {
                     preds.push(syntax::WhereClause::Trait {
                         ty: self.lower_ty(ty)?,

--- a/crates/formality-rust/src/to_rust/traits_and_impls.rs
+++ b/crates/formality-rust/src/to_rust/traits_and_impls.rs
@@ -114,7 +114,7 @@ impl RustBuilder {
             |term, generics, pp| {
                 let mut bounds = Vec::new();
                 for ensure in &term.ensures {
-                    match ensure.data() {
+                    match ensure {
                         WhereBoundData::IsImplemented(trait_id, parameters) => {
                             bounds.push(syntax::TypeBound::Trait {
                                 trait_name: trait_id.deref().clone(),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -25,9 +25,8 @@ fn parser() {
             × expected `:`
                ╭────
              1 │ [crate Foo { trait Baz where cake {} }]
-               · ▲▲▲          ▲▲        ▲▲    ▲▲   ▲
-               · │││          ││        ││    ││   ╰── expected `:`
-               · │││          ││        ││    │╰── while parsing WhereClauseData
+               · ▲▲▲          ▲▲        ▲▲    ▲    ▲
+               · │││          ││        ││    │    ╰── expected `:`
                · │││          ││        ││    ╰── while parsing WhereClause
                · │││          ││        │╰── while parsing TraitBoundData
                · │││          ││        ╰── while parsing TraitBinder


### PR DESCRIPTION
## What does this PR do?
Follows the #338 pattern: `WhereClause` and `WhereBound` are now single enums (no more `Foo { data: Arc<FooData> }` wrapper). `ForAll` variants hold `Arc<Binder<...>>`. Kept `WhereClauseData`/`WhereBoundData` as type aliases for migration. Snapshot regenerated.

Part of #318 

## How does it work, what questions do you have?
Okay so the wrapper struct existed to hold the enum behind an Arc so no variants or grammar were added, the existing ones still go over unchanged. The recursive ForAll still goes through the Arc Binder but it's just placed at the variant instead of wrapper. Then the snapshot losing one layer is expected with there being literally one fewer parser frame. Lastly,  the migration aliases mean existing FooData::Variant call sites keep meaning the same thing.

## AI disclosure

<!-- Remove the items that do not apply -->

* I used an AI to author the main logic of the code

