### PR TITLE
Flatten PlaceExpr/PlaceExprData into a single enum

### DIFF
--- a/book/src/formality_core/parse.md
+++ b/book/src/formality_core/parse.md
@@ -239,10 +239,10 @@ The default associativity is left, which can be written explicitly as `#[precede
 One thing precedence doesn't give you is user-controlled grouping. In a real expression grammar you'd want to write `(a + b) * c` to override the default precedence. Formality doesn't currently handle this automatically. You have to add an explicit `Parens` variant to your grammar:
 
 ```rust
-{{#include ../../../crates/formality-rust/src/grammar/expr/mod.rs:PlaceExprData}}
+{{#include ../../../crates/formality-rust/src/grammar/expr/mod.rs:PlaceExpr}}
 ```
 
-Here `PlaceExprData` has a prefix operator (`* expr`) and a postfix operator (`expr . field`). Without the `Parens` variant, there's no way to distinguish `*(x.field)` from `(*x).field`. Adding `#[grammar(($v0))] Parens(PlaceExpr)` lets the user write `(*x).field` to make the grouping explicit.
+Here `PlaceExpr` has a prefix operator (`* expr`) and a postfix operator (`expr . field`). Without the `Parens` variant, there's no way to distinguish `*(x.field)` from `(*x).field`. Adding `#[grammar(($v0))] Parens(PlaceExpr)` lets the user write `(*x).field` to make the grouping explicit.
 
 This is admittedly a bit awkward. Formality's design goal is that the type structure matches what you'd find in a paper, and `Parens` nodes are parser machinery, not semantics. We may improve this in the future.
 

--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -456,7 +456,7 @@ judgment_fn! {
         (
             // A bare function name used as a value (e.g., `foo` in `foo(args)`).
             // Only applies when `id` is NOT a local variable.
-            (if let PlaceExprData::Var(id) = place.data())
+            (if let PlaceExpr::Var(id) = place)
             (if !state.has_local(id))!
             (let fn_decl = env.crates().fn_named(id)?)
             (if fn_decl.binder.len() == 0)

--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -5,7 +5,7 @@ use crate::check::borrow_check::typed_place_expression::{
     TypedPlaceExpr, TypedPlaceExpressionData,
 };
 
-use crate::grammar::expr::{Block, Expr, ExprData, Init, PlaceExpr, PlaceExprData, Stmt};
+use crate::grammar::expr::{Block, Expr, ExprData, Init, PlaceExpr, Stmt};
 use crate::grammar::{
     AliasTy, ExistentialVar, FieldName, Fn, Lt, Parameter, RefKind, Relation, RigidName, RigidTy,
     ScalarId, Struct, StructBoundData, TraitId, Ty, TyData, Variable, Wcs, WhereClause,
@@ -558,7 +558,7 @@ judgment_fn! {
         (
             (let ty = state.local_variable(&local_id)?)
             ------------------------------------------------------------ ("local")
-            (borrow_check_place_expr(_env, _assumptions, state, PlaceExprData::Var(local_id)) => (
+            (borrow_check_place_expr(_env, _assumptions, state, PlaceExpr::Var(local_id)) => (
                 TypedPlaceExpr::new(ty, TypedPlaceExpressionData::local(local_id)),
                 state,
             ))
@@ -573,7 +573,7 @@ judgment_fn! {
             (field in fields)
             (if field.name == *field_name)
             ------------------------------------------------------------ ("struct field")
-            (borrow_check_place_expr(env, assumptions, state, PlaceExprData::Field { prefix, field_name }) => (
+            (borrow_check_place_expr(env, assumptions, state, PlaceExpr::Field { prefix, field_name }) => (
                 TypedPlaceExpr::new(&field.ty, TypedPlaceExpressionData::field(prefix_typed, field_name)),
                 state,
             ))
@@ -585,7 +585,7 @@ judgment_fn! {
             (if field_index < arity)
             (if let Parameter::Ty(field_ty) = &parameters[*field_index])
             ------------------------------------------------------------ ("tuple field")
-            (borrow_check_place_expr(env, assumptions, state, PlaceExprData::Field { prefix, field_name: FieldName::Index(field_index) }) => (
+            (borrow_check_place_expr(env, assumptions, state, PlaceExpr::Field { prefix, field_name: FieldName::Index(field_index) }) => (
                 TypedPlaceExpr::new(field_ty, TypedPlaceExpressionData::field(prefix_typed, field_index)),
                 state,
             ))
@@ -594,7 +594,7 @@ judgment_fn! {
         (
             (borrow_check_place_expr(env, assumptions, state, place) => (place_typed, state))
             ------------------------------------------------------------ ("parens")
-            (borrow_check_place_expr(env, assumptions, state, PlaceExprData::Parens(place)) => (place_typed, state))
+            (borrow_check_place_expr(env, assumptions, state, PlaceExpr::Parens(place)) => (place_typed, state))
         )
 
         (
@@ -603,7 +603,7 @@ judgment_fn! {
             (prove_ty_is_rigid(env, assumptions, state, &prefix_typed.ty) => (RigidTy { name: RigidName::Ref(_ref_kind), parameters }, state))
             (if let Parameter::Ty(referent_ty) = &parameters[1])
             ------------------------------------------------------------ ("deref-ref")
-            (borrow_check_place_expr(env, assumptions, state, PlaceExprData::Deref { prefix }) => (
+            (borrow_check_place_expr(env, assumptions, state, PlaceExpr::Deref { prefix }) => (
                 TypedPlaceExpr::new(referent_ty, TypedPlaceExpressionData::deref(prefix_typed)),
                 state,
             ))

--- a/crates/formality-rust/src/check/borrow_check/typed_place_expression.rs
+++ b/crates/formality-rust/src/check/borrow_check/typed_place_expression.rs
@@ -1,8 +1,5 @@
-use crate::grammar::{
-    expr::{PlaceExpr, PlaceExprData},
-    FieldName, Ty, ValueId,
-};
-use formality_core::{cast_impl, term, DowncastTo, Upcast};
+use crate::grammar::{expr::PlaceExpr, FieldName, Ty, ValueId};
+use formality_core::{cast_impl, term, DowncastTo};
 use std::sync::Arc;
 
 #[term($data: $ty)]
@@ -42,12 +39,10 @@ impl TypedPlaceExpr {
     /// Convert to an untyped PlaceExpression
     pub fn to_place_expression(&self) -> PlaceExpr {
         match self.data() {
-            TypedPlaceExpressionData::Local(id) => PlaceExprData::var(id).upcast(),
-            TypedPlaceExpressionData::Deref(inner) => {
-                PlaceExprData::deref(inner.to_place_expression()).upcast()
-            }
+            TypedPlaceExpressionData::Local(id) => PlaceExpr::var(id),
+            TypedPlaceExpressionData::Deref(inner) => PlaceExpr::deref(inner.to_place_expression()),
             TypedPlaceExpressionData::Field(root, field) => {
-                PlaceExprData::field(root.to_place_expression(), field).upcast()
+                PlaceExpr::field(root.to_place_expression(), field)
             }
         }
     }

--- a/crates/formality-rust/src/grammar/expr/codegen.rs
+++ b/crates/formality-rust/src/grammar/expr/codegen.rs
@@ -10,7 +10,7 @@ use crate::grammar::{
     Crates, Fallible, PredicateTy, RigidName, ScalarId, Ty, TyData,
 };
 
-use super::{ExprData, PlaceExprData};
+use super::ExprData;
 
 struct ExprBuilder<'b> {
     program: &'b Crates,
@@ -136,14 +136,14 @@ impl ExprBuilder<'_> {
     }
 
     pub fn codegen_place_expr(&mut self, expr: &PlaceExpr) -> Fallible<lang::PlaceExpr> {
-        match expr.data() {
-            PlaceExprData::Var(id) => Ok(lang::PlaceExpr::Local(self.lookup_variable(id)?)),
-            PlaceExprData::Parens(inner) => self.codegen_place_expr(inner),
-            PlaceExprData::Deref { prefix: _ } => {
+        match expr {
+            PlaceExpr::Var(id) => Ok(lang::PlaceExpr::Local(self.lookup_variable(id)?)),
+            PlaceExpr::Parens(inner) => self.codegen_place_expr(inner),
+            PlaceExpr::Deref { prefix: _ } => {
                 // Ok(lang::PlaceExpr::Deref { operand: (), ty: () }}
                 unimplemented!("deref expression")
             }
-            PlaceExprData::Field {
+            PlaceExpr::Field {
                 prefix: expr,
                 field_name: field,
             } => {

--- a/crates/formality-rust/src/grammar/expr/mod.rs
+++ b/crates/formality-rust/src/grammar/expr/mod.rs
@@ -212,8 +212,6 @@ pub enum PlaceExpr {
 }
 // ANCHOR_END: PlaceExpr
 
-pub type PlaceExprData = PlaceExpr;
-
 impl PlaceExpr {
     pub fn is_prefix_of(&self, other: &PlaceExpr) -> bool {
         other.all_prefixes().contains(&self)

--- a/crates/formality-rust/src/grammar/expr/mod.rs
+++ b/crates/formality-rust/src/grammar/expr/mod.rs
@@ -2,7 +2,7 @@ mod codegen;
 
 use std::sync::Arc;
 
-use formality_core::{cast_impl, id, term, DowncastTo, UpcastFrom};
+use formality_core::{id, term, DowncastTo};
 
 use crate::grammar::{
     AdtId, Binder, FieldName, Lt, Parameter, RefKind, ScalarId, TraitId, Ty, ValueId,
@@ -177,16 +177,44 @@ impl DowncastTo<ExprData> for Expr {
     }
 }
 
-#[term($data)]
-pub struct PlaceExpr {
-    pub data: Arc<PlaceExprData>,
+// ANCHOR: PlaceExpr
+#[term]
+pub enum PlaceExpr {
+    /// `x`
+    ///
+    /// A variable reference. Whether this is a place (lvalue) or
+    /// value (rvalue) depends on context: place on the left of `=`
+    /// or as operand of `&`, value everywhere else.
+    #[cast]
+    Var(ValueId),
+
+    /// `* expr`
+    ///
+    /// Dereference. Like `Var`, place vs value depends on context.
+    #[grammar(* $prefix)]
+    Deref { prefix: Arc<PlaceExpr> },
+
+    /// `( expr )`
+    ///
+    /// Parenthesized expression, needed so users can write `(*x).field`.
+    #[grammar(($v0))]
+    Parens(Arc<PlaceExpr>),
+
+    /// `expr . field`
+    ///
+    /// Field projection. Like `Var`, place vs value depends on context.
+    #[grammar($prefix . $field_name)]
+    #[reject(PlaceExpr::Deref { .. }, _)]
+    Field {
+        prefix: Arc<PlaceExpr>,
+        field_name: FieldName,
+    },
 }
+// ANCHOR_END: PlaceExpr
+
+pub type PlaceExprData = PlaceExpr;
 
 impl PlaceExpr {
-    pub fn data(&self) -> &PlaceExprData {
-        &self.data
-    }
-
     pub fn is_prefix_of(&self, other: &PlaceExpr) -> bool {
         other.all_prefixes().contains(&self)
     }
@@ -202,68 +230,17 @@ impl PlaceExpr {
     }
 
     pub fn prefix(&self) -> Option<&PlaceExpr> {
-        match self.data() {
-            PlaceExprData::Var(_) => None,
-            PlaceExprData::Deref { prefix } => Some(prefix),
-            PlaceExprData::Field {
+        match self {
+            PlaceExpr::Var(_) => None,
+            PlaceExpr::Deref { prefix } => Some(prefix),
+            PlaceExpr::Field {
                 prefix,
                 field_name: _,
             } => Some(prefix),
-            PlaceExprData::Parens(place_expr) => Some(place_expr),
+            PlaceExpr::Parens(place_expr) => Some(place_expr),
         }
     }
 }
-
-impl UpcastFrom<PlaceExprData> for PlaceExpr {
-    fn upcast_from(data: PlaceExprData) -> Self {
-        PlaceExpr {
-            data: Arc::new(data),
-        }
-    }
-}
-
-impl DowncastTo<PlaceExprData> for PlaceExpr {
-    fn downcast_to(&self) -> Option<PlaceExprData> {
-        Some(PlaceExprData::clone(&self.data))
-    }
-}
-
-// ANCHOR: PlaceExprData
-#[term]
-pub enum PlaceExprData {
-    /// `x`
-    ///
-    /// A variable reference. Whether this is a place (lvalue) or
-    /// value (rvalue) depends on context: place on the left of `=`
-    /// or as operand of `&`, value everywhere else.
-    #[cast]
-    Var(ValueId),
-
-    /// `* expr`
-    ///
-    /// Dereference. Like `Var`, place vs value depends on context.
-    #[grammar(* $prefix)]
-    Deref { prefix: PlaceExpr },
-
-    /// `( expr )`
-    ///
-    /// Parenthesized expression, needed so users can write `(*x).field`.
-    #[grammar(($v0))]
-    Parens(PlaceExpr),
-
-    /// `expr . field`
-    ///
-    /// Field projection. Like `Var`, place vs value depends on context.
-    #[grammar($prefix . $field_name)]
-    #[reject(PlaceExprData::Deref { .. }, _)]
-    Field {
-        prefix: PlaceExpr,
-        field_name: FieldName,
-    },
-}
-// ANCHOR_END: PlaceExprData
-
-cast_impl!((ValueId) <: (PlaceExprData) <: (PlaceExpr));
 
 /// A named reference to a function or associated function.
 #[term($name: $value)]

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -191,45 +191,11 @@ fn test_parse_trusted_fn() {
 fn test_place_expr_ambiguity_deref_vs_field() {
     let p: PlaceExpr = term("*p.f");
     expect_test::expect![[r#"
-        PlaceExpr {
-            data: Deref {
-                prefix: PlaceExpr {
-                    data: Field {
-                        prefix: PlaceExpr {
-                            data: Var(
-                                p,
-                            ),
-                        },
-                        field_name: Id(
-                            f,
-                        ),
-                    },
-                },
-            },
-        }
-    "#]]
-    .assert_debug_eq(&p);
-}
-
-#[test]
-fn test_place_expr_parens_override() {
-    let p: PlaceExpr = term("(*p).f");
-    expect_test::expect![[r#"
-        PlaceExpr {
-            data: Field {
-                prefix: PlaceExpr {
-                    data: Parens(
-                        PlaceExpr {
-                            data: Deref {
-                                prefix: PlaceExpr {
-                                    data: Var(
-                                        p,
-                                    ),
-                                },
-                            },
-                        },
-                    ),
-                },
+        Deref {
+            prefix: Field {
+                prefix: Var(
+                    p,
+                ),
                 field_name: Id(
                     f,
                 ),
@@ -240,27 +206,41 @@ fn test_place_expr_parens_override() {
 }
 
 #[test]
+fn test_place_expr_parens_override() {
+    let p: PlaceExpr = term("(*p).f");
+    expect_test::expect![[r#"
+        Field {
+            prefix: Parens(
+                Deref {
+                    prefix: Var(
+                        p,
+                    ),
+                },
+            ),
+            field_name: Id(
+                f,
+            ),
+        }
+    "#]]
+    .assert_debug_eq(&p);
+}
+
+#[test]
 fn test_place_expr_field_left_associativity() {
     let p: PlaceExpr = term("p.f.g");
     expect_test::expect![[r#"
-        PlaceExpr {
-            data: Field {
-                prefix: PlaceExpr {
-                    data: Field {
-                        prefix: PlaceExpr {
-                            data: Var(
-                                p,
-                            ),
-                        },
-                        field_name: Id(
-                            f,
-                        ),
-                    },
-                },
+        Field {
+            prefix: Field {
+                prefix: Var(
+                    p,
+                ),
                 field_name: Id(
-                    g,
+                    f,
                 ),
             },
+            field_name: Id(
+                g,
+            ),
         }
     "#]]
     .assert_debug_eq(&p);
@@ -270,27 +250,19 @@ fn test_place_expr_field_left_associativity() {
 fn test_place_expr_deref_with_field_chain() {
     let p: PlaceExpr = term("*p.f.g");
     expect_test::expect![[r#"
-        PlaceExpr {
-            data: Deref {
-                prefix: PlaceExpr {
-                    data: Field {
-                        prefix: PlaceExpr {
-                            data: Field {
-                                prefix: PlaceExpr {
-                                    data: Var(
-                                        p,
-                                    ),
-                                },
-                                field_name: Id(
-                                    f,
-                                ),
-                            },
-                        },
-                        field_name: Id(
-                            g,
-                        ),
-                    },
+        Deref {
+            prefix: Field {
+                prefix: Field {
+                    prefix: Var(
+                        p,
+                    ),
+                    field_name: Id(
+                        f,
+                    ),
                 },
+                field_name: Id(
+                    g,
+                ),
             },
         }
     "#]]

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use crate::grammar::{
-    expr::{Block, Expr, ExprData, FieldExpr, Init, Label, PlaceExpr, PlaceExprData, Stmt},
+    expr::{Block, Expr, ExprData, FieldExpr, Init, Label, PlaceExpr, Stmt},
     Binder, Fallible, FieldName, RefKind, Ty, ValueId,
 };
 
@@ -156,15 +156,15 @@ impl RustBuilder {
     }
 
     pub fn lower_place_expr(&mut self, place_expr: &PlaceExpr) -> Fallible<syntax::PlaceExpr> {
-        match place_expr.data() {
-            PlaceExprData::Var(value_id) => Ok(syntax::PlaceExpr::Var(value_id.deref().clone())),
-            PlaceExprData::Deref { prefix } => Ok(syntax::PlaceExpr::Deref(Box::new(
+        match place_expr {
+            PlaceExpr::Var(value_id) => Ok(syntax::PlaceExpr::Var(value_id.deref().clone())),
+            PlaceExpr::Deref { prefix } => Ok(syntax::PlaceExpr::Deref(Box::new(
                 self.lower_place_expr(prefix)?,
             ))),
-            PlaceExprData::Parens(place_expr) => Ok(syntax::PlaceExpr::Paren(Box::new(
+            PlaceExpr::Parens(place_expr) => Ok(syntax::PlaceExpr::Paren(Box::new(
                 self.lower_place_expr(place_expr)?,
             ))),
-            PlaceExprData::Field { prefix, field_name } => Ok(syntax::PlaceExpr::Field {
+            PlaceExpr::Field { prefix, field_name } => Ok(syntax::PlaceExpr::Field {
                 prefix: Box::new(self.lower_place_expr(prefix)?),
                 field: match field_name {
                     FieldName::Id(id) => id.deref().clone(),


### PR DESCRIPTION
## What does this PR do?
Same pattern as #338 (Wc) and #353 (WhereClause): drop the wrapper struct, promote the enum to be the type, keep PlaceExprData as a migration alias. Recursive variants hold Arc<PlaceExpr> directly.

Part of #318 

## How does it work, what questions do you have?

After the flatten, the recursion is still broken by Arc, just placed on the recursive fields themselves. So sharing/cheap-clone behavior is preserved.
I kept pub type PlaceExprData = PlaceExpr as a migration alias so any code (or future PRs) that still says PlaceExprData::Var(..) continues to work. The methods (prefix, all_prefixes, is_prefix_of) moved straight onto the enum and now match on self directly instead of going through self.data().
Same pattern as #338 (Wc) and #353 (WhereClause), so I'm following an established shape and that's part of why I'm fairly confident it's correct. I will wait for this to be reviewed and merged before I start working on the flattening of Expr/ExprData which has a bigger blast radius than this current one.
Quick question:
 - Is the pub type PlaceExprData = PlaceExpr alias still wanted, or should I just rename all call sites in
  this PR? Since this leaves only Arc<T> as the remaining wrapper in the grammar, which I think is what unblocks the
  precedence-bug fix discussed in office hours.


## AI disclosure

<!-- Remove the items that do not apply -->
* I used an AI to author the main logic of the code

