### PR TITLE
Flatten Expr/ExprData into a single Expr enum

### DIFF
--- a/crates/formality-rust/src/check/borrow_check/liveness.rs
+++ b/crates/formality-rust/src/check/borrow_check/liveness.rs
@@ -1,7 +1,7 @@
 use crate::{
     check::borrow_check::env::TypeckEnv,
     check::borrow_check::flow_state::FlowState,
-    grammar::expr::{Block, Expr, ExprData, FieldExpr, Init, Label, LabelId, PlaceExpr, Stmt},
+    grammar::expr::{Block, Expr, FieldExpr, Init, Label, LabelId, PlaceExpr, Stmt},
 };
 use formality_core::{Set, Upcast};
 
@@ -313,32 +313,32 @@ impl LiveBefore for Expr {
         places_live: impl Upcast<LivePlaces>,
     ) -> LivePlaces {
         let places_live: LivePlaces = places_live.upcast();
-        match self.data() {
+        match self {
             // place = expr: the assignment kills `place`, then we need liveness of `expr`.
-            ExprData::Assign { place, expr } => {
-                Seq(expr, Assignment(place)).live_before(env, scopes, places_live)
+            Expr::Assign { place, expr } => {
+                Seq(&**expr, Assignment(place)).live_before(env, scopes, places_live)
             }
 
             // call callee(args): callee and args are all evaluated (callee first, then args left-to-right).
-            ExprData::Call { callee, args } => {
-                Seq(callee, args).live_before(env, scopes, places_live)
+            Expr::Call { callee, args } => {
+                Seq(&**callee, args).live_before(env, scopes, places_live)
             }
 
             // Literals don't access any places.
-            ExprData::Literal { .. } | ExprData::True | ExprData::False => places_live,
+            Expr::Literal { .. } | Expr::True | Expr::False => places_live,
 
             // &expr or &mut expr: the operand place is accessed.
-            ExprData::Ref {
+            Expr::Ref {
                 kind: _,
                 lt: _,
                 place: expr,
             } => expr.live_before(env, scopes, places_live),
 
             // A place expression used as a value: the place is live.
-            ExprData::Place(place_expr) => place_expr.live_before(env, scopes, places_live),
+            Expr::Place(place_expr) => place_expr.live_before(env, scopes, places_live),
 
             // Struct { field_exprs }: each field expression is evaluated.
-            ExprData::Struct {
+            Expr::Struct {
                 field_exprs,
                 adt_id: _,
                 turbofish: _,
@@ -346,7 +346,7 @@ impl LiveBefore for Expr {
 
             // Turbofish is just a variable reference with explicit type args —
             // the variable itself is live.
-            ExprData::Turbofish { id, args: _ } => {
+            Expr::Turbofish { id, args: _ } => {
                 let place_expr: PlaceExpr = id.upcast();
                 place_expr.live_before(env, scopes, places_live)
             }

--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -5,7 +5,7 @@ use crate::check::borrow_check::typed_place_expression::{
     TypedPlaceExpr, TypedPlaceExpressionData,
 };
 
-use crate::grammar::expr::{Block, Expr, ExprData, Init, PlaceExpr, Stmt};
+use crate::grammar::expr::{Block, Expr, Init, PlaceExpr, Stmt};
 use crate::grammar::{
     AliasTy, ExistentialVar, FieldName, Fn, Lt, Parameter, RefKind, Relation, RigidName, RigidTy,
     ScalarId, Struct, StructBoundData, TraitId, Ty, TyData, Variable, Wcs, WhereClause,
@@ -365,7 +365,7 @@ judgment_fn! {
 
             (let state = kill_loans(place, state))
             ------------------------------------------------------------ ("assign")
-            (borrow_check_expr(env, assumptions, state, ExprData::Assign { place, expr }, places_live_on_exit) => (Ty::unit(), state))
+            (borrow_check_expr(env, assumptions, state, Expr::Assign { place, expr }, places_live_on_exit) => (Ty::unit(), state))
         )
 
         (
@@ -397,22 +397,22 @@ judgment_fn! {
 
             (prove_where_clauses(env, assumptions, state, where_clauses) => state)
             ------------------------------------------------------------ ("call")
-            (borrow_check_expr(env, assumptions, state, ExprData::Call { callee, args }, places_live) => (output_ty, state))
+            (borrow_check_expr(env, assumptions, state, Expr::Call { callee, args }, places_live) => (output_ty, state))
         )
 
         (
             ------------------------------------------------------------ ("literal")
-            (borrow_check_expr(_env, _assumptions, state, ExprData::Literal { value: _, ty }, _places_live_on_exit) => (ty, state))
+            (borrow_check_expr(_env, _assumptions, state, Expr::Literal { value: _, ty }, _places_live_on_exit) => (ty, state))
         )
 
         (
             ------------------------------------------------------------ ("true")
-            (borrow_check_expr(_env, _assumptions, state, ExprData::True, _places_live_on_exit) => (ScalarId::Bool, state))
+            (borrow_check_expr(_env, _assumptions, state, Expr::True, _places_live_on_exit) => (ScalarId::Bool, state))
         )
 
         (
             ------------------------------------------------------------ ("false")
-            (borrow_check_expr(_env, _assumptions, state, ExprData::False, _places_live_on_exit) => (ScalarId::Bool, state))
+            (borrow_check_expr(_env, _assumptions, state, Expr::False, _places_live_on_exit) => (ScalarId::Bool, state))
         )
 
         (
@@ -440,7 +440,7 @@ judgment_fn! {
             (let state = state.with_loan(Loan::new(lt, place, kind)))
             (let ty = place.ty.ref_ty_of_kind(kind, lt))
             ------------------------------------------------------------ ("ref")
-            (borrow_check_expr(env, assumptions, state, ExprData::Ref { kind, lt, place }, places_live_on_exit) => (ty, state))
+            (borrow_check_expr(env, assumptions, state, Expr::Ref { kind, lt, place }, places_live_on_exit) => (ty, state))
         )
 
         (
@@ -450,7 +450,7 @@ judgment_fn! {
             // FIXME(#296): also need to track that the place has been moved from
             (prove_place_is_movable(env, assumptions, state, place) => state)
             ------------------------------------------------------------ ("place")
-            (borrow_check_expr(env, assumptions, state, ExprData::Place(place), places_live_on_exit) => (&place.ty, state))
+            (borrow_check_expr(env, assumptions, state, Expr::Place(place), places_live_on_exit) => (&place.ty, state))
         )
 
         (
@@ -463,7 +463,7 @@ judgment_fn! {
             (let ty = Ty::rigid(RigidName::fn_def(id), ()))
             // FIXME: check where clauses from fn
             ------------------------------------------------------------ ("fn-name")
-            (borrow_check_expr(env, _assumptions, state, ExprData::Place(place), _places_live_on_exit) => (ty, state))
+            (borrow_check_expr(env, _assumptions, state, Expr::Place(place), _places_live_on_exit) => (ty, state))
         )
 
         (
@@ -473,7 +473,7 @@ judgment_fn! {
             (let ty = Ty::rigid(RigidName::fn_def(id), args))
             // FIXME: check where clauses from fn
             ------------------------------------------------------------ ("turbofish")
-            (borrow_check_expr(env, _assumptions, state, ExprData::Turbofish { id, args }, _places_live_on_exit) => (ty, state))
+            (borrow_check_expr(env, _assumptions, state, Expr::Turbofish { id, args }, _places_live_on_exit) => (ty, state))
         )
 
         // fn foo<'a, T>() where T: 'a { }
@@ -512,7 +512,7 @@ judgment_fn! {
 
             (let ty = RigidTy::new(adt_id, &turbofish.parameters))
             ------------------------------------------------------------ ("struct")
-            (borrow_check_expr(env, assumptions, state, ExprData::Struct { adt_id, turbofish, field_exprs }, places_live_on_exit) => (ty, state))
+            (borrow_check_expr(env, assumptions, state, Expr::Struct { adt_id, turbofish, field_exprs }, places_live_on_exit) => (ty, state))
         )
     }
 }

--- a/crates/formality-rust/src/grammar/expr/codegen.rs
+++ b/crates/formality-rust/src/grammar/expr/codegen.rs
@@ -10,8 +10,6 @@ use crate::grammar::{
     Crates, Fallible, PredicateTy, RigidName, ScalarId, Ty, TyData,
 };
 
-use super::ExprData;
-
 struct ExprBuilder<'b> {
     program: &'b Crates,
 
@@ -89,13 +87,13 @@ impl ExprBuilder<'_> {
         expr: &Expr,
     ) -> Fallible<Cursor> {
         let target: PlaceExpr = target.upcast();
-        match expr.data() {
-            ExprData::Assign { place, expr } => {
+        match expr {
+            Expr::Assign { place, expr } => {
                 cursor = self.codegen_expr_writing_to(cursor, place, expr)?;
                 cursor = self.write_unit(cursor, target)?;
                 Ok(cursor)
             }
-            ExprData::Place(place_expr) => {
+            Expr::Place(place_expr) => {
                 let target = self.codegen_place_expr(&target)?;
                 let source = self.codegen_place_expr(place_expr)?;
                 let source = lang::ValueExpr::Load {
@@ -104,20 +102,20 @@ impl ExprBuilder<'_> {
                 cursor = self.write_assign(cursor, target, source)?;
                 Ok(cursor)
             }
-            ExprData::Call { callee, args } => todo!(),
-            ExprData::Literal { value, ty } => todo!(),
-            ExprData::True | ExprData::False => todo!(),
-            ExprData::Ref {
+            Expr::Call { callee, args } => todo!(),
+            Expr::Literal { value, ty } => todo!(),
+            Expr::True | Expr::False => todo!(),
+            Expr::Ref {
                 kind,
                 lt,
                 place: expr,
             } => todo!(),
-            ExprData::Struct {
+            Expr::Struct {
                 field_exprs,
                 adt_id,
                 turbofish,
             } => todo!(),
-            ExprData::Turbofish { id, args } => todo!(),
+            Expr::Turbofish { id, args } => todo!(),
         }
     }
 

--- a/crates/formality-rust/src/grammar/expr/mod.rs
+++ b/crates/formality-rust/src/grammar/expr/mod.rs
@@ -2,7 +2,7 @@ mod codegen;
 
 use std::sync::Arc;
 
-use formality_core::{id, term, DowncastTo};
+use formality_core::{id, term};
 
 use crate::grammar::{
     AdtId, Binder, FieldName, Lt, Parameter, RefKind, ScalarId, TraitId, Ty, ValueId,
@@ -101,32 +101,21 @@ pub enum Stmt {
     Exists { binder: Binder<Block> },
 }
 
-#[term($data)]
-pub struct Expr {
-    pub data: Arc<ExprData>,
-}
-
-impl Expr {
-    pub fn data(&self) -> &ExprData {
-        &self.data
-    }
-}
-
 #[term]
-pub enum ExprData {
+pub enum Expr {
     /// `place = expr`
     ///
     /// Assign a value to a place expression. Evaluates to `()`.
     /// The left-hand side must be a place expression (variable, deref, field).
     #[grammar($place = $expr)]
-    Assign { place: PlaceExpr, expr: Expr },
+    Assign { place: PlaceExpr, expr: Arc<Expr> },
 
     /// `call callee<tys>(args)`
     ///
     /// Call a function. The callee is a named function reference.
     /// Returns the call's result as a value.
     #[grammar($callee ($,args))]
-    Call { callee: Expr, args: Vec<Expr> },
+    Call { callee: Arc<Expr>, args: Vec<Expr> },
 
     /// `42_u32`
     ///
@@ -169,12 +158,6 @@ pub enum ExprData {
         adt_id: AdtId,
         turbofish: Turbofish,
     },
-}
-
-impl DowncastTo<ExprData> for Expr {
-    fn downcast_to(&self) -> Option<ExprData> {
-        Some(ExprData::clone(&self.data))
-    }
 }
 
 // ANCHOR: PlaceExpr

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -3,7 +3,7 @@
 use crate::rust::{term, try_term};
 use formality_macros::test;
 
-use crate::grammar::expr::{ExprData, PlaceExpr};
+use crate::grammar::expr::{Expr, PlaceExpr};
 use crate::grammar::{Crates, Fallible, ScalarId};
 
 #[test]
@@ -271,21 +271,21 @@ fn test_place_expr_deref_with_field_chain() {
 
 #[test]
 fn test_parse_literals() {
-    let expr_data: Fallible<ExprData> = try_term("0 _ bool");
+    let expr_data: Fallible<Expr> = try_term("0 _ bool");
     assert!(expr_data.is_err());
 
-    let expr_data: ExprData = try_term("0 _ u8").unwrap();
+    let expr_data: Expr = try_term("0 _ u8").unwrap();
     assert!(matches!(
         expr_data,
-        ExprData::Literal {
+        Expr::Literal {
             value: 0,
             ty: ScalarId::U8
         }
     ));
 
-    let expr_data: ExprData = try_term("false").unwrap();
-    assert!(matches!(expr_data, ExprData::False));
+    let expr_data: Expr = try_term("false").unwrap();
+    assert!(matches!(expr_data, Expr::False));
 
-    let expr_data: ExprData = try_term("true").unwrap();
-    assert!(matches!(expr_data, ExprData::True));
+    let expr_data: Expr = try_term("true").unwrap();
+    assert!(matches!(expr_data, Expr::True));
 }

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use crate::grammar::{
-    expr::{Block, Expr, ExprData, FieldExpr, Init, Label, PlaceExpr, Stmt},
+    expr::{Block, Expr, FieldExpr, Init, Label, PlaceExpr, Stmt},
     Binder, Fallible, FieldName, RefKind, Ty, ValueId,
 };
 
@@ -82,39 +82,37 @@ impl RustBuilder {
     }
 
     pub fn lower_expr(&mut self, expr: &Expr) -> Fallible<syntax::Expr> {
-        match expr.data() {
-            ExprData::Assign { place, expr } => Ok(syntax::Expr::Assign {
+        match expr {
+            Expr::Assign { place, expr } => Ok(syntax::Expr::Assign {
                 place: self.lower_place_expr(place)?,
                 value: Box::new(self.lower_expr(expr)?),
             }),
-            ExprData::Call { callee, args } => Ok(syntax::Expr::Call {
+            Expr::Call { callee, args } => Ok(syntax::Expr::Call {
                 callee: Box::new(self.lower_expr(callee)?),
                 args: args
                     .iter()
                     .map(|arg| self.lower_expr(arg))
                     .collect::<Result<Vec<_>, _>>()?,
             }),
-            ExprData::Literal { value, ty } => Ok(syntax::Expr::Literal {
+            Expr::Literal { value, ty } => Ok(syntax::Expr::Literal {
                 value: value.to_string(),
                 suffix: self.scalar_to_string(ty),
             }),
-            ExprData::True => Ok(syntax::Expr::Bool(true)),
-            ExprData::False => Ok(syntax::Expr::Bool(false)),
-            ExprData::Ref { kind, lt: _, place } => Ok(syntax::Expr::Ref {
+            Expr::True => Ok(syntax::Expr::Bool(true)),
+            Expr::False => Ok(syntax::Expr::Bool(false)),
+            Expr::Ref { kind, lt: _, place } => Ok(syntax::Expr::Ref {
                 mutable: matches!(kind, RefKind::Mut),
                 place: self.lower_place_expr(place)?,
             }),
-            ExprData::Place(place_expr) => {
-                Ok(syntax::Expr::Place(self.lower_place_expr(place_expr)?))
-            }
-            ExprData::Turbofish { id, args } => Ok(syntax::Expr::Path {
+            Expr::Place(place_expr) => Ok(syntax::Expr::Place(self.lower_place_expr(place_expr)?)),
+            Expr::Turbofish { id, args } => Ok(syntax::Expr::Path {
                 name: id.deref().clone(),
                 args: args
                     .iter()
                     .map(|arg| self.lower_generic_arg(arg))
                     .collect::<Result<Vec<_>, _>>()?,
             }),
-            ExprData::Struct {
+            Expr::Struct {
                 field_exprs,
                 adt_id,
                 turbofish,

--- a/tests/mir_typeck.rs
+++ b/tests/mir_typeck.rs
@@ -115,7 +115,7 @@ fn test_cyclic_goto() {
     )
 }
 
-/// Returns true (ExprData::True) type-checking coverage
+/// Returns true (Expr::True) type-checking coverage
 #[test]
 fn test_ret_true() {
     assert_ok!(


### PR DESCRIPTION
## What does this PR do?

Removes the `Expr` wrapper struct around `ExprData` and promotes the enum to be named `Expr` directly. This is the last flatten for the series as `Arc<T>` is now the only wrapper left in the grammar.

e.g., closes #318 

## How does it work, what questions do you have?

Same approach as PR #354 (PlaceExpr): the recursive variants (`Assign.expr` and `Call.callee`) wrap their inner `Expr` in `Arc` to keep the enum sized. Non-recursive variants and `Vec<Expr>` fields stay as direct values. All `ExprData::*` call sites are renamed to `Expr::*` in this PR so no migration alias.

## AI disclosure

<!-- Remove the items that do not apply -->

* I used an AI to author the main logic of the code

