### PR TITLE
Refactor `to_rust` module

### DIFF
--- a/crates/formality-rust/src/to_rust/context.rs
+++ b/crates/formality-rust/src/to_rust/context.rs
@@ -191,4 +191,4 @@ macro_rules! open_bounded {
         (term, generics)
     }};
 }
-pub(crate) use open_bounded; // <-- the trick
+pub(crate) use open_bounded;

--- a/crates/formality-rust/src/to_rust/context.rs
+++ b/crates/formality-rust/src/to_rust/context.rs
@@ -1,0 +1,182 @@
+use crate::{
+    grammar::{
+        Binder, BoundVar, ExistentialVar, Fallible, ParameterKind, UniversalVar, VarIndex,
+        Variable, WhereClause,
+    },
+    rust::Fold,
+    to_rust::{lower_generics_for_binder, syntax},
+};
+
+#[derive(Debug)]
+pub struct Context {
+    counter: VarIndex,
+}
+
+impl Context {
+    pub fn empty() -> Context {
+        Context::default()
+    }
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self {
+            counter: VarIndex { index: 0 },
+        }
+    }
+}
+
+impl Context {
+    /// Applies the operation `op` to the term contained within the binder `b`.
+    ///
+    /// The binder is instantiated with a fresh set of bound variables. Since a
+    /// binder introduces new generic variables, those variables are lowered at
+    /// this point and provided to the caller via the `syntax::Generics` argument
+    /// passed to `op`.
+    ///
+    /// The function `g` is used to extract the relevant `&[WhereClause]` clauses from the
+    /// instantiated term.
+    ///
+    /// When lowering generics for a trait declaration, `is_trait` must be set to
+    /// `true`. In this case, the implicit first generic parameter represents
+    /// `Self` and is therefore not treated as a regular generic parameter.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use formality_rust::grammar::{AdtId, Binder, Struct, StructBoundData, Fallible};
+    /// # use formality_rust::to_rust::{context::Context, syntax::StructItem};
+    /// fn lower_struct(term: Struct) -> Fallible<StructItem> {
+    ///     let mut ctx = Context::empty();
+    ///     ctx.with_binder(
+    ///         &term.binder,
+    ///         true,
+    ///         |term| &term.where_clauses,
+    ///         |term, generics, ctx| todo!(),
+    ///     )
+    /// }
+    /// ```
+    pub fn with_binder<T: Fold, R>(
+        &mut self,
+        b: &Binder<T>,
+        is_trait: bool,
+        g: impl Fn(&T) -> &[WhereClause],
+        mut op: impl FnMut(T, syntax::Generics, &mut Context) -> Fallible<R>,
+    ) -> Fallible<R> {
+        let subst = self.bounded_substitution(b);
+        let term = b.instantiate_with(&subst).expect("suitable substitution");
+
+        let names = subst
+            .into_iter()
+            .map(|var| format!("{}{}", self.kind_to_string(&var.kind), var.var_index.index))
+            .collect::<Vec<_>>();
+        let generics =
+            lower_generics_for_binder(self, b.kinds(), g(&term), names.as_slice(), is_trait)?;
+
+        let result = op(term, generics, self);
+        result
+    }
+
+    pub fn core_variable_to_string(&self, variable: &Variable) -> Fallible<String> {
+        let index = match variable {
+            Variable::UniversalVar(universal_var) => universal_var.var_index,
+            Variable::ExistentialVar(existential_var) => existential_var.var_index,
+            Variable::BoundVar(bound_var) => {
+                if bound_var.debruijn.is_some() {
+                    anyhow::bail!("binder is not open")
+                }
+                bound_var.var_index
+            }
+        }
+        .index;
+        let kind = self.kind_to_string(&variable.kind());
+        Ok(format!("{kind}{index}"))
+    }
+
+    fn kind_to_string(&self, kind: &ParameterKind) -> &'static str {
+        match kind {
+            ParameterKind::Ty => "T",
+            ParameterKind::Lt => "'a",
+            ParameterKind::Const => "N",
+        }
+    }
+
+    /// Creates a substitution that replaces the variables introduced by the
+    /// binder `b` with fresh bound variables.
+    ///
+    /// Each binder parameter is mapped to a new [`BoundVar`] with a fresh
+    /// variable index. The resulting substitution can be used to instantiate
+    /// the binder without capturing existing variables.
+    pub fn bounded_substitution<T>(&mut self, b: &Binder<T>) -> Vec<BoundVar>
+    where
+        T: Fold,
+    {
+        self.substitution(b, |kind, var_index| BoundVar {
+            debruijn: None,
+            kind,
+            var_index,
+        })
+    }
+
+    /// Creates a substitution that replaces the variables introduced by the
+    /// binder `b` with fresh existential variables.
+    ///
+    /// Each binder parameter is mapped to a new [`ExistentialVar`] with a fresh
+    /// variable index. The resulting substitution can be used to instantiate
+    /// the binder without capturing existing variables.
+    pub fn existential_substitution<T>(&mut self, b: &Binder<T>) -> Vec<ExistentialVar>
+    where
+        T: Fold,
+    {
+        self.substitution(b, |kind, var_index| ExistentialVar { kind, var_index })
+    }
+
+    /// Creates a substitution that replaces the variables introduced by the
+    /// binder `b` with fresh universal variables.
+    ///
+    /// Each binder parameter is mapped to a new [`UniversalVar`] with a fresh
+    /// variable index. The resulting substitution can be used to instantiate
+    /// the binder without capturing existing variables.
+    pub fn universal_substitution<T>(&mut self, b: &Binder<T>) -> Vec<UniversalVar>
+    where
+        T: Fold,
+    {
+        self.substitution(b, |kind, var_index| UniversalVar { kind, var_index })
+    }
+
+    /// Creates a substitution for the binder `b` using freshly generated
+    /// variables.
+    ///
+    /// For each parameter introduced by the binder, a fresh variable is created
+    /// by invoking the generator function `v`. The resulting substitution can be
+    /// used to instantiate the binder.
+    fn substitution<T, V>(
+        &mut self,
+        b: &Binder<T>,
+        v: impl Fn(ParameterKind, VarIndex) -> V,
+    ) -> Vec<V>
+    where
+        T: Fold,
+    {
+        let subst = self.fresh_substitution(b.kinds(), v);
+        subst
+    }
+
+    /// Creates a fresh substitution for the given parameter kinds.
+    ///
+    /// For each entry in `kinds`, this function generates a fresh variable index
+    /// and invokes the callback `v` with the corresponding `ParameterKind` and
+    /// index. The collected results form the substitution in binder order.
+    fn fresh_substitution<V>(
+        &mut self,
+        kinds: &[ParameterKind],
+        v: impl Fn(ParameterKind, VarIndex) -> V,
+    ) -> Vec<V> {
+        let fresh_index = self.counter;
+        self.counter = self.counter + kinds.len();
+        kinds
+            .iter()
+            .zip(0..)
+            .map(|(&kind, offset)| v(kind, fresh_index + offset))
+            .collect()
+    }
+}

--- a/crates/formality-rust/src/to_rust/context.rs
+++ b/crates/formality-rust/src/to_rust/context.rs
@@ -1,10 +1,8 @@
 use crate::{
     grammar::{
-        Binder, BoundVar, ExistentialVar, Fallible, ParameterKind, UniversalVar, VarIndex,
-        Variable, WhereClause,
+        Binder, BoundVar, ExistentialVar, Fallible, ParameterKind, UniversalVar, VarIndex, Variable,
     },
     rust::Fold,
-    to_rust::{lower_generics_for_binder, syntax},
 };
 
 #[derive(Debug)]
@@ -27,53 +25,40 @@ impl Default for Context {
 }
 
 impl Context {
-    /// Applies the operation `op` to the term contained within the binder `b`.
-    ///
-    /// The binder is instantiated with a fresh set of bound variables. Since a
-    /// binder introduces new generic variables, those variables are lowered at
-    /// this point and provided to the caller via the `syntax::Generics` argument
-    /// passed to `op`.
-    ///
-    /// The function `g` is used to extract the relevant `&[WhereClause]` clauses from the
-    /// instantiated term.
-    ///
-    /// When lowering generics for a trait declaration, `is_trait` must be set to
-    /// `true`. In this case, the implicit first generic parameter represents
-    /// `Self` and is therefore not treated as a regular generic parameter.
-    ///
-    /// # Example
-    /// ```rust,no_run
-    /// # use formality_rust::grammar::{AdtId, Binder, Struct, StructBoundData, Fallible};
-    /// # use formality_rust::to_rust::{context::Context, syntax::StructItem};
-    /// fn lower_struct(term: Struct) -> Fallible<StructItem> {
-    ///     let mut ctx = Context::empty();
-    ///     ctx.with_binder(
-    ///         &term.binder,
-    ///         true,
-    ///         |term| &term.where_clauses,
-    ///         |term, generics, ctx| todo!(),
-    ///     )
-    /// }
-    /// ```
-    pub fn with_binder<T: Fold, R>(
-        &mut self,
-        b: &Binder<T>,
-        is_trait: bool,
-        g: impl Fn(&T) -> &[WhereClause],
-        mut op: impl FnMut(T, syntax::Generics, &mut Context) -> Fallible<R>,
-    ) -> Fallible<R> {
+    /// Opens the binder `b` and instatiates ith with a fresh set of
+    /// bounded variables and returns the term and the names
+    pub fn open_bounded<T: Fold>(&mut self, b: &Binder<T>) -> (T, Vec<String>) {
         let subst = self.bounded_substitution(b);
         let term = b.instantiate_with(&subst).expect("suitable substitution");
-
         let names = subst
             .into_iter()
             .map(|var| format!("{}{}", self.kind_to_string(&var.kind), var.var_index.index))
             .collect::<Vec<_>>();
-        let generics =
-            lower_generics_for_binder(self, b.kinds(), g(&term), names.as_slice(), is_trait)?;
+        (term, names)
+    }
 
-        let result = op(term, generics, self);
-        result
+    /// Opens the binder `b` and instatiates ith with a fresh set of
+    /// existential variables and returns the term and the names
+    pub fn open_exists<T: Fold>(&mut self, b: &Binder<T>) -> (T, Vec<String>) {
+        let subst = self.existential_substitution(b);
+        let term = b.instantiate_with(&subst).expect("suitable substitution");
+        let names = subst
+            .into_iter()
+            .map(|var| format!("{}{}", self.kind_to_string(&var.kind), var.var_index.index))
+            .collect::<Vec<_>>();
+        (term, names)
+    }
+
+    /// Opens the binder `b` and instatiates ith with a fresh set of
+    /// universal variables and returns the term and the names
+    pub fn open_universal<T: Fold>(&mut self, b: &Binder<T>) -> (T, Vec<String>) {
+        let subst = self.universal_substitution(b);
+        let term = b.instantiate_with(&subst).expect("suitable substitution");
+        let names = subst
+            .into_iter()
+            .map(|var| format!("{}{}", self.kind_to_string(&var.kind), var.var_index.index))
+            .collect::<Vec<_>>();
+        (term, names)
     }
 
     pub fn core_variable_to_string(&self, variable: &Variable) -> Fallible<String> {
@@ -180,3 +165,30 @@ impl Context {
             .collect()
     }
 }
+
+#[macro_export]
+macro_rules! open_bounded {
+    ($ctx:expr, $binder:expr) => {{
+        let (term, names) = $ctx.open_bounded($binder);
+        let generics = $crate::to_rust::lower_generics_for_binder(
+            $ctx,
+            $binder.kinds(),
+            &term.where_clauses,
+            &names,
+            false,
+        )?;
+        (term, generics)
+    }};
+    ($ctx:expr, $binder:expr, $is_trait:literal) => {{
+        let (term, names) = $ctx.open_bounded($binder);
+        let generics = $crate::to_rust::lower_generics_for_binder(
+            $ctx,
+            $binder.kinds(),
+            &term.where_clauses,
+            &names,
+            $is_trait,
+        )?;
+        (term, generics)
+    }};
+}
+pub(crate) use open_bounded; // <-- the trick

--- a/crates/formality-rust/src/to_rust/crates.rs
+++ b/crates/formality-rust/src/to_rust/crates.rs
@@ -1,0 +1,58 @@
+use crate::grammar::{AdtItem, Crate, CrateItem, Crates, Fallible};
+use crate::to_rust::{
+    context::Context, feature_gate, fns, structs_enums_and_adts, syntax, traits_and_impls,
+};
+use std::{collections::HashMap, ops::Deref};
+
+pub fn build_crates(ctx: &mut Context, crates: &Crates) -> Fallible<HashMap<String, String>> {
+    crates
+        .crates
+        .iter()
+        .map(|krate| {
+            let lowered = lower_crate(ctx, krate)?;
+            Ok((krate.id.deref().clone(), lowered.to_string()))
+        })
+        .collect()
+}
+
+pub fn lower_crate(ctx: &mut Context, krate: &Crate) -> Fallible<syntax::RustCrate> {
+    let mut attrs = Vec::new();
+    let mut items = Vec::new();
+
+    for item in &krate.items {
+        match item {
+            CrateItem::FeatureGate(gate) => attrs.push(feature_gate::lower_feature_gate(gate)?),
+            CrateItem::AdtItem(AdtItem::Struct(strukt)) => {
+                items.push(syntax::Item::Struct(structs_enums_and_adts::lower_struct(
+                    ctx, strukt,
+                )?));
+            }
+            CrateItem::AdtItem(AdtItem::Enum(e)) => {
+                items.push(syntax::Item::Enum(structs_enums_and_adts::lower_enum(
+                    ctx, e,
+                )?));
+            }
+            CrateItem::Trait(t) => {
+                items.push(syntax::Item::Trait(traits_and_impls::lower_trait(ctx, t)?));
+            }
+            CrateItem::TraitImpl(trait_impl) => {
+                items.push(syntax::Item::Impl(traits_and_impls::lower_trait_impl(
+                    ctx, trait_impl,
+                )?));
+            }
+            CrateItem::NegTraitImpl(neg_trait_impl) => {
+                items.push(syntax::Item::NegImpl(
+                    traits_and_impls::lower_neg_trait_impl(ctx, neg_trait_impl)?,
+                ));
+            }
+            CrateItem::Fn(function) => {
+                items.push(syntax::Item::Function(fns::lower_fn(ctx, function)?));
+            }
+            CrateItem::Test(_) => {
+                todo!("lowering `test` crate items is not implemented yet")
+            }
+        }
+    }
+
+    Ok(syntax::RustCrate { attrs, items })
+}

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -71,11 +71,7 @@ pub fn lower_let(
 
 pub fn lower_exists_stmt(ctx: &mut Context, binder: &Binder<Block>) -> Fallible<syntax::Stmt> {
     // TODO: Check again, after codegen is merged, if "erased" lifetimes could work here.
-    let subst = ctx.existential_substitution(binder);
-    let term = binder
-        .instantiate_with(&subst)
-        .expect("suitable substitution");
-
+    let (term, _) = ctx.open_exists(binder);
     let result = syntax::Stmt::Block(lower_block(ctx, &term)?);
     Ok(result)
 }

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -5,7 +5,7 @@ use crate::grammar::{
     Binder, Fallible, FieldName, RefKind, Ty, ValueId,
 };
 
-use crate::to_rust::{syntax, tys, Context};
+use crate::to_rust::{context::Context, syntax, tys};
 
 pub fn lower_block(ctx: &mut Context, block: &Block) -> Fallible<syntax::Block> {
     let label = block.label.as_ref().map(|l| l.id.as_str().to_owned());

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -5,189 +5,187 @@ use crate::grammar::{
     Binder, Fallible, FieldName, RefKind, Ty, ValueId,
 };
 
-use super::{syntax, RustBuilder};
+use crate::to_rust::{syntax, tys, Context};
 
-impl RustBuilder {
-    pub fn lower_block(&mut self, block: &Block) -> Fallible<syntax::Block> {
-        let label = block.label.as_ref().map(|l| l.id.as_str().to_owned());
-        let stmts = block
-            .stmts
-            .iter()
-            .map(|stmt| self.lower_stmt(stmt))
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(syntax::Block { label, stmts })
+pub fn lower_block(ctx: &mut Context, block: &Block) -> Fallible<syntax::Block> {
+    let label = block.label.as_ref().map(|l| l.id.as_str().to_owned());
+    let stmts = block
+        .stmts
+        .iter()
+        .map(|stmt| lower_stmt(ctx, stmt))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(syntax::Block { label, stmts })
+}
+
+pub fn lower_stmt(ctx: &mut Context, stmt: &Stmt) -> Fallible<syntax::Stmt> {
+    match stmt {
+        Stmt::Let {
+            label,
+            id,
+            ty,
+            init,
+        } => lower_let(ctx, label.as_ref(), id, ty, init.as_ref()),
+        Stmt::If {
+            condition,
+            then_block,
+            else_block,
+        } => Ok(syntax::Stmt::If {
+            condition: lower_expr(ctx, condition)?,
+            then_block: lower_block(ctx, then_block)?,
+            else_block: lower_block(ctx, else_block)?,
+        }),
+        Stmt::Expr { expr } => Ok(syntax::Stmt::Expr(lower_expr(ctx, expr)?)),
+        Stmt::Loop { label, body } => Ok(syntax::Stmt::Loop {
+            label: label.as_ref().map(|l| l.id.deref().clone()),
+            body: lower_block(ctx, body)?,
+        }),
+        Stmt::Break { label } => Ok(syntax::Stmt::Break {
+            label: label.deref().clone(),
+        }),
+        Stmt::Continue { label } => Ok(syntax::Stmt::Continue {
+            label: label.deref().clone(),
+        }),
+        Stmt::Return { expr } => Ok(syntax::Stmt::Return {
+            expr: lower_expr(ctx, expr)?,
+        }),
+        Stmt::Block(block) => Ok(syntax::Stmt::Block(lower_block(ctx, block)?)),
+        Stmt::Exists { binder } => lower_exists_stmt(ctx, binder),
     }
+}
 
-    fn lower_stmt(&mut self, stmt: &Stmt) -> Fallible<syntax::Stmt> {
-        match stmt {
-            Stmt::Let {
-                label,
-                id,
-                ty,
-                init,
-            } => self.lower_let(label.as_ref(), id, ty, init.as_ref()),
-            Stmt::If {
-                condition,
-                then_block,
-                else_block,
-            } => Ok(syntax::Stmt::If {
-                condition: self.lower_expr(condition)?,
-                then_block: self.lower_block(then_block)?,
-                else_block: self.lower_block(else_block)?,
-            }),
-            Stmt::Expr { expr } => Ok(syntax::Stmt::Expr(self.lower_expr(expr)?)),
-            Stmt::Loop { label, body } => Ok(syntax::Stmt::Loop {
-                label: label.as_ref().map(|l| l.id.deref().clone()),
-                body: self.lower_block(body)?,
-            }),
-            Stmt::Break { label } => Ok(syntax::Stmt::Break {
-                label: label.deref().clone(),
-            }),
-            Stmt::Continue { label } => Ok(syntax::Stmt::Continue {
-                label: label.deref().clone(),
-            }),
-            Stmt::Return { expr } => Ok(syntax::Stmt::Return {
-                expr: self.lower_expr(expr)?,
-            }),
-            Stmt::Block(block) => Ok(syntax::Stmt::Block(self.lower_block(block)?)),
-            Stmt::Exists { binder } => self.lower_exists_stmt(binder),
-        }
-    }
+pub fn lower_let(
+    ctx: &mut Context,
+    _label: Option<&Label>,
+    id: &ValueId,
+    ty: &Ty,
+    init: Option<&Init>,
+) -> Fallible<syntax::Stmt> {
+    Ok(syntax::Stmt::Let {
+        // TODO: is there a way to know, if the variable must be mutable or not?
+        mutable: true,
+        name: id.deref().clone(),
+        ty: tys::lower_ty(ctx, ty)?,
+        init: init.map(|init| lower_expr(ctx, &init.expr)).transpose()?,
+    })
+}
 
-    fn lower_let(
-        &mut self,
-        _label: Option<&Label>,
-        id: &ValueId,
-        ty: &Ty,
-        init: Option<&Init>,
-    ) -> Fallible<syntax::Stmt> {
-        Ok(syntax::Stmt::Let {
-            // TODO: is there a way to know, if the variable must be mutable or not?
-            mutable: true,
+pub fn lower_exists_stmt(ctx: &mut Context, binder: &Binder<Block>) -> Fallible<syntax::Stmt> {
+    // TODO: Check again, after codegen is merged, if "erased" lifetimes could work here.
+    let subst = ctx.existential_substitution(binder);
+    let term = binder
+        .instantiate_with(&subst)
+        .expect("suitable substitution");
+
+    let result = syntax::Stmt::Block(lower_block(ctx, &term)?);
+    Ok(result)
+}
+
+pub fn lower_expr(ctx: &mut Context, expr: &Expr) -> Fallible<syntax::Expr> {
+    match expr {
+        Expr::Assign { place, expr } => Ok(syntax::Expr::Assign {
+            place: lower_place_expr(ctx, place)?,
+            value: Box::new(lower_expr(ctx, expr)?),
+        }),
+        Expr::Call { callee, args } => Ok(syntax::Expr::Call {
+            callee: Box::new(lower_expr(ctx, callee)?),
+            args: args
+                .iter()
+                .map(|arg| lower_expr(ctx, arg))
+                .collect::<Result<Vec<_>, _>>()?,
+        }),
+        Expr::Literal { value, ty } => Ok(syntax::Expr::Literal {
+            value: value.to_string(),
+            suffix: tys::scalar_to_string(ty),
+        }),
+        Expr::True => Ok(syntax::Expr::Bool(true)),
+        Expr::False => Ok(syntax::Expr::Bool(false)),
+        Expr::Ref { kind, lt: _, place } => Ok(syntax::Expr::Ref {
+            mutable: matches!(kind, RefKind::Mut),
+            place: lower_place_expr(ctx, place)?,
+        }),
+        Expr::Place(place_expr) => Ok(syntax::Expr::Place(lower_place_expr(ctx, place_expr)?)),
+        Expr::Turbofish { id, args } => Ok(syntax::Expr::Path {
             name: id.deref().clone(),
-            ty: self.lower_ty(ty)?,
-            init: init.map(|init| self.lower_expr(&init.expr)).transpose()?,
-        })
-    }
+            args: args
+                .iter()
+                .map(|arg| tys::lower_generic_arg(ctx, arg))
+                .collect::<Result<Vec<_>, _>>()?,
+        }),
+        Expr::Struct {
+            field_exprs,
+            adt_id,
+            turbofish,
+        } => {
+            let args = turbofish
+                .parameters
+                .iter()
+                .map(|arg| tys::lower_generic_arg(ctx, arg))
+                .collect::<Result<Vec<_>, _>>()?;
 
-    fn lower_exists_stmt(&mut self, binder: &Binder<Block>) -> Fallible<syntax::Stmt> {
-        // TODO: Check again, after codegen is merged, if "erased" lifetimes could work here.
-        let subst = self.existential_substitution(binder);
-        let term = binder
-            .instantiate_with(&subst)
-            .expect("suitable substitution");
+            let named_fields = field_exprs
+                .iter()
+                .filter_map(|field| match field.name {
+                    FieldName::Id(_) => Some(lower_named_field_expr(ctx, field)),
+                    FieldName::Index(_) => None,
+                })
+                .collect::<Result<Vec<_>, _>>()?;
 
-        let result = syntax::Stmt::Block(self.lower_block(&term)?);
-        Ok(result)
-    }
-
-    pub fn lower_expr(&mut self, expr: &Expr) -> Fallible<syntax::Expr> {
-        match expr {
-            Expr::Assign { place, expr } => Ok(syntax::Expr::Assign {
-                place: self.lower_place_expr(place)?,
-                value: Box::new(self.lower_expr(expr)?),
-            }),
-            Expr::Call { callee, args } => Ok(syntax::Expr::Call {
-                callee: Box::new(self.lower_expr(callee)?),
-                args: args
-                    .iter()
-                    .map(|arg| self.lower_expr(arg))
-                    .collect::<Result<Vec<_>, _>>()?,
-            }),
-            Expr::Literal { value, ty } => Ok(syntax::Expr::Literal {
-                value: value.to_string(),
-                suffix: self.scalar_to_string(ty),
-            }),
-            Expr::True => Ok(syntax::Expr::Bool(true)),
-            Expr::False => Ok(syntax::Expr::Bool(false)),
-            Expr::Ref { kind, lt: _, place } => Ok(syntax::Expr::Ref {
-                mutable: matches!(kind, RefKind::Mut),
-                place: self.lower_place_expr(place)?,
-            }),
-            Expr::Place(place_expr) => Ok(syntax::Expr::Place(self.lower_place_expr(place_expr)?)),
-            Expr::Turbofish { id, args } => Ok(syntax::Expr::Path {
-                name: id.deref().clone(),
-                args: args
-                    .iter()
-                    .map(|arg| self.lower_generic_arg(arg))
-                    .collect::<Result<Vec<_>, _>>()?,
-            }),
-            Expr::Struct {
-                field_exprs,
-                adt_id,
-                turbofish,
-            } => {
-                let args = turbofish
-                    .parameters
-                    .iter()
-                    .map(|arg| self.lower_generic_arg(arg))
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                let named_fields = field_exprs
-                    .iter()
-                    .filter_map(|field| match field.name {
-                        FieldName::Id(_) => Some(self.lower_named_field_expr(field)),
-                        FieldName::Index(_) => None,
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                if named_fields.len() == field_exprs.len() {
-                    return Ok(syntax::Expr::Struct {
-                        path: adt_id.deref().clone(),
-                        args,
-                        fields: syntax::StructExprFields::Named(named_fields),
-                    });
-                }
-
-                let tuple_fields = field_exprs
-                    .iter()
-                    .map(|field| self.lower_expr(&field.value))
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                Ok(syntax::Expr::Struct {
+            if named_fields.len() == field_exprs.len() {
+                return Ok(syntax::Expr::Struct {
                     path: adt_id.deref().clone(),
                     args,
-                    fields: syntax::StructExprFields::Tuple(tuple_fields),
-                })
+                    fields: syntax::StructExprFields::Named(named_fields),
+                });
             }
+
+            let tuple_fields = field_exprs
+                .iter()
+                .map(|field| lower_expr(ctx, &field.value))
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(syntax::Expr::Struct {
+                path: adt_id.deref().clone(),
+                args,
+                fields: syntax::StructExprFields::Tuple(tuple_fields),
+            })
         }
     }
+}
 
-    pub fn lower_place_expr(&mut self, place_expr: &PlaceExpr) -> Fallible<syntax::PlaceExpr> {
-        match place_expr {
-            PlaceExpr::Var(value_id) => Ok(syntax::PlaceExpr::Var(value_id.deref().clone())),
-            PlaceExpr::Deref { prefix } => Ok(syntax::PlaceExpr::Deref(Box::new(
-                self.lower_place_expr(prefix)?,
-            ))),
-            PlaceExpr::Parens(place_expr) => Ok(syntax::PlaceExpr::Paren(Box::new(
-                self.lower_place_expr(place_expr)?,
-            ))),
-            PlaceExpr::Field { prefix, field_name } => Ok(syntax::PlaceExpr::Field {
-                prefix: Box::new(self.lower_place_expr(prefix)?),
-                field: match field_name {
-                    FieldName::Id(id) => id.deref().clone(),
-                    FieldName::Index(idx) => idx.to_string(),
-                },
-            }),
+pub fn lower_place_expr(ctx: &mut Context, place_expr: &PlaceExpr) -> Fallible<syntax::PlaceExpr> {
+    match place_expr {
+        PlaceExpr::Var(value_id) => Ok(syntax::PlaceExpr::Var(value_id.deref().clone())),
+        PlaceExpr::Deref { prefix } => Ok(syntax::PlaceExpr::Deref(Box::new(lower_place_expr(
+            ctx, prefix,
+        )?))),
+        PlaceExpr::Parens(place_expr) => Ok(syntax::PlaceExpr::Paren(Box::new(lower_place_expr(
+            ctx, place_expr,
+        )?))),
+        PlaceExpr::Field { prefix, field_name } => Ok(syntax::PlaceExpr::Field {
+            prefix: Box::new(lower_place_expr(ctx, prefix)?),
+            field: match field_name {
+                FieldName::Id(id) => id.deref().clone(),
+                FieldName::Index(idx) => idx.to_string(),
+            },
+        }),
+    }
+}
+
+pub fn lower_named_field_expr(
+    ctx: &mut Context,
+    field_expr: &FieldExpr,
+) -> Fallible<syntax::NamedFieldExpr> {
+    let name = match &field_expr.name {
+        FieldName::Id(id) => id.deref().clone(),
+        FieldName::Index(_) => {
+            anyhow::bail!("expected named field expression but found tuple field")
         }
-    }
+    };
 
-    fn lower_named_field_expr(
-        &mut self,
-        field_expr: &FieldExpr,
-    ) -> Fallible<syntax::NamedFieldExpr> {
-        let name = match &field_expr.name {
-            FieldName::Id(id) => id.deref().clone(),
-            FieldName::Index(_) => {
-                anyhow::bail!("expected named field expression but found tuple field")
-            }
-        };
-
-        Ok(syntax::NamedFieldExpr {
-            name,
-            expr: self.lower_expr(&field_expr.value)?,
-        })
-    }
+    Ok(syntax::NamedFieldExpr {
+        name,
+        expr: lower_expr(ctx, &field_expr.value)?,
+    })
 }
 
 #[cfg(test)]

--- a/crates/formality-rust/src/to_rust/feature_gate.rs
+++ b/crates/formality-rust/src/to_rust/feature_gate.rs
@@ -1,0 +1,10 @@
+use crate::grammar::{Fallible, FeatureGate, FeatureGateName};
+
+use crate::to_rust::syntax;
+
+pub fn lower_feature_gate(gate: &FeatureGate) -> Fallible<syntax::Attr> {
+    let name = match gate.name {
+        FeatureGateName::PoloniusAlpha => "polonius_alpha",
+    };
+    Ok(syntax::Attr::Feature(name.to_owned()))
+}

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -3,32 +3,29 @@ use std::ops::Deref;
 use crate::grammar::{Fallible, Fn, FnBody, InputArg, MaybeFnBody};
 use crate::prove::prove::Safety;
 
-use crate::to_rust::{context::Context, syntax, tys};
+use crate::to_rust::{
+    context::{open_bounded, Context},
+    syntax, tys,
+};
 
 pub fn lower_fn(ctx: &mut Context, function: &Fn) -> Fallible<syntax::FunctionItem> {
-    ctx.with_binder(
-        &function.binder,
-        false,
-        |term| &term.where_clauses,
-        |term, generics, ctx| {
-            let params = term
-                .input_args
-                .iter()
-                .map(|arg| lower_fn_param(ctx, arg))
-                .collect::<Result<Vec<_>, _>>()?;
-            let return_ty = tys::lower_ty(ctx, &term.output_ty)?;
-            let body = lower_fn_body(ctx, &term.body)?;
+    let (term, generics) = open_bounded!(ctx, &function.binder);
+    let params = term
+        .input_args
+        .iter()
+        .map(|arg| lower_fn_param(ctx, arg))
+        .collect::<Result<Vec<_>, _>>()?;
+    let return_ty = tys::lower_ty(ctx, &term.output_ty)?;
+    let body = lower_fn_body(ctx, &term.body)?;
 
-            Ok(syntax::FunctionItem {
-                is_unsafe: matches!(function.safety, Safety::Unsafe),
-                name: function.id.deref().clone(),
-                generics,
-                params,
-                return_ty,
-                body,
-            })
-        },
-    )
+    Ok(syntax::FunctionItem {
+        is_unsafe: matches!(function.safety, Safety::Unsafe),
+        name: function.id.deref().clone(),
+        generics,
+        params,
+        return_ty,
+        body,
+    })
 }
 
 pub fn lower_fn_param(ctx: &mut Context, arg: &InputArg) -> Fallible<syntax::FnParam> {

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -3,52 +3,52 @@ use std::ops::Deref;
 use crate::grammar::{Fallible, Fn, FnBody, InputArg, MaybeFnBody};
 use crate::prove::prove::Safety;
 
-use super::{syntax, RustBuilder};
+use crate::to_rust::{syntax, tys, Context};
 
-impl RustBuilder {
-    pub fn lower_fn(&mut self, function: &Fn) -> Fallible<syntax::FunctionItem> {
-        self.with_binder(
-            &function.binder,
-            false,
-            |term| &term.where_clauses,
-            |term, generics, pp| {
-                let params = term
-                    .input_args
-                    .iter()
-                    .map(|arg| pp.lower_fn_param(arg))
-                    .collect::<Result<Vec<_>, _>>()?;
-                let return_ty = pp.lower_ty(&term.output_ty)?;
-                let body = pp.lower_fn_body(&term.body)?;
+pub fn lower_fn(ctx: &mut Context, function: &Fn) -> Fallible<syntax::FunctionItem> {
+    ctx.with_binder(
+        &function.binder,
+        false,
+        |term| &term.where_clauses,
+        |term, generics, ctx| {
+            let params = term
+                .input_args
+                .iter()
+                .map(|arg| lower_fn_param(ctx, arg))
+                .collect::<Result<Vec<_>, _>>()?;
+            let return_ty = tys::lower_ty(ctx, &term.output_ty)?;
+            let body = lower_fn_body(ctx, &term.body)?;
 
-                Ok(syntax::FunctionItem {
-                    is_unsafe: matches!(function.safety, Safety::Unsafe),
-                    name: function.id.deref().clone(),
-                    generics,
-                    params,
-                    return_ty,
-                    body,
-                })
-            },
-        )
-    }
+            Ok(syntax::FunctionItem {
+                is_unsafe: matches!(function.safety, Safety::Unsafe),
+                name: function.id.deref().clone(),
+                generics,
+                params,
+                return_ty,
+                body,
+            })
+        },
+    )
+}
 
-    fn lower_fn_param(&mut self, arg: &InputArg) -> Fallible<syntax::FnParam> {
-        Ok(syntax::FnParam {
-            // TODO: Is there a way to know if a variable must be mutable?
-            mutable: true,
-            name: arg.id.deref().clone(),
-            ty: self.lower_ty(&arg.ty)?,
-        })
-    }
+pub fn lower_fn_param(ctx: &mut Context, arg: &InputArg) -> Fallible<syntax::FnParam> {
+    Ok(syntax::FnParam {
+        // TODO: Is there a way to know if a variable must be mutable?
+        mutable: true,
+        name: arg.id.deref().clone(),
+        ty: tys::lower_ty(ctx, &arg.ty)?,
+    })
+}
 
-    fn lower_fn_body(&mut self, body: &MaybeFnBody) -> Fallible<syntax::FunctionBody> {
-        match body {
-            MaybeFnBody::NoFnBody => Ok(syntax::FunctionBody::Declaration),
-            MaybeFnBody::FnBody(fn_body) => match fn_body {
-                FnBody::TrustedFnBody => Ok(syntax::FunctionBody::Trusted),
-                FnBody::Expr(block) => Ok(syntax::FunctionBody::Block(self.lower_block(block)?)),
-            },
-        }
+pub fn lower_fn_body(ctx: &mut Context, body: &MaybeFnBody) -> Fallible<syntax::FunctionBody> {
+    match body {
+        MaybeFnBody::NoFnBody => Ok(syntax::FunctionBody::Declaration),
+        MaybeFnBody::FnBody(fn_body) => match fn_body {
+            FnBody::TrustedFnBody => Ok(syntax::FunctionBody::Trusted),
+            FnBody::Expr(block) => Ok(syntax::FunctionBody::Block(
+                crate::to_rust::expr::lower_block(ctx, block)?,
+            )),
+        },
     }
 }
 

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use crate::grammar::{Fallible, Fn, FnBody, InputArg, MaybeFnBody};
 use crate::prove::prove::Safety;
 
-use crate::to_rust::{syntax, tys, Context};
+use crate::to_rust::{context::Context, syntax, tys};
 
 pub fn lower_fn(ctx: &mut Context, function: &Fn) -> Fallible<syntax::FunctionItem> {
     ctx.with_binder(

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -1,14 +1,10 @@
-use crate::{
-    grammar::{
-        AdtItem, Binder, BoundVar, Crate, CrateItem, Crates, ExistentialVar, Fallible, FeatureGate,
-        FeatureGateName, ParameterKind, Ty, UniversalVar, VarIndex, Variable, WhereClause,
-        WhereClauseData,
-    },
-    rust::Fold,
-};
-use std::{collections::HashMap, ops::Deref};
+use crate::grammar::{Crates, Fallible, ParameterKind, Ty, WhereClause, WhereClauseData};
+use std::ops::Deref;
 
+pub mod context;
+mod crates;
 mod expr;
+mod feature_gate;
 mod fns;
 mod structs_enums_and_adts;
 pub mod syntax;
@@ -38,8 +34,8 @@ pub fn check_workspace(
 pub fn create_workspace(crates: &Crates, root_directory: &std::path::Path) -> Fallible<String> {
     use std::io::Write;
 
-    let mut ctx = Context::default();
-    let crates = build_crates(&mut ctx, crates)?;
+    let mut ctx = context::Context::default();
+    let crates = crates::build_crates(&mut ctx, crates)?;
     let crates_path = root_directory.join("crates");
     let root_toml_path = root_directory.join("Cargo.toml");
 
@@ -81,234 +77,6 @@ pub fn create_workspace(crates: &Crates, root_directory: &std::path::Path) -> Fa
     Ok(location.to_string())
 }
 
-#[derive(Debug)]
-pub struct Context {
-    counter: VarIndex,
-}
-
-impl Default for Context {
-    fn default() -> Self {
-        Self {
-            counter: VarIndex { index: 0 },
-        }
-    }
-}
-
-impl Context {
-    /// Applies the operation `op` to the term contained within the binder `b`.
-    ///
-    /// The binder is instantiated with a fresh set of bound variables. Since a
-    /// binder introduces new generic variables, those variables are lowered at
-    /// this point and provided to the caller via the `syntax::Generics` argument
-    /// passed to `op`.
-    ///
-    /// The function `g` is used to extract the relevant `&[WhereClause]` clauses from the
-    /// instantiated term.
-    ///
-    /// When lowering generics for a trait declaration, `is_trait` must be set to
-    /// `true`. In this case, the implicit first generic parameter represents
-    /// `Self` and is therefore not treated as a regular generic parameter.
-    ///
-    /// # Example
-    /// ```rust,no_run
-    /// # use formality_rust::grammar::{AdtId, Binder, Struct, StructBoundData, Fallible};
-    /// # use formality_rust::to_rust::{Context, syntax::StructItem};
-    /// fn lower_struct(term: Struct) -> Fallible<StructItem> {
-    ///     let mut pp = Context::default();
-    ///     pp.with_binder(
-    ///         &term.binder,
-    ///         true,
-    ///         |term| &term.where_clauses,
-    ///         |term, generics, pp| todo!(),
-    ///     )
-    /// }
-    /// ```
-    pub fn with_binder<T: Fold, R>(
-        &mut self,
-        b: &Binder<T>,
-        is_trait: bool,
-        g: impl Fn(&T) -> &[WhereClause],
-        mut op: impl FnMut(T, syntax::Generics, &mut Context) -> Fallible<R>,
-    ) -> Fallible<R> {
-        let subst = self.bounded_substitution(b);
-        let term = b.instantiate_with(&subst).expect("suitable substitution");
-
-        let names = subst
-            .into_iter()
-            .map(|var| format!("{}{}", self.kind_to_string(&var.kind), var.var_index.index))
-            .collect::<Vec<_>>();
-        let generics =
-            lower_generics_for_binder(self, b.kinds(), g(&term), names.as_slice(), is_trait)?;
-
-        let result = op(term, generics, self);
-        result
-    }
-
-    pub fn core_variable_to_string(&self, variable: &Variable) -> Fallible<String> {
-        let index = match variable {
-            Variable::UniversalVar(universal_var) => universal_var.var_index,
-            Variable::ExistentialVar(existential_var) => existential_var.var_index,
-            Variable::BoundVar(bound_var) => {
-                if bound_var.debruijn.is_some() {
-                    anyhow::bail!("binder is not open")
-                }
-                bound_var.var_index
-            }
-        }
-        .index;
-        let kind = self.kind_to_string(&variable.kind());
-        Ok(format!("{kind}{index}"))
-    }
-
-    fn kind_to_string(&self, kind: &ParameterKind) -> &'static str {
-        match kind {
-            ParameterKind::Ty => "T",
-            ParameterKind::Lt => "'a",
-            ParameterKind::Const => "N",
-        }
-    }
-
-    /// Creates a substitution for the binder `b` using freshly generated
-    /// variables.
-    ///
-    /// For each parameter introduced by the binder, a fresh variable is created
-    /// by invoking the generator function `v`. The resulting substitution can be
-    /// used to instantiate the binder.
-    pub fn substitution<T, V>(
-        &mut self,
-        b: &Binder<T>,
-        v: impl Fn(ParameterKind, VarIndex) -> V,
-    ) -> Vec<V>
-    where
-        T: Fold,
-    {
-        let subst = self.fresh_substitution(b.kinds(), v);
-        subst
-    }
-
-    /// Creates a substitution that replaces the variables introduced by the
-    /// binder `b` with fresh bound variables.
-    ///
-    /// Each binder parameter is mapped to a new [`BoundVar`] with a fresh
-    /// variable index. The resulting substitution can be used to instantiate
-    /// the binder without capturing existing variables.
-    pub fn bounded_substitution<T>(&mut self, b: &Binder<T>) -> Vec<BoundVar>
-    where
-        T: Fold,
-    {
-        self.substitution(b, |kind, var_index| BoundVar {
-            debruijn: None,
-            kind,
-            var_index,
-        })
-    }
-
-    /// Creates a substitution that replaces the variables introduced by the
-    /// binder `b` with fresh existential variables.
-    ///
-    /// Each binder parameter is mapped to a new [`ExistentialVar`] with a fresh
-    /// variable index. The resulting substitution can be used to instantiate
-    /// the binder without capturing existing variables.
-    pub fn existential_substitution<T>(&mut self, b: &Binder<T>) -> Vec<ExistentialVar>
-    where
-        T: Fold,
-    {
-        self.substitution(b, |kind, var_index| ExistentialVar { kind, var_index })
-    }
-
-    /// Creates a substitution that replaces the variables introduced by the
-    /// binder `b` with fresh universal variables.
-    ///
-    /// Each binder parameter is mapped to a new [`UniversalVar`] with a fresh
-    /// variable index. The resulting substitution can be used to instantiate
-    /// the binder without capturing existing variables.
-    pub fn universal_substitution<T>(&mut self, b: &Binder<T>) -> Vec<UniversalVar>
-    where
-        T: Fold,
-    {
-        self.substitution(b, |kind, var_index| UniversalVar { kind, var_index })
-    }
-
-    /// Creates a fresh substitution for the given parameter kinds.
-    ///
-    /// For each entry in `kinds`, this function generates a fresh variable index
-    /// and invokes the callback `v` with the corresponding `ParameterKind` and
-    /// index. The collected results form the substitution in binder order.
-    fn fresh_substitution<V>(
-        &mut self,
-        kinds: &[ParameterKind],
-        v: impl Fn(ParameterKind, VarIndex) -> V,
-    ) -> Vec<V> {
-        let fresh_index = self.counter;
-        self.counter = self.counter + kinds.len();
-        kinds
-            .iter()
-            .zip(0..)
-            .map(|(&kind, offset)| v(kind, fresh_index + offset))
-            .collect()
-    }
-}
-
-pub fn build_crates(ctx: &mut Context, crates: &Crates) -> Fallible<HashMap<String, String>> {
-    crates
-        .crates
-        .iter()
-        .map(|krate| {
-            let lowered = lower_crate(ctx, krate)?;
-            Ok((krate.id.deref().clone(), lowered.to_string()))
-        })
-        .collect()
-}
-
-pub fn lower_crate(ctx: &mut Context, krate: &Crate) -> Fallible<syntax::RustCrate> {
-    let mut attrs = Vec::new();
-    let mut items = Vec::new();
-
-    for item in &krate.items {
-        match item {
-            CrateItem::FeatureGate(gate) => attrs.push(lower_feature_gate(ctx, gate)?),
-            CrateItem::AdtItem(AdtItem::Struct(strukt)) => {
-                items.push(syntax::Item::Struct(structs_enums_and_adts::lower_struct(
-                    ctx, strukt,
-                )?));
-            }
-            CrateItem::AdtItem(AdtItem::Enum(e)) => {
-                items.push(syntax::Item::Enum(structs_enums_and_adts::lower_enum(
-                    ctx, e,
-                )?));
-            }
-            CrateItem::Trait(t) => {
-                items.push(syntax::Item::Trait(traits_and_impls::lower_trait(ctx, t)?));
-            }
-            CrateItem::TraitImpl(trait_impl) => {
-                items.push(syntax::Item::Impl(traits_and_impls::lower_trait_impl(
-                    ctx, trait_impl,
-                )?));
-            }
-            CrateItem::NegTraitImpl(neg_trait_impl) => {
-                items.push(syntax::Item::NegImpl(
-                    traits_and_impls::lower_neg_trait_impl(ctx, neg_trait_impl)?,
-                ));
-            }
-            CrateItem::Fn(function) => {
-                items.push(syntax::Item::Function(fns::lower_fn(ctx, function)?));
-            }
-            CrateItem::Test(_) => {
-                todo!("lowering `test` crate items is not implemented yet")
-            }
-        }
-    }
-
-    Ok(syntax::RustCrate { attrs, items })
-}
-
-pub fn lower_feature_gate(ctx: &mut Context, gate: &FeatureGate) -> Fallible<syntax::Attr> {
-    let name = match gate.name {
-        FeatureGateName::PoloniusAlpha => "polonius_alpha",
-    };
-    Ok(syntax::Attr::Feature(name.to_owned()))
-}
-
 /// Lowers generic parameters and `where` clauses for a binder.
 ///
 /// Set `skip_first` when lowering generics for a trait
@@ -316,7 +84,7 @@ pub fn lower_feature_gate(ctx: &mut Context, gate: &FeatureGate) -> Fallible<syn
 /// represents `Self` and must not be treated as a regular generic
 /// parameter.
 pub fn lower_generics_for_binder(
-    ctx: &mut Context,
+    ctx: &mut context::Context,
     binder_kinds: &[ParameterKind],
     where_clauses: &[WhereClause],
     names: &[String],
@@ -394,7 +162,7 @@ pub fn lower_generics_for_binder(
 }
 
 pub fn lower_where_clauses(
-    ctx: &mut Context,
+    ctx: &mut context::Context,
     where_clauses: &[WhereClause],
 ) -> Fallible<Vec<syntax::WhereClause>> {
     let mut preds = Vec::new();

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -38,7 +38,8 @@ pub fn check_workspace(
 pub fn create_workspace(crates: &Crates, root_directory: &std::path::Path) -> Fallible<String> {
     use std::io::Write;
 
-    let crates = RustBuilder::default().build_crates(crates)?;
+    let mut ctx = Context::default();
+    let crates = build_crates(&mut ctx, crates)?;
     let crates_path = root_directory.join("crates");
     let root_toml_path = root_directory.join("Cargo.toml");
 
@@ -81,11 +82,11 @@ pub fn create_workspace(crates: &Crates, root_directory: &std::path::Path) -> Fa
 }
 
 #[derive(Debug)]
-pub struct RustBuilder {
+pub struct Context {
     counter: VarIndex,
 }
 
-impl Default for RustBuilder {
+impl Default for Context {
     fn default() -> Self {
         Self {
             counter: VarIndex { index: 0 },
@@ -93,7 +94,7 @@ impl Default for RustBuilder {
     }
 }
 
-impl RustBuilder {
+impl Context {
     /// Applies the operation `op` to the term contained within the binder `b`.
     ///
     /// The binder is instantiated with a fresh set of bound variables. Since a
@@ -111,9 +112,9 @@ impl RustBuilder {
     /// # Example
     /// ```rust,no_run
     /// # use formality_rust::grammar::{AdtId, Binder, Struct, StructBoundData, Fallible};
-    /// # use formality_rust::to_rust::{RustBuilder, syntax::StructItem};
+    /// # use formality_rust::to_rust::{Context, syntax::StructItem};
     /// fn lower_struct(term: Struct) -> Fallible<StructItem> {
-    ///     let mut pp = RustBuilder::default();
+    ///     let mut pp = Context::default();
     ///     pp.with_binder(
     ///         &term.binder,
     ///         true,
@@ -127,7 +128,7 @@ impl RustBuilder {
         b: &Binder<T>,
         is_trait: bool,
         g: impl Fn(&T) -> &[WhereClause],
-        mut op: impl FnMut(T, syntax::Generics, &mut RustBuilder) -> Fallible<R>,
+        mut op: impl FnMut(T, syntax::Generics, &mut Context) -> Fallible<R>,
     ) -> Fallible<R> {
         let subst = self.bounded_substitution(b);
         let term = b.instantiate_with(&subst).expect("suitable substitution");
@@ -137,7 +138,7 @@ impl RustBuilder {
             .map(|var| format!("{}{}", self.kind_to_string(&var.kind), var.var_index.index))
             .collect::<Vec<_>>();
         let generics =
-            self.lower_generics_for_binder(b.kinds(), g(&term), names.as_slice(), is_trait)?;
+            lower_generics_for_binder(self, b.kinds(), g(&term), names.as_slice(), is_trait)?;
 
         let result = op(term, generics, self);
         result
@@ -246,210 +247,216 @@ impl RustBuilder {
             .map(|(&kind, offset)| v(kind, fresh_index + offset))
             .collect()
     }
+}
 
-    pub fn build_crates(&mut self, crates: &Crates) -> Fallible<HashMap<String, String>> {
-        crates
-            .crates
-            .iter()
-            .map(|krate| {
-                let lowered = self.lower_crate(krate)?;
-                Ok((krate.id.deref().clone(), lowered.to_string()))
-            })
-            .collect()
-    }
-
-    fn lower_crate(&mut self, krate: &Crate) -> Fallible<syntax::RustCrate> {
-        let mut attrs = Vec::new();
-        let mut items = Vec::new();
-
-        for item in &krate.items {
-            match item {
-                CrateItem::FeatureGate(gate) => attrs.push(self.lower_feature_gate(gate)?),
-                CrateItem::AdtItem(AdtItem::Struct(strukt)) => {
-                    items.push(syntax::Item::Struct(self.lower_struct(strukt)?));
-                }
-                CrateItem::AdtItem(AdtItem::Enum(e)) => {
-                    items.push(syntax::Item::Enum(self.lower_enum(e)?));
-                }
-                CrateItem::Trait(t) => {
-                    items.push(syntax::Item::Trait(self.lower_trait(t)?));
-                }
-                CrateItem::TraitImpl(trait_impl) => {
-                    items.push(syntax::Item::Impl(self.lower_trait_impl(trait_impl)?));
-                }
-                CrateItem::NegTraitImpl(neg_trait_impl) => {
-                    items.push(syntax::Item::NegImpl(
-                        self.lower_neg_trait_impl(neg_trait_impl)?,
-                    ));
-                }
-                CrateItem::Fn(function) => {
-                    items.push(syntax::Item::Function(self.lower_fn(function)?));
-                }
-                CrateItem::Test(_) => {
-                    todo!("lowering `test` crate items is not implemented yet")
-                }
-            }
-        }
-
-        Ok(syntax::RustCrate { attrs, items })
-    }
-
-    fn lower_feature_gate(&mut self, gate: &FeatureGate) -> Fallible<syntax::Attr> {
-        let name = match gate.name {
-            FeatureGateName::PoloniusAlpha => "polonius_alpha",
-        };
-        Ok(syntax::Attr::Feature(name.to_owned()))
-    }
-
-    /// Lowers generic parameters and `where` clauses for a binder.
-    ///
-    /// Set `skip_first` when lowering generics for a trait
-    /// declaration.  In trait declarations, the first parameter
-    /// represents `Self` and must not be treated as a regular generic
-    /// parameter.
-    pub fn lower_generics_for_binder(
-        &mut self,
-        binder_kinds: &[ParameterKind],
-        where_clauses: &[WhereClause],
-        names: &[String],
-        skip_first: bool,
-    ) -> Fallible<syntax::Generics> {
-        if names.len() != binder_kinds.len() {
-            anyhow::bail!(
-                "binder metadata mismatch: {} names but {} kinds",
-                names.len(),
-                binder_kinds.len()
-            );
-        }
-
-        let start = usize::from(skip_first);
-        let mut params: Vec<syntax::GenericParam> = names
-            .iter()
-            .skip(start)
-            .cloned()
-            .zip(binder_kinds.iter().copied().skip(start))
-            .map(|(name, kind)| Self::generic_param_from_kind(name, kind))
-            .collect();
-
-        for wc in where_clauses {
-            match wc {
-                WhereClauseData::IsImplemented(ty, _, _) => {
-                    if let Ty::Variable(var) = ty {
-                        let name = self.core_variable_to_string(&var)?;
-                        // If the `where` clause referes to a type
-                        // variable from an outer binder, that
-                        // variable is not yet included in `params`.
-                        Self::push_type_param_if_missing(&mut params, name);
-                    }
-                }
-                WhereClauseData::TypeOfConst(konst, ty) => {
-                    let name = match self.lower_const(konst)? {
-                        syntax::ConstExpr::Ident(id) => id,
-                        other => anyhow::bail!(
-                            "const generic parameter must be an identifier, found `{other}`"
-                        ),
-                    };
-                    let ty = self.lower_ty(ty)?;
-
-                    if let Some(existing_ty) = params.iter_mut().find_map(|param| match param {
-                        syntax::GenericParam::Const { name: existing, ty } if existing == &name => {
-                            Some(ty)
-                        }
-                        _ => None,
-                    }) {
-                        *existing_ty = ty;
-                    } else {
-                        // If the `where` clause referes to a type
-                        // variable from an outer binder, that
-                        // variable is not yet included in `params`.
-                        params.push(syntax::GenericParam::Const { name, ty });
-                    }
-                }
-                WhereClauseData::AliasEq(_, _) => {
-                    todo!("lowering `AliasEq` where-clauses is not implemented yet")
-                }
-                WhereClauseData::Outlives(_, _) => {
-                    todo!("lowering `Outlives` where-clauses is not implemented yet")
-                }
-                WhereClauseData::ForAll(_) => {
-                    todo!("lowering `ForAll` where-clauses is not implemented yet")
-                }
-            }
-        }
-
-        let where_clauses = self.lower_where_clauses(where_clauses)?;
-
-        Ok(syntax::Generics {
-            params,
-            where_clauses,
+pub fn build_crates(ctx: &mut Context, crates: &Crates) -> Fallible<HashMap<String, String>> {
+    crates
+        .crates
+        .iter()
+        .map(|krate| {
+            let lowered = lower_crate(ctx, krate)?;
+            Ok((krate.id.deref().clone(), lowered.to_string()))
         })
-    }
+        .collect()
+}
 
-    pub fn lower_where_clauses(
-        &mut self,
-        where_clauses: &[WhereClause],
-    ) -> Fallible<Vec<syntax::WhereClause>> {
-        let mut preds = Vec::new();
+pub fn lower_crate(ctx: &mut Context, krate: &Crate) -> Fallible<syntax::RustCrate> {
+    let mut attrs = Vec::new();
+    let mut items = Vec::new();
 
-        for wc in where_clauses {
-            match wc {
-                WhereClauseData::IsImplemented(ty, trait_id, params) => {
-                    preds.push(syntax::WhereClause::Trait {
-                        ty: self.lower_ty(ty)?,
-                        trait_name: trait_id.deref().clone(),
-                        args: params
-                            .iter()
-                            .map(|param| self.lower_generic_arg(param))
-                            .collect::<Result<Vec<_>, _>>()?,
-                    });
-                }
-                WhereClauseData::TypeOfConst(_, _) => {}
-                WhereClauseData::AliasEq(_, _) => {
-                    anyhow::bail!("lowering `AliasEq` where-clauses is not implemented yet")
-                }
-                WhereClauseData::Outlives(_, _) => {
-                    anyhow::bail!("lowering `Outlives` where-clauses is not implemented yet")
-                }
-                WhereClauseData::ForAll(_) => {
-                    anyhow::bail!("lowering `ForAll` where-clauses is not implemented yet")
-                }
+    for item in &krate.items {
+        match item {
+            CrateItem::FeatureGate(gate) => attrs.push(lower_feature_gate(ctx, gate)?),
+            CrateItem::AdtItem(AdtItem::Struct(strukt)) => {
+                items.push(syntax::Item::Struct(structs_enums_and_adts::lower_struct(
+                    ctx, strukt,
+                )?));
+            }
+            CrateItem::AdtItem(AdtItem::Enum(e)) => {
+                items.push(syntax::Item::Enum(structs_enums_and_adts::lower_enum(
+                    ctx, e,
+                )?));
+            }
+            CrateItem::Trait(t) => {
+                items.push(syntax::Item::Trait(traits_and_impls::lower_trait(ctx, t)?));
+            }
+            CrateItem::TraitImpl(trait_impl) => {
+                items.push(syntax::Item::Impl(traits_and_impls::lower_trait_impl(
+                    ctx, trait_impl,
+                )?));
+            }
+            CrateItem::NegTraitImpl(neg_trait_impl) => {
+                items.push(syntax::Item::NegImpl(
+                    traits_and_impls::lower_neg_trait_impl(ctx, neg_trait_impl)?,
+                ));
+            }
+            CrateItem::Fn(function) => {
+                items.push(syntax::Item::Function(fns::lower_fn(ctx, function)?));
+            }
+            CrateItem::Test(_) => {
+                todo!("lowering `test` crate items is not implemented yet")
             }
         }
-
-        Ok(preds)
     }
 
-    fn push_type_param_if_missing(params: &mut Vec<syntax::GenericParam>, name: String) {
-        if name == "Self" {
-            return;
-        }
+    Ok(syntax::RustCrate { attrs, items })
+}
 
-        if !params
-            .iter()
-            .any(|param| matches!(param, syntax::GenericParam::Type(existing) if existing == &name))
-        {
-            params.push(syntax::GenericParam::Type(name));
+pub fn lower_feature_gate(ctx: &mut Context, gate: &FeatureGate) -> Fallible<syntax::Attr> {
+    let name = match gate.name {
+        FeatureGateName::PoloniusAlpha => "polonius_alpha",
+    };
+    Ok(syntax::Attr::Feature(name.to_owned()))
+}
+
+/// Lowers generic parameters and `where` clauses for a binder.
+///
+/// Set `skip_first` when lowering generics for a trait
+/// declaration.  In trait declarations, the first parameter
+/// represents `Self` and must not be treated as a regular generic
+/// parameter.
+pub fn lower_generics_for_binder(
+    ctx: &mut Context,
+    binder_kinds: &[ParameterKind],
+    where_clauses: &[WhereClause],
+    names: &[String],
+    skip_first: bool,
+) -> Fallible<syntax::Generics> {
+    if names.len() != binder_kinds.len() {
+        anyhow::bail!(
+            "binder metadata mismatch: {} names but {} kinds",
+            names.len(),
+            binder_kinds.len()
+        );
+    }
+
+    let start = usize::from(skip_first);
+    let mut params: Vec<syntax::GenericParam> = names
+        .iter()
+        .skip(start)
+        .cloned()
+        .zip(binder_kinds.iter().copied().skip(start))
+        .map(|(name, kind)| generic_param_from_kind(name, kind))
+        .collect();
+
+    for wc in where_clauses {
+        match wc {
+            WhereClauseData::IsImplemented(ty, _, _) => {
+                if let Ty::Variable(var) = ty {
+                    let name = ctx.core_variable_to_string(&var)?;
+                    // If the `where` clause referes to a type
+                    // variable from an outer binder, that
+                    // variable is not yet included in `params`.
+                    push_type_param_if_missing(&mut params, name);
+                }
+            }
+            WhereClauseData::TypeOfConst(konst, ty) => {
+                let name = match tys::lower_const(ctx, konst)? {
+                    syntax::ConstExpr::Ident(id) => id,
+                    other => anyhow::bail!(
+                        "const generic parameter must be an identifier, found `{other}`"
+                    ),
+                };
+                let ty = tys::lower_ty(ctx, ty)?;
+
+                if let Some(existing_ty) = params.iter_mut().find_map(|param| match param {
+                    syntax::GenericParam::Const { name: existing, ty } if existing == &name => {
+                        Some(ty)
+                    }
+                    _ => None,
+                }) {
+                    *existing_ty = ty;
+                } else {
+                    // If the `where` clause referes to a type
+                    // variable from an outer binder, that
+                    // variable is not yet included in `params`.
+                    params.push(syntax::GenericParam::Const { name, ty });
+                }
+            }
+            WhereClauseData::AliasEq(_, _) => {
+                todo!("lowering `AliasEq` where-clauses is not implemented yet")
+            }
+            WhereClauseData::Outlives(_, _) => {
+                todo!("lowering `Outlives` where-clauses is not implemented yet")
+            }
+            WhereClauseData::ForAll(_) => {
+                todo!("lowering `ForAll` where-clauses is not implemented yet")
+            }
         }
     }
 
-    /// Creates a generic parameter nameed `name` with the given
-    /// `kind`.
-    ///
-    /// For const generics, a default type of `usize` is used.  This
-    /// default should not be relied upon, as it is an implementation
-    /// detail and my change in the future.
-    fn generic_param_from_kind(name: String, kind: ParameterKind) -> syntax::GenericParam {
-        match kind {
-            ParameterKind::Ty => syntax::GenericParam::Type(name),
-            ParameterKind::Lt => syntax::GenericParam::Lifetime(name),
-            ParameterKind::Const => syntax::GenericParam::Const {
-                name,
-                ty: syntax::Type::Path {
-                    name: "usize".to_owned(),
-                    args: Vec::new(),
-                },
+    let where_clauses = lower_where_clauses(ctx, where_clauses)?;
+
+    Ok(syntax::Generics {
+        params,
+        where_clauses,
+    })
+}
+
+pub fn lower_where_clauses(
+    ctx: &mut Context,
+    where_clauses: &[WhereClause],
+) -> Fallible<Vec<syntax::WhereClause>> {
+    let mut preds = Vec::new();
+
+    for wc in where_clauses {
+        match wc {
+            WhereClauseData::IsImplemented(ty, trait_id, params) => {
+                preds.push(syntax::WhereClause::Trait {
+                    ty: tys::lower_ty(ctx, ty)?,
+                    trait_name: trait_id.deref().clone(),
+                    args: params
+                        .iter()
+                        .map(|param| tys::lower_generic_arg(ctx, param))
+                        .collect::<Result<Vec<_>, _>>()?,
+                });
+            }
+            WhereClauseData::TypeOfConst(_, _) => {}
+            WhereClauseData::AliasEq(_, _) => {
+                anyhow::bail!("lowering `AliasEq` where-clauses is not implemented yet")
+            }
+            WhereClauseData::Outlives(_, _) => {
+                anyhow::bail!("lowering `Outlives` where-clauses is not implemented yet")
+            }
+            WhereClauseData::ForAll(_) => {
+                anyhow::bail!("lowering `ForAll` where-clauses is not implemented yet")
+            }
+        }
+    }
+
+    Ok(preds)
+}
+
+fn push_type_param_if_missing(params: &mut Vec<syntax::GenericParam>, name: String) {
+    if name == "Self" {
+        return;
+    }
+
+    if !params
+        .iter()
+        .any(|param| matches!(param, syntax::GenericParam::Type(existing) if existing == &name))
+    {
+        params.push(syntax::GenericParam::Type(name));
+    }
+}
+
+/// Creates a generic parameter nameed `name` with the given
+/// `kind`.
+///
+/// For const generics, a default type of `usize` is used.  This
+/// default should not be relied upon, as it is an implementation
+/// detail and my change in the future.
+fn generic_param_from_kind(name: String, kind: ParameterKind) -> syntax::GenericParam {
+    match kind {
+        ParameterKind::Ty => syntax::GenericParam::Type(name),
+        ParameterKind::Lt => syntax::GenericParam::Lifetime(name),
+        ParameterKind::Const => syntax::GenericParam::Const {
+            name,
+            ty: syntax::Type::Path {
+                name: "usize".to_owned(),
+                args: Vec::new(),
             },
-        }
+        },
     }
 }
 

--- a/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
+++ b/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use crate::grammar::{Enum, Fallible, Field, FieldName, Struct, Variant};
 
-use crate::to_rust::{syntax, tys, Context};
+use crate::to_rust::{context::Context, syntax, tys};
 
 pub fn lower_struct(ctx: &mut Context, strukt: &Struct) -> Fallible<syntax::StructItem> {
     ctx.with_binder(
@@ -53,7 +53,10 @@ pub fn lower_variant(ctx: &mut Context, variant: &Variant) -> Fallible<syntax::E
     })
 }
 
-fn lower_variant_fields(ctx: &mut Context, fields: &[Field]) -> Fallible<syntax::VariantFields> {
+pub fn lower_variant_fields(
+    ctx: &mut Context,
+    fields: &[Field],
+) -> Fallible<syntax::VariantFields> {
     if fields.is_empty() {
         return Ok(syntax::VariantFields::Unit);
     }
@@ -73,7 +76,7 @@ fn lower_variant_fields(ctx: &mut Context, fields: &[Field]) -> Fallible<syntax:
     Ok(syntax::VariantFields::Struct(named))
 }
 
-fn lower_named_struct_field(ctx: &mut Context, field: &Field) -> Fallible<syntax::StructField> {
+pub fn lower_named_struct_field(ctx: &mut Context, field: &Field) -> Fallible<syntax::StructField> {
     match &field.name {
         FieldName::Id(id) => Ok(syntax::StructField {
             name: id.deref().clone(),

--- a/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
+++ b/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
@@ -2,47 +2,38 @@ use std::ops::Deref;
 
 use crate::grammar::{Enum, Fallible, Field, FieldName, Struct, Variant};
 
-use crate::to_rust::{context::Context, syntax, tys};
+use crate::to_rust::{
+    context::{open_bounded, Context},
+    syntax, tys,
+};
 
 pub fn lower_struct(ctx: &mut Context, strukt: &Struct) -> Fallible<syntax::StructItem> {
-    ctx.with_binder(
-        &strukt.binder,
-        false,
-        |term| &term.where_clauses,
-        |term, generics, ctx| {
-            let fields = term
-                .fields
-                .iter()
-                .map(|field| lower_named_struct_field(ctx, field))
-                .collect::<Result<Vec<_>, _>>()?;
+    let (term, generics) = open_bounded!(ctx, &strukt.binder);
+    let fields = term
+        .fields
+        .iter()
+        .map(|field| lower_named_struct_field(ctx, field))
+        .collect::<Result<Vec<_>, _>>()?;
 
-            Ok(syntax::StructItem {
-                name: strukt.id.deref().clone(),
-                generics,
-                fields,
-            })
-        },
-    )
+    Ok(syntax::StructItem {
+        name: strukt.id.deref().clone(),
+        generics,
+        fields,
+    })
 }
 
 pub fn lower_enum(ctx: &mut Context, e: &Enum) -> Fallible<syntax::EnumItem> {
-    ctx.with_binder(
-        &e.binder,
-        false,
-        |term| &term.where_clauses,
-        |term, generics, ctx| {
-            let variants = term
-                .variants
-                .iter()
-                .map(|variant| lower_variant(ctx, variant))
-                .collect::<Result<Vec<_>, _>>()?;
-            Ok(syntax::EnumItem {
-                name: e.id.deref().clone(),
-                generics,
-                variants,
-            })
-        },
-    )
+    let (term, generics) = open_bounded!(ctx, &e.binder);
+    let variants = term
+        .variants
+        .iter()
+        .map(|variant| lower_variant(ctx, variant))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(syntax::EnumItem {
+        name: e.id.deref().clone(),
+        generics,
+        variants,
+    })
 }
 
 pub fn lower_variant(ctx: &mut Context, variant: &Variant) -> Fallible<syntax::EnumVariant> {

--- a/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
+++ b/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
@@ -2,88 +2,86 @@ use std::ops::Deref;
 
 use crate::grammar::{Enum, Fallible, Field, FieldName, Struct, Variant};
 
-use super::{syntax, RustBuilder};
+use crate::to_rust::{syntax, tys, Context};
 
-impl RustBuilder {
-    pub fn lower_struct(&mut self, strukt: &Struct) -> Fallible<syntax::StructItem> {
-        self.with_binder(
-            &strukt.binder,
-            false,
-            |term| &term.where_clauses,
-            |term, generics, pp| {
-                let fields = term
-                    .fields
-                    .iter()
-                    .map(|field| pp.lower_named_struct_field(field))
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                Ok(syntax::StructItem {
-                    name: strukt.id.deref().clone(),
-                    generics,
-                    fields,
-                })
-            },
-        )
-    }
-
-    pub fn lower_enum(&mut self, e: &Enum) -> Fallible<syntax::EnumItem> {
-        self.with_binder(
-            &e.binder,
-            false,
-            |term| &term.where_clauses,
-            |term, generics, pp| {
-                let variants = term
-                    .variants
-                    .iter()
-                    .map(|variant| pp.lower_variant(variant))
-                    .collect::<Result<Vec<_>, _>>()?;
-                Ok(syntax::EnumItem {
-                    name: e.id.deref().clone(),
-                    generics,
-                    variants,
-                })
-            },
-        )
-    }
-
-    fn lower_variant(&mut self, variant: &Variant) -> Fallible<syntax::EnumVariant> {
-        let fields = self.lower_variant_fields(&variant.fields)?;
-        Ok(syntax::EnumVariant {
-            name: variant.name.deref().clone(),
-            fields,
-        })
-    }
-
-    fn lower_variant_fields(&mut self, fields: &[Field]) -> Fallible<syntax::VariantFields> {
-        if fields.is_empty() {
-            return Ok(syntax::VariantFields::Unit);
-        }
-
-        if matches!(fields[0].name, FieldName::Index(_)) {
-            let tys = fields
+pub fn lower_struct(ctx: &mut Context, strukt: &Struct) -> Fallible<syntax::StructItem> {
+    ctx.with_binder(
+        &strukt.binder,
+        false,
+        |term| &term.where_clauses,
+        |term, generics, ctx| {
+            let fields = term
+                .fields
                 .iter()
-                .map(|field| self.lower_ty(&field.ty))
+                .map(|field| lower_named_struct_field(ctx, field))
                 .collect::<Result<Vec<_>, _>>()?;
-            return Ok(syntax::VariantFields::Tuple(tys));
-        }
 
-        let named = fields
-            .iter()
-            .map(|field| self.lower_named_struct_field(field))
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(syntax::VariantFields::Struct(named))
+            Ok(syntax::StructItem {
+                name: strukt.id.deref().clone(),
+                generics,
+                fields,
+            })
+        },
+    )
+}
+
+pub fn lower_enum(ctx: &mut Context, e: &Enum) -> Fallible<syntax::EnumItem> {
+    ctx.with_binder(
+        &e.binder,
+        false,
+        |term| &term.where_clauses,
+        |term, generics, ctx| {
+            let variants = term
+                .variants
+                .iter()
+                .map(|variant| lower_variant(ctx, variant))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(syntax::EnumItem {
+                name: e.id.deref().clone(),
+                generics,
+                variants,
+            })
+        },
+    )
+}
+
+pub fn lower_variant(ctx: &mut Context, variant: &Variant) -> Fallible<syntax::EnumVariant> {
+    let fields = lower_variant_fields(ctx, &variant.fields)?;
+    Ok(syntax::EnumVariant {
+        name: variant.name.deref().clone(),
+        fields,
+    })
+}
+
+fn lower_variant_fields(ctx: &mut Context, fields: &[Field]) -> Fallible<syntax::VariantFields> {
+    if fields.is_empty() {
+        return Ok(syntax::VariantFields::Unit);
     }
 
-    fn lower_named_struct_field(&mut self, field: &Field) -> Fallible<syntax::StructField> {
-        match &field.name {
-            FieldName::Id(id) => Ok(syntax::StructField {
-                name: id.deref().clone(),
-                ty: self.lower_ty(&field.ty)?,
-            }),
-            FieldName::Index(idx) => anyhow::bail!(
-                "expected named field but found tuple field index `{idx}` while lowering struct"
-            ),
-        }
+    if matches!(fields[0].name, FieldName::Index(_)) {
+        let tys = fields
+            .iter()
+            .map(|field| tys::lower_ty(ctx, &field.ty))
+            .collect::<Result<Vec<_>, _>>()?;
+        return Ok(syntax::VariantFields::Tuple(tys));
+    }
+
+    let named = fields
+        .iter()
+        .map(|field| lower_named_struct_field(ctx, field))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(syntax::VariantFields::Struct(named))
+}
+
+fn lower_named_struct_field(ctx: &mut Context, field: &Field) -> Fallible<syntax::StructField> {
+    match &field.name {
+        FieldName::Id(id) => Ok(syntax::StructField {
+            name: id.deref().clone(),
+            ty: tys::lower_ty(ctx, &field.ty)?,
+        }),
+        FieldName::Index(idx) => anyhow::bail!(
+            "expected named field but found tuple field index `{idx}` while lowering struct"
+        ),
     }
 }
 

--- a/crates/formality-rust/src/to_rust/test_util.rs
+++ b/crates/formality-rust/src/to_rust/test_util.rs
@@ -4,7 +4,7 @@
 use crate::{
     check::check_all_crates,
     rust::term,
-    to_rust::{build_crates, check_workspace, Context},
+    to_rust::{check_workspace, context::Context, crates::build_crates},
 };
 
 /// Asserts that the given Formality input is translated into the expected

--- a/crates/formality-rust/src/to_rust/test_util.rs
+++ b/crates/formality-rust/src/to_rust/test_util.rs
@@ -4,7 +4,7 @@
 use crate::{
     check::check_all_crates,
     rust::term,
-    to_rust::{check_workspace, RustBuilder},
+    to_rust::{build_crates, check_workspace, Context},
 };
 
 /// Asserts that the given Formality input is translated into the expected
@@ -22,8 +22,8 @@ macro_rules! assert_rust {
 #[track_caller]
 pub fn assert_rust(input: &str, expected: &str) {
     let program = term(input);
-    let rust = RustBuilder::default()
-        .build_crates(&program)
+    let mut ctx = Context::default();
+    let rust = build_crates(&mut ctx, &program)
         .unwrap()
         .into_iter()
         .next()

--- a/crates/formality-rust/src/to_rust/traits_and_impls.rs
+++ b/crates/formality-rust/src/to_rust/traits_and_impls.rs
@@ -6,7 +6,7 @@ use crate::grammar::{
 };
 use crate::prove::prove::Safety;
 
-use crate::to_rust::{self, fns, syntax, tys, Context};
+use crate::to_rust::{self, context::Context, fns, syntax, tys};
 
 pub fn lower_trait(ctx: &mut Context, t: &Trait) -> Fallible<syntax::TraitItem> {
     // NOTE: Is this right with explicit binder?

--- a/crates/formality-rust/src/to_rust/traits_and_impls.rs
+++ b/crates/formality-rust/src/to_rust/traits_and_impls.rs
@@ -6,164 +6,165 @@ use crate::grammar::{
 };
 use crate::prove::prove::Safety;
 
-use super::{syntax, RustBuilder};
+use crate::to_rust::{self, fns, syntax, tys, Context};
 
-impl RustBuilder {
-    pub fn lower_trait(&mut self, t: &Trait) -> Fallible<syntax::TraitItem> {
-        // NOTE: Is this right with explicit binder?
-        self.with_binder(
-            &t.binder.explicit_binder,
-            true,
-            |term| &term.where_clauses,
-            |term, generics, pp| {
-                let mut items = Vec::new();
-                for item in &term.trait_items {
-                    match item {
-                        TraitItem::Fn(f) => {
-                            items.push(syntax::TraitMember::Function(pp.lower_fn(f)?))
-                        }
-                        TraitItem::AssociatedTy(assoc_ty) => items.push(
-                            syntax::TraitMember::AssociatedType(pp.lower_assoc_ty(assoc_ty)?),
-                        ),
+pub fn lower_trait(ctx: &mut Context, t: &Trait) -> Fallible<syntax::TraitItem> {
+    // NOTE: Is this right with explicit binder?
+    ctx.with_binder(
+        &t.binder.explicit_binder,
+        true,
+        |term| &term.where_clauses,
+        |term, generics, ctx| {
+            let mut items = Vec::new();
+            for item in &term.trait_items {
+                match item {
+                    TraitItem::Fn(f) => {
+                        items.push(syntax::TraitMember::Function(fns::lower_fn(ctx, f)?))
+                    }
+                    TraitItem::AssociatedTy(assoc_ty) => items.push(
+                        syntax::TraitMember::AssociatedType(lower_assoc_ty(ctx, assoc_ty)?),
+                    ),
+                }
+            }
+
+            Ok(syntax::TraitItem {
+                is_unsafe: matches!(t.safety, Safety::Unsafe),
+                name: t.id.deref().clone(),
+                generics,
+                items,
+            })
+        },
+    )
+}
+
+pub fn lower_trait_impl(ctx: &mut Context, trait_impl: &TraitImpl) -> Fallible<syntax::ImplItem> {
+    ctx.with_binder(
+        &trait_impl.binder,
+        false,
+        |term| &term.where_clauses,
+        |term, generics, ctx| {
+            let mut items = Vec::new();
+            for item in &term.impl_items {
+                match item {
+                    ImplItem::Fn(f) => {
+                        items.push(syntax::ImplMember::Function(fns::lower_fn(ctx, f)?))
+                    }
+                    ImplItem::AssociatedTyValue(v) => {
+                        items.push(syntax::ImplMember::AssociatedTypeValue(
+                            lower_assoc_ty_value(ctx, v)?,
+                        ));
                     }
                 }
+            }
 
-                Ok(syntax::TraitItem {
-                    is_unsafe: matches!(t.safety, Safety::Unsafe),
-                    name: t.id.deref().clone(),
-                    generics,
-                    items,
-                })
-            },
-        )
-    }
+            let trait_args = term
+                .trait_parameters
+                .iter()
+                .map(|arg| tys::lower_generic_arg(ctx, arg))
+                .collect::<Result<Vec<_>, _>>()?;
+            let self_ty = tys::lower_ty(ctx, &term.self_ty)?;
 
-    pub fn lower_trait_impl(&mut self, trait_impl: &TraitImpl) -> Fallible<syntax::ImplItem> {
-        self.with_binder(
-            &trait_impl.binder,
-            false,
-            |term| &term.where_clauses,
-            |term, generics, pp| {
-                let mut items = Vec::new();
-                for item in &term.impl_items {
-                    match item {
-                        ImplItem::Fn(f) => {
-                            items.push(syntax::ImplMember::Function(pp.lower_fn(f)?))
-                        }
-                        ImplItem::AssociatedTyValue(v) => {
-                            items.push(syntax::ImplMember::AssociatedTypeValue(
-                                pp.lower_assoc_ty_value(v)?,
-                            ));
-                        }
+            Ok(syntax::ImplItem {
+                is_unsafe: matches!(trait_impl.safety, Safety::Unsafe),
+                generics,
+                trait_name: term.trait_id.deref().clone(),
+                trait_args,
+                self_ty,
+                items,
+            })
+        },
+    )
+}
+
+pub fn lower_neg_trait_impl(
+    ctx: &mut Context,
+    neg_trait_impl: &NegTraitImpl,
+) -> Fallible<syntax::NegImplItem> {
+    ctx.with_binder(
+        &neg_trait_impl.binder,
+        false,
+        |term| &term.where_clauses,
+        |term, generics, ctx| {
+            let trait_args = term
+                .trait_parameters
+                .iter()
+                .map(|arg| tys::lower_generic_arg(ctx, arg))
+                .collect::<Result<Vec<_>, _>>()?;
+            let self_ty = tys::lower_ty(ctx, &term.self_ty)?;
+            let where_clauses = to_rust::lower_where_clauses(ctx, &term.where_clauses)?;
+
+            Ok(syntax::NegImplItem {
+                is_unsafe: matches!(neg_trait_impl.safety, Safety::Unsafe),
+                generics,
+                trait_name: term.trait_id.deref().clone(),
+                trait_args,
+                self_ty,
+                where_clauses,
+            })
+        },
+    )
+}
+
+pub fn lower_assoc_ty(
+    ctx: &mut Context,
+    assoc_ty: &AssociatedTy,
+) -> Fallible<syntax::AssociatedTypeItem> {
+    ctx.with_binder(
+        &assoc_ty.binder,
+        false,
+        |term| &term.where_clauses,
+        |term, generics, ctx| {
+            let mut bounds = Vec::new();
+            for ensure in &term.ensures {
+                match ensure {
+                    WhereBoundData::IsImplemented(trait_id, parameters) => {
+                        bounds.push(syntax::TypeBound::Trait {
+                            trait_name: trait_id.deref().clone(),
+                            args: parameters
+                                .iter()
+                                .map(|arg| tys::lower_generic_arg(ctx, arg))
+                                .collect::<Result<Vec<_>, _>>()?,
+                        });
+                    }
+                    WhereBoundData::Outlives(_) => {
+                        anyhow::bail!(
+                            "lowering associated type outlives bounds is not implemented yet"
+                        )
+                    }
+                    WhereBoundData::ForAll(_) => {
+                        anyhow::bail!(
+                            "lowering associated type `for` bounds is not implemented yet"
+                        )
                     }
                 }
+            }
 
-                let trait_args = term
-                    .trait_parameters
-                    .iter()
-                    .map(|arg| pp.lower_generic_arg(arg))
-                    .collect::<Result<Vec<_>, _>>()?;
-                let self_ty = pp.lower_ty(&term.self_ty)?;
+            Ok(syntax::AssociatedTypeItem {
+                name: assoc_ty.id.deref().clone(),
+                generics,
+                bounds,
+            })
+        },
+    )
+}
 
-                Ok(syntax::ImplItem {
-                    is_unsafe: matches!(trait_impl.safety, Safety::Unsafe),
-                    generics,
-                    trait_name: term.trait_id.deref().clone(),
-                    trait_args,
-                    self_ty,
-                    items,
-                })
-            },
-        )
-    }
-
-    pub fn lower_neg_trait_impl(
-        &mut self,
-        neg_trait_impl: &NegTraitImpl,
-    ) -> Fallible<syntax::NegImplItem> {
-        self.with_binder(
-            &neg_trait_impl.binder,
-            false,
-            |term| &term.where_clauses,
-            |term, generics, pp| {
-                let trait_args = term
-                    .trait_parameters
-                    .iter()
-                    .map(|arg| pp.lower_generic_arg(arg))
-                    .collect::<Result<Vec<_>, _>>()?;
-                let self_ty = pp.lower_ty(&term.self_ty)?;
-                let where_clauses = pp.lower_where_clauses(&term.where_clauses)?;
-
-                Ok(syntax::NegImplItem {
-                    is_unsafe: matches!(neg_trait_impl.safety, Safety::Unsafe),
-                    generics,
-                    trait_name: term.trait_id.deref().clone(),
-                    trait_args,
-                    self_ty,
-                    where_clauses,
-                })
-            },
-        )
-    }
-
-    fn lower_assoc_ty(&mut self, assoc_ty: &AssociatedTy) -> Fallible<syntax::AssociatedTypeItem> {
-        self.with_binder(
-            &assoc_ty.binder,
-            false,
-            |term| &term.where_clauses,
-            |term, generics, pp| {
-                let mut bounds = Vec::new();
-                for ensure in &term.ensures {
-                    match ensure {
-                        WhereBoundData::IsImplemented(trait_id, parameters) => {
-                            bounds.push(syntax::TypeBound::Trait {
-                                trait_name: trait_id.deref().clone(),
-                                args: parameters
-                                    .iter()
-                                    .map(|arg| pp.lower_generic_arg(arg))
-                                    .collect::<Result<Vec<_>, _>>()?,
-                            });
-                        }
-                        WhereBoundData::Outlives(_) => {
-                            anyhow::bail!(
-                                "lowering associated type outlives bounds is not implemented yet"
-                            )
-                        }
-                        WhereBoundData::ForAll(_) => {
-                            anyhow::bail!(
-                                "lowering associated type `for` bounds is not implemented yet"
-                            )
-                        }
-                    }
-                }
-
-                Ok(syntax::AssociatedTypeItem {
-                    name: assoc_ty.id.deref().clone(),
-                    generics,
-                    bounds,
-                })
-            },
-        )
-    }
-
-    fn lower_assoc_ty_value(
-        &mut self,
-        assoc_ty: &AssociatedTyValue,
-    ) -> Fallible<syntax::AssociatedTypeValueItem> {
-        self.with_binder(
-            &assoc_ty.binder,
-            false,
-            |term| &term.where_clauses,
-            |term, generics, pp| {
-                let ty = pp.lower_ty(&term.ty)?;
-                Ok(syntax::AssociatedTypeValueItem {
-                    name: assoc_ty.id.deref().clone(),
-                    generics,
-                    ty,
-                })
-            },
-        )
-    }
+pub fn lower_assoc_ty_value(
+    ctx: &mut Context,
+    assoc_ty: &AssociatedTyValue,
+) -> Fallible<syntax::AssociatedTypeValueItem> {
+    ctx.with_binder(
+        &assoc_ty.binder,
+        false,
+        |term| &term.where_clauses,
+        |term, generics, ctx| {
+            let ty = tys::lower_ty(ctx, &term.ty)?;
+            Ok(syntax::AssociatedTypeValueItem {
+                name: assoc_ty.id.deref().clone(),
+                generics,
+                ty,
+            })
+        },
+    )
 }
 
 #[cfg(test)]

--- a/crates/formality-rust/src/to_rust/traits_and_impls.rs
+++ b/crates/formality-rust/src/to_rust/traits_and_impls.rs
@@ -6,165 +6,130 @@ use crate::grammar::{
 };
 use crate::prove::prove::Safety;
 
-use crate::to_rust::{self, context::Context, fns, syntax, tys};
+use crate::to_rust::{
+    self,
+    context::{open_bounded, Context},
+    fns, syntax, tys,
+};
 
 pub fn lower_trait(ctx: &mut Context, t: &Trait) -> Fallible<syntax::TraitItem> {
-    // NOTE: Is this right with explicit binder?
-    ctx.with_binder(
-        &t.binder.explicit_binder,
-        true,
-        |term| &term.where_clauses,
-        |term, generics, ctx| {
-            let mut items = Vec::new();
-            for item in &term.trait_items {
-                match item {
-                    TraitItem::Fn(f) => {
-                        items.push(syntax::TraitMember::Function(fns::lower_fn(ctx, f)?))
-                    }
-                    TraitItem::AssociatedTy(assoc_ty) => items.push(
-                        syntax::TraitMember::AssociatedType(lower_assoc_ty(ctx, assoc_ty)?),
-                    ),
-                }
-            }
+    let (term, generics) = open_bounded!(ctx, &t.binder.explicit_binder, true);
+    let mut items = Vec::new();
+    for item in &term.trait_items {
+        match item {
+            TraitItem::Fn(f) => items.push(syntax::TraitMember::Function(fns::lower_fn(ctx, f)?)),
+            TraitItem::AssociatedTy(assoc_ty) => items.push(syntax::TraitMember::AssociatedType(
+                lower_assoc_ty(ctx, assoc_ty)?,
+            )),
+        }
+    }
 
-            Ok(syntax::TraitItem {
-                is_unsafe: matches!(t.safety, Safety::Unsafe),
-                name: t.id.deref().clone(),
-                generics,
-                items,
-            })
-        },
-    )
+    Ok(syntax::TraitItem {
+        is_unsafe: matches!(t.safety, Safety::Unsafe),
+        name: t.id.deref().clone(),
+        generics,
+        items,
+    })
 }
 
 pub fn lower_trait_impl(ctx: &mut Context, trait_impl: &TraitImpl) -> Fallible<syntax::ImplItem> {
-    ctx.with_binder(
-        &trait_impl.binder,
-        false,
-        |term| &term.where_clauses,
-        |term, generics, ctx| {
-            let mut items = Vec::new();
-            for item in &term.impl_items {
-                match item {
-                    ImplItem::Fn(f) => {
-                        items.push(syntax::ImplMember::Function(fns::lower_fn(ctx, f)?))
-                    }
-                    ImplItem::AssociatedTyValue(v) => {
-                        items.push(syntax::ImplMember::AssociatedTypeValue(
-                            lower_assoc_ty_value(ctx, v)?,
-                        ));
-                    }
-                }
+    let (term, generics) = open_bounded!(ctx, &trait_impl.binder);
+    let mut items = Vec::new();
+    for item in &term.impl_items {
+        match item {
+            ImplItem::Fn(f) => items.push(syntax::ImplMember::Function(fns::lower_fn(ctx, f)?)),
+            ImplItem::AssociatedTyValue(v) => {
+                items.push(syntax::ImplMember::AssociatedTypeValue(
+                    lower_assoc_ty_value(ctx, v)?,
+                ));
             }
+        }
+    }
 
-            let trait_args = term
-                .trait_parameters
-                .iter()
-                .map(|arg| tys::lower_generic_arg(ctx, arg))
-                .collect::<Result<Vec<_>, _>>()?;
-            let self_ty = tys::lower_ty(ctx, &term.self_ty)?;
+    let trait_args = term
+        .trait_parameters
+        .iter()
+        .map(|arg| tys::lower_generic_arg(ctx, arg))
+        .collect::<Result<Vec<_>, _>>()?;
+    let self_ty = tys::lower_ty(ctx, &term.self_ty)?;
 
-            Ok(syntax::ImplItem {
-                is_unsafe: matches!(trait_impl.safety, Safety::Unsafe),
-                generics,
-                trait_name: term.trait_id.deref().clone(),
-                trait_args,
-                self_ty,
-                items,
-            })
-        },
-    )
+    Ok(syntax::ImplItem {
+        is_unsafe: matches!(trait_impl.safety, Safety::Unsafe),
+        generics,
+        trait_name: term.trait_id.deref().clone(),
+        trait_args,
+        self_ty,
+        items,
+    })
 }
 
 pub fn lower_neg_trait_impl(
     ctx: &mut Context,
     neg_trait_impl: &NegTraitImpl,
 ) -> Fallible<syntax::NegImplItem> {
-    ctx.with_binder(
-        &neg_trait_impl.binder,
-        false,
-        |term| &term.where_clauses,
-        |term, generics, ctx| {
-            let trait_args = term
-                .trait_parameters
-                .iter()
-                .map(|arg| tys::lower_generic_arg(ctx, arg))
-                .collect::<Result<Vec<_>, _>>()?;
-            let self_ty = tys::lower_ty(ctx, &term.self_ty)?;
-            let where_clauses = to_rust::lower_where_clauses(ctx, &term.where_clauses)?;
+    let (term, generics) = open_bounded!(ctx, &neg_trait_impl.binder);
+    let trait_args = term
+        .trait_parameters
+        .iter()
+        .map(|arg| tys::lower_generic_arg(ctx, arg))
+        .collect::<Result<Vec<_>, _>>()?;
+    let self_ty = tys::lower_ty(ctx, &term.self_ty)?;
+    let where_clauses = to_rust::lower_where_clauses(ctx, &term.where_clauses)?;
 
-            Ok(syntax::NegImplItem {
-                is_unsafe: matches!(neg_trait_impl.safety, Safety::Unsafe),
-                generics,
-                trait_name: term.trait_id.deref().clone(),
-                trait_args,
-                self_ty,
-                where_clauses,
-            })
-        },
-    )
+    Ok(syntax::NegImplItem {
+        is_unsafe: matches!(neg_trait_impl.safety, Safety::Unsafe),
+        generics,
+        trait_name: term.trait_id.deref().clone(),
+        trait_args,
+        self_ty,
+        where_clauses,
+    })
 }
 
 pub fn lower_assoc_ty(
     ctx: &mut Context,
     assoc_ty: &AssociatedTy,
 ) -> Fallible<syntax::AssociatedTypeItem> {
-    ctx.with_binder(
-        &assoc_ty.binder,
-        false,
-        |term| &term.where_clauses,
-        |term, generics, ctx| {
-            let mut bounds = Vec::new();
-            for ensure in &term.ensures {
-                match ensure {
-                    WhereBoundData::IsImplemented(trait_id, parameters) => {
-                        bounds.push(syntax::TypeBound::Trait {
-                            trait_name: trait_id.deref().clone(),
-                            args: parameters
-                                .iter()
-                                .map(|arg| tys::lower_generic_arg(ctx, arg))
-                                .collect::<Result<Vec<_>, _>>()?,
-                        });
-                    }
-                    WhereBoundData::Outlives(_) => {
-                        anyhow::bail!(
-                            "lowering associated type outlives bounds is not implemented yet"
-                        )
-                    }
-                    WhereBoundData::ForAll(_) => {
-                        anyhow::bail!(
-                            "lowering associated type `for` bounds is not implemented yet"
-                        )
-                    }
-                }
+    let (term, generics) = open_bounded!(ctx, &assoc_ty.binder);
+    let mut bounds = Vec::new();
+    for ensure in &term.ensures {
+        match ensure {
+            WhereBoundData::IsImplemented(trait_id, parameters) => {
+                bounds.push(syntax::TypeBound::Trait {
+                    trait_name: trait_id.deref().clone(),
+                    args: parameters
+                        .iter()
+                        .map(|arg| tys::lower_generic_arg(ctx, arg))
+                        .collect::<Result<Vec<_>, _>>()?,
+                });
             }
+            WhereBoundData::Outlives(_) => {
+                anyhow::bail!("lowering associated type outlives bounds is not implemented yet")
+            }
+            WhereBoundData::ForAll(_) => {
+                anyhow::bail!("lowering associated type `for` bounds is not implemented yet")
+            }
+        }
+    }
 
-            Ok(syntax::AssociatedTypeItem {
-                name: assoc_ty.id.deref().clone(),
-                generics,
-                bounds,
-            })
-        },
-    )
+    Ok(syntax::AssociatedTypeItem {
+        name: assoc_ty.id.deref().clone(),
+        generics,
+        bounds,
+    })
 }
 
 pub fn lower_assoc_ty_value(
     ctx: &mut Context,
     assoc_ty: &AssociatedTyValue,
 ) -> Fallible<syntax::AssociatedTypeValueItem> {
-    ctx.with_binder(
-        &assoc_ty.binder,
-        false,
-        |term| &term.where_clauses,
-        |term, generics, ctx| {
-            let ty = tys::lower_ty(ctx, &term.ty)?;
-            Ok(syntax::AssociatedTypeValueItem {
-                name: assoc_ty.id.deref().clone(),
-                generics,
-                ty,
-            })
-        },
-    )
+    let (term, generics) = open_bounded!(ctx, &assoc_ty.binder);
+    let ty = tys::lower_ty(ctx, &term.ty)?;
+    Ok(syntax::AssociatedTypeValueItem {
+        name: assoc_ty.id.deref().clone(),
+        generics,
+        ty,
+    })
 }
 
 #[cfg(test)]

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -5,213 +5,219 @@ use crate::grammar::{
     RigidTy, ScalarId, ScalarValue, Ty, Variable,
 };
 
-use super::{syntax, RustBuilder};
+use super::{syntax, Context};
 
-impl RustBuilder {
-    pub fn lower_generic_arg(&mut self, parameter: &Parameter) -> Fallible<syntax::GenericArg> {
-        match parameter {
-            Parameter::Ty(ty) => Ok(syntax::GenericArg::Type(self.lower_ty(ty)?)),
-            Parameter::Lt(lt) => Ok(syntax::GenericArg::Lifetime(self.lower_lt(lt)?)),
-            Parameter::Const(konst) => Ok(syntax::GenericArg::Const(self.lower_const(konst)?)),
-        }
+pub fn lower_generic_arg(ctx: &mut Context, parameter: &Parameter) -> Fallible<syntax::GenericArg> {
+    match parameter {
+        Parameter::Ty(ty) => Ok(syntax::GenericArg::Type(lower_ty(ctx, ty)?)),
+        Parameter::Lt(lt) => Ok(syntax::GenericArg::Lifetime(lower_lt(ctx, lt)?)),
+        Parameter::Const(konst) => Ok(syntax::GenericArg::Const(lower_const(ctx, konst)?)),
     }
+}
 
-    pub fn lower_const(&mut self, konst: &Const) -> Fallible<syntax::ConstExpr> {
-        match konst {
-            ConstData::RigidValue(_) => {
-                todo!("lowering rigid const values is not implemented yet")
-            }
-            ConstData::Scalar(value) => {
-                let (value, suffix) = match value {
-                    ScalarValue::U8(v) => (v.to_string(), "u8"),
-                    ScalarValue::U16(v) => (v.to_string(), "u16"),
-                    ScalarValue::U32(v) => (v.to_string(), "u32"),
-                    ScalarValue::U64(v) => (v.to_string(), "u64"),
-                    ScalarValue::I8(v) => (v.to_string(), "i8"),
-                    ScalarValue::I16(v) => (v.to_string(), "i16"),
-                    ScalarValue::I32(v) => (v.to_string(), "i32"),
-                    ScalarValue::I64(v) => (v.to_string(), "i64"),
-                    ScalarValue::Usize(v) => (v.to_string(), "usize"),
-                    ScalarValue::Isize(v) => (v.to_string(), "isize"),
-                    ScalarValue::Bool(v) => {
-                        return Ok(syntax::ConstExpr::Ident(v.to_string()));
-                    }
-                };
-
-                Ok(syntax::ConstExpr::Scalar {
-                    value,
-                    suffix: suffix.to_owned(),
-                })
-            }
-            ConstData::Block(_) => {
-                todo!("lowering const block expressions is not implemented yet")
-            }
-            ConstData::Variable(core_variable) => Ok(syntax::ConstExpr::Ident(
-                self.core_variable_to_string(&core_variable)?,
-            )),
+pub fn lower_const(ctx: &mut Context, konst: &Const) -> Fallible<syntax::ConstExpr> {
+    match konst {
+        ConstData::RigidValue(_) => {
+            todo!("lowering rigid const values is not implemented yet")
         }
-    }
+        ConstData::Scalar(value) => {
+            let (value, suffix) = match value {
+                ScalarValue::U8(v) => (v.to_string(), "u8"),
+                ScalarValue::U16(v) => (v.to_string(), "u16"),
+                ScalarValue::U32(v) => (v.to_string(), "u32"),
+                ScalarValue::U64(v) => (v.to_string(), "u64"),
+                ScalarValue::I8(v) => (v.to_string(), "i8"),
+                ScalarValue::I16(v) => (v.to_string(), "i16"),
+                ScalarValue::I32(v) => (v.to_string(), "i32"),
+                ScalarValue::I64(v) => (v.to_string(), "i64"),
+                ScalarValue::Usize(v) => (v.to_string(), "usize"),
+                ScalarValue::Isize(v) => (v.to_string(), "isize"),
+                ScalarValue::Bool(v) => {
+                    return Ok(syntax::ConstExpr::Ident(v.to_string()));
+                }
+            };
 
-    pub fn lower_ty(&mut self, ty: &Ty) -> Fallible<syntax::Type> {
-        match ty {
-            Ty::RigidTy(rigid_ty) => self.lower_rigid_ty(&rigid_ty),
-            Ty::AliasTy(_) => todo!("lowering alias types is not implemented yet"),
-            Ty::PredicateTy(_) => {
-                todo!("lowering predicate types is not implemented yet")
-            }
-            Ty::Variable(core_variable) => Ok(syntax::Type::Path {
-                name: self.core_variable_to_string(&core_variable)?,
-                args: Vec::new(),
-            }),
-        }
-    }
-
-    pub fn lower_rigid_ty(&mut self, rigid_ty: &RigidTy) -> Fallible<syntax::Type> {
-        match &rigid_ty.name {
-            RigidName::AdtId(adt_id) => {
-                let args = rigid_ty
-                    .parameters
-                    .iter()
-                    .map(|arg| self.lower_generic_arg(arg))
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                Ok(syntax::Type::Path {
-                    name: adt_id.deref().clone(),
-                    args,
-                })
-            }
-            RigidName::ScalarId(scalar_id) => Ok(syntax::Type::Path {
-                name: self.scalar_to_string(scalar_id),
-                args: Vec::new(),
-            }),
-            RigidName::Ref(ref_kind) => self.lower_ref(ref_kind, &rigid_ty.parameters),
-            RigidName::Raw(ptr_kind) => self.lower_ptr(ptr_kind, &rigid_ty.parameters),
-            RigidName::Tuple(size) => self.lower_tuple(*size, &rigid_ty.parameters),
-            RigidName::FnPtr(size) => self.lower_fn_ptr(*size, &rigid_ty.parameters),
-            RigidName::FnDef(fn_id) => {
-                todo!("lowering fn def type `{:?}` is not implemented yet", fn_id)
-            }
-            RigidName::Never => Ok(syntax::Type::Never),
-        }
-    }
-
-    pub fn scalar_to_string(&self, scalar_id: &ScalarId) -> String {
-        match scalar_id {
-            ScalarId::U8 => "u8",
-            ScalarId::U16 => "u16",
-            ScalarId::U32 => "u32",
-            ScalarId::U64 => "u64",
-            ScalarId::I8 => "i8",
-            ScalarId::I16 => "i16",
-            ScalarId::I32 => "i32",
-            ScalarId::I64 => "i64",
-            ScalarId::Bool => "bool",
-            ScalarId::Usize => "usize",
-            ScalarId::Isize => "isize",
-        }
-        .to_owned()
-    }
-
-    fn lower_ref(&mut self, ref_kind: &RefKind, parameters: &Parameters) -> Fallible<syntax::Type> {
-        let lifetime = parameters
-            .first()
-            .and_then(|p| match p {
-                Parameter::Lt(lt) => Some(lt.deref().clone()),
-                _ => None,
+            Ok(syntax::ConstExpr::Scalar {
+                value,
+                suffix: suffix.to_owned(),
             })
-            .ok_or_else(|| anyhow::anyhow!("reference type is missing lifetime argument"))?;
+        }
+        ConstData::Block(_) => {
+            todo!("lowering const block expressions is not implemented yet")
+        }
+        ConstData::Variable(core_variable) => Ok(syntax::ConstExpr::Ident(
+            ctx.core_variable_to_string(&core_variable)?,
+        )),
+    }
+}
 
-        let pointee = parameters
-            .get(1)
-            .and_then(|p| match p {
-                Parameter::Ty(ty) => Some(ty),
-                _ => None,
+pub fn lower_ty(ctx: &mut Context, ty: &Ty) -> Fallible<syntax::Type> {
+    match ty {
+        Ty::RigidTy(rigid_ty) => lower_rigid_ty(ctx, &rigid_ty),
+        Ty::AliasTy(_) => todo!("lowering alias types is not implemented yet"),
+        Ty::PredicateTy(_) => {
+            todo!("lowering predicate types is not implemented yet")
+        }
+        Ty::Variable(core_variable) => Ok(syntax::Type::Path {
+            name: ctx.core_variable_to_string(&core_variable)?,
+            args: Vec::new(),
+        }),
+    }
+}
+
+pub fn lower_rigid_ty(ctx: &mut Context, rigid_ty: &RigidTy) -> Fallible<syntax::Type> {
+    match &rigid_ty.name {
+        RigidName::AdtId(adt_id) => {
+            let args = rigid_ty
+                .parameters
+                .iter()
+                .map(|arg| lower_generic_arg(ctx, arg))
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(syntax::Type::Path {
+                name: adt_id.deref().clone(),
+                args,
             })
-            .ok_or_else(|| anyhow::anyhow!("reference type is missing pointee type argument"))?;
+        }
+        RigidName::ScalarId(scalar_id) => Ok(syntax::Type::Path {
+            name: scalar_to_string(scalar_id),
+            args: Vec::new(),
+        }),
+        RigidName::Ref(ref_kind) => lower_ref(ctx, ref_kind, &rigid_ty.parameters),
+        RigidName::Raw(ptr_kind) => lower_ptr(ctx, ptr_kind, &rigid_ty.parameters),
+        RigidName::Tuple(size) => lower_tuple(ctx, *size, &rigid_ty.parameters),
+        RigidName::FnPtr(size) => lower_fn_ptr(ctx, *size, &rigid_ty.parameters),
+        RigidName::FnDef(fn_id) => {
+            todo!("lowering fn def type `{:?}` is not implemented yet", fn_id)
+        }
+        RigidName::Never => Ok(syntax::Type::Never),
+    }
+}
 
-        let lifetime = match &lifetime {
-            Lt::Variable(Variable::ExistentialVar(_)) => None,
-            _ => Some(self.lower_lt(&lifetime)?),
-        };
-        let pointee = self.lower_ty(pointee)?;
+pub fn scalar_to_string(scalar_id: &ScalarId) -> String {
+    match scalar_id {
+        ScalarId::U8 => "u8",
+        ScalarId::U16 => "u16",
+        ScalarId::U32 => "u32",
+        ScalarId::U64 => "u64",
+        ScalarId::I8 => "i8",
+        ScalarId::I16 => "i16",
+        ScalarId::I32 => "i32",
+        ScalarId::I64 => "i64",
+        ScalarId::Bool => "bool",
+        ScalarId::Usize => "usize",
+        ScalarId::Isize => "isize",
+    }
+    .to_owned()
+}
 
-        Ok(syntax::Type::Ref {
-            lifetime,
-            mutable: matches!(ref_kind, RefKind::Mut),
-            ty: Box::new(pointee),
+fn lower_ref(
+    ctx: &mut Context,
+    ref_kind: &RefKind,
+    parameters: &Parameters,
+) -> Fallible<syntax::Type> {
+    let lifetime = parameters
+        .first()
+        .and_then(|p| match p {
+            Parameter::Lt(lt) => Some(lt.deref().clone()),
+            _ => None,
         })
-    }
+        .ok_or_else(|| anyhow::anyhow!("reference type is missing lifetime argument"))?;
 
-    fn lower_ptr(&mut self, ptr_kind: &PtrKind, parameters: &Parameters) -> Fallible<syntax::Type> {
-        let pointee = parameters
-            .first()
-            .and_then(|p| match p {
-                Parameter::Ty(ty) => Some(ty),
-                _ => None,
-            })
-            .ok_or_else(|| anyhow::anyhow!("raw pointer type is missing pointee type argument"))?;
-
-        Ok(syntax::Type::RawPtr {
-            mutable: matches!(ptr_kind, PtrKind::Mut),
-            ty: Box::new(self.lower_ty(pointee)?),
+    let pointee = parameters
+        .get(1)
+        .and_then(|p| match p {
+            Parameter::Ty(ty) => Some(ty),
+            _ => None,
         })
-    }
+        .ok_or_else(|| anyhow::anyhow!("reference type is missing pointee type argument"))?;
 
-    pub fn lower_lt(&mut self, lt: &Lt) -> Fallible<String> {
-        match lt {
-            LtData::Static => Ok("'static".to_owned()),
-            LtData::Variable(core_variable) => self.core_variable_to_string(&core_variable),
-        }
-    }
+    let lifetime = match &lifetime {
+        Lt::Variable(Variable::ExistentialVar(_)) => None,
+        _ => Some(lower_lt(ctx, &lifetime)?),
+    };
+    let pointee = lower_ty(ctx, pointee)?;
 
-    fn lower_tuple(&mut self, size: usize, parameters: &Parameters) -> Fallible<syntax::Type> {
-        if size != parameters.len() {
-            anyhow::bail!(
-                "tuple arity mismatch: expected {size} arguments but found {}",
-                parameters.len()
-            );
-        }
+    Ok(syntax::Type::Ref {
+        lifetime,
+        mutable: matches!(ref_kind, RefKind::Mut),
+        ty: Box::new(pointee),
+    })
+}
 
-        let types = parameters
-            .iter()
-            .map(|p| match p {
-                Parameter::Ty(ty) => self.lower_ty(ty),
-                _ => anyhow::bail!("tuple parameters must all be types"),
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(syntax::Type::Tuple(types))
-    }
-
-    fn lower_fn_ptr(&mut self, size: usize, parameters: &Parameters) -> Fallible<syntax::Type> {
-        if size != parameters.len() {
-            anyhow::bail!(
-                "function pointer arity mismatch: expected {size} arguments but found {}",
-                parameters.len()
-            );
-        }
-
-        if parameters.is_empty() {
-            anyhow::bail!("function pointer must include a return type")
-        }
-
-        let mut types = parameters
-            .iter()
-            .map(|p| match p {
-                Parameter::Ty(ty) => self.lower_ty(ty),
-                _ => anyhow::bail!("function pointer parameters must all be types"),
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let output = types
-            .pop()
-            .ok_or_else(|| anyhow::anyhow!("function pointer must include a return type"))?;
-
-        Ok(syntax::Type::FnPtr {
-            inputs: types,
-            output: Box::new(output),
+fn lower_ptr(
+    ctx: &mut Context,
+    ptr_kind: &PtrKind,
+    parameters: &Parameters,
+) -> Fallible<syntax::Type> {
+    let pointee = parameters
+        .first()
+        .and_then(|p| match p {
+            Parameter::Ty(ty) => Some(ty),
+            _ => None,
         })
+        .ok_or_else(|| anyhow::anyhow!("raw pointer type is missing pointee type argument"))?;
+
+    Ok(syntax::Type::RawPtr {
+        mutable: matches!(ptr_kind, PtrKind::Mut),
+        ty: Box::new(lower_ty(ctx, pointee)?),
+    })
+}
+
+pub fn lower_lt(ctx: &mut Context, lt: &Lt) -> Fallible<String> {
+    match lt {
+        LtData::Static => Ok("'static".to_owned()),
+        LtData::Variable(core_variable) => ctx.core_variable_to_string(&core_variable),
     }
+}
+
+fn lower_tuple(ctx: &mut Context, size: usize, parameters: &Parameters) -> Fallible<syntax::Type> {
+    if size != parameters.len() {
+        anyhow::bail!(
+            "tuple arity mismatch: expected {size} arguments but found {}",
+            parameters.len()
+        );
+    }
+
+    let types = parameters
+        .iter()
+        .map(|p| match p {
+            Parameter::Ty(ty) => lower_ty(ctx, ty),
+            _ => anyhow::bail!("tuple parameters must all be types"),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(syntax::Type::Tuple(types))
+}
+
+fn lower_fn_ptr(ctx: &mut Context, size: usize, parameters: &Parameters) -> Fallible<syntax::Type> {
+    if size != parameters.len() {
+        anyhow::bail!(
+            "function pointer arity mismatch: expected {size} arguments but found {}",
+            parameters.len()
+        );
+    }
+
+    if parameters.is_empty() {
+        anyhow::bail!("function pointer must include a return type")
+    }
+
+    let mut types = parameters
+        .iter()
+        .map(|p| match p {
+            Parameter::Ty(ty) => lower_ty(ctx, ty),
+            _ => anyhow::bail!("function pointer parameters must all be types"),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let output = types
+        .pop()
+        .ok_or_else(|| anyhow::anyhow!("function pointer must include a return type"))?;
+
+    Ok(syntax::Type::FnPtr {
+        inputs: types,
+        output: Box::new(output),
+    })
 }
 
 #[cfg(test)]
@@ -246,52 +252,52 @@ mod test {
 
     #[test]
     fn pretty_print_type_variables() {
-        let b = RustBuilder::default();
+        let b = Context::default();
         let ty1 = create_ty(1);
         assert_eq!("T1", b.core_variable_to_string(&ty1).unwrap());
     }
 
     #[test]
     fn pretty_print_life_time_variables() {
-        let b = RustBuilder::default();
+        let b = Context::default();
         let lt1 = create_lt(1);
         assert_eq!("'a1", b.core_variable_to_string(&lt1).unwrap());
     }
 
     #[test]
     fn pretty_print_const_variables() {
-        let b = RustBuilder::default();
+        let b = Context::default();
         let const1 = create_const(1);
         assert_eq!("N1", b.core_variable_to_string(&const1).unwrap());
     }
 
     #[test]
     fn pretty_print_adt() {
-        let mut pp = RustBuilder::default();
+        let mut ctx = Context::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::AdtId(AdtId::new("Foo")),
             parameters: Vec::new(),
         });
-        let t = pp.lower_ty(&ty).unwrap().to_string();
+        let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
 
         assert_eq!("Foo", t);
     }
 
     #[test]
     fn pretty_print_scalar() {
-        let mut pp = RustBuilder::default();
+        let mut ctx = Context::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::ScalarId(ScalarId::U8),
             parameters: Vec::new(),
         });
-        let t = pp.lower_ty(&ty).unwrap().to_string();
+        let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
 
         assert_eq!("u8", t);
     }
 
     #[test]
     fn pretty_print_shared_ref() {
-        let mut pp = RustBuilder::default();
+        let mut ctx = Context::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Ref(RefKind::Shared),
             parameters: vec![
@@ -305,13 +311,13 @@ mod test {
                 ),
             ],
         });
-        let t = pp.lower_ty(&ty).unwrap().to_string();
+        let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
         assert_eq!("&'a1 u8", t);
     }
 
     #[test]
     fn pretty_print_mutable_ref() {
-        let mut pp = RustBuilder::default();
+        let mut ctx = Context::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Ref(RefKind::Mut),
             parameters: vec![
@@ -325,13 +331,13 @@ mod test {
                 ),
             ],
         });
-        let t = pp.lower_ty(&ty).unwrap().to_string();
+        let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
         assert_eq!("&'a1 mut u8", t);
     }
 
     #[test]
     fn pretty_print_mutable_static_ref() {
-        let mut pp = RustBuilder::default();
+        let mut ctx = Context::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Ref(RefKind::Mut),
             parameters: vec![
@@ -345,13 +351,13 @@ mod test {
                 ),
             ],
         });
-        let t = pp.lower_ty(&ty).unwrap().to_string();
+        let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
         assert_eq!("&'static mut u8", t);
     }
 
     #[test]
     fn pretty_print_existential_ref() {
-        let mut pp = RustBuilder::default();
+        let mut ctx = Context::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Ref(RefKind::Mut),
             parameters: vec![
@@ -371,13 +377,13 @@ mod test {
                 ),
             ],
         });
-        let t = pp.lower_ty(&ty).unwrap().to_string();
+        let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
         assert_eq!("&mut u8", t);
     }
 
     #[test]
     fn pretty_print_raw_ptr() {
-        let mut pp = RustBuilder::default();
+        let mut ctx = Context::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Raw(PtrKind::Const),
             parameters: vec![Parameter::Ty(
@@ -388,7 +394,7 @@ mod test {
                 .into(),
             )],
         });
-        let t = pp.lower_ty(&ty).unwrap().to_string();
+        let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
         assert_eq!("*const u8", t);
 
         let ty = Ty::RigidTy(RigidTy {
@@ -401,13 +407,13 @@ mod test {
                 .into(),
             )],
         });
-        let t = pp.lower_ty(&ty).unwrap().to_string();
+        let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
         assert_eq!("*mut u8", t);
     }
 
     #[test]
     fn pretty_print_tuple() {
-        let mut pp = RustBuilder::default();
+        let mut ctx = Context::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Tuple(2),
             parameters: vec![
@@ -427,14 +433,14 @@ mod test {
                 ),
             ],
         });
-        let t = pp.lower_ty(&ty).unwrap().to_string();
+        let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
 
         assert_eq!("(u8, i64)", t);
     }
 
     #[test]
     fn pretty_print_fn_ptr() {
-        let mut pp = RustBuilder::default();
+        let mut ctx = Context::default();
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::FnPtr(3),
             parameters: vec![
@@ -461,7 +467,7 @@ mod test {
                 ),
             ],
         });
-        let t = pp.lower_ty(&ty).unwrap().to_string();
+        let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
 
         assert_eq!("fn(u8, i64) -> isize", t);
     }

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -5,7 +5,7 @@ use crate::grammar::{
     RigidTy, ScalarId, ScalarValue, Ty, Variable,
 };
 
-use super::{syntax, Context};
+use super::{context::Context, syntax};
 
 pub fn lower_generic_arg(ctx: &mut Context, parameter: &Parameter) -> Fallible<syntax::GenericArg> {
     match parameter {
@@ -111,7 +111,7 @@ pub fn scalar_to_string(scalar_id: &ScalarId) -> String {
     .to_owned()
 }
 
-fn lower_ref(
+pub fn lower_ref(
     ctx: &mut Context,
     ref_kind: &RefKind,
     parameters: &Parameters,
@@ -145,7 +145,7 @@ fn lower_ref(
     })
 }
 
-fn lower_ptr(
+pub fn lower_ptr(
     ctx: &mut Context,
     ptr_kind: &PtrKind,
     parameters: &Parameters,
@@ -171,7 +171,11 @@ pub fn lower_lt(ctx: &mut Context, lt: &Lt) -> Fallible<String> {
     }
 }
 
-fn lower_tuple(ctx: &mut Context, size: usize, parameters: &Parameters) -> Fallible<syntax::Type> {
+pub fn lower_tuple(
+    ctx: &mut Context,
+    size: usize,
+    parameters: &Parameters,
+) -> Fallible<syntax::Type> {
     if size != parameters.len() {
         anyhow::bail!(
             "tuple arity mismatch: expected {size} arguments but found {}",
@@ -190,7 +194,11 @@ fn lower_tuple(ctx: &mut Context, size: usize, parameters: &Parameters) -> Falli
     Ok(syntax::Type::Tuple(types))
 }
 
-fn lower_fn_ptr(ctx: &mut Context, size: usize, parameters: &Parameters) -> Fallible<syntax::Type> {
+pub fn lower_fn_ptr(
+    ctx: &mut Context,
+    size: usize,
+    parameters: &Parameters,
+) -> Fallible<syntax::Type> {
     if size != parameters.len() {
         anyhow::bail!(
             "function pointer arity mismatch: expected {size} arguments but found {}",


### PR DESCRIPTION
## What does this PR do?

Refactors the `to_rust` module to use freestanding functions. The handling of binders is unified and simplified.

## How does it work, what questions do you have?

<!-- In your own words (**no LLM usage here**), explain the main idea of why it's correct. It's ok if you're not sure! Please include any questions you have. If you wish to use an LLM for translation, include the original as well as the translated version. Thanks! -->

Transforming methods to freestanding functions and renaming `RustBuilder` to `Context`

The previous `with_binder` function had a complicated type signature and didn't feel right. The replacement function `open_bounded` instantiates the binder with a new substitution and returns the term including the newly generated variable names.

To prevent replication (opening binder followed by generating the generics), I implemented the macro `open_bounded!` that calls the `open_bounded` function on Context and generates the Generics afterward.

## AI disclosure

* I did not use any AI tools

