### PR TITLE
Lower `Ty::AliasTy(_)` to Rust

### DIFF
--- a/crates/formality-rust/src/to_rust/crates.rs
+++ b/crates/formality-rust/src/to_rust/crates.rs
@@ -1,27 +1,44 @@
 use crate::grammar::{AdtItem, Crate, CrateItem, Crates, Fallible};
 use crate::to_rust::{
     context::Context, feature_gate, fns, structs_enums_and_adts, syntax, traits_and_impls,
+    CORE_CRATE_NAME, MY_CORE_CRATE_NAME, MY_CORE_IMPORT,
 };
-use std::{collections::HashMap, ops::Deref};
+use std::collections::HashMap;
 
 pub fn build_crates(ctx: &mut Context, crates: &Crates) -> Fallible<HashMap<String, String>> {
-    // TODO: If core crate:
-    // 1. rename it to something like amirformality-core
-    // 2. add it as a dependencie to the other crates
-    // 3. add import statements in other crates.
+    let contains_core = crates
+        .crates
+        .iter()
+        .find(|c| *(c.id) == CORE_CRATE_NAME)
+        .is_some();
+
     crates
         .crates
         .iter()
         .map(|krate| {
-            let lowered = lower_crate(ctx, krate)?;
-            Ok((krate.id.deref().clone(), lowered.to_string()))
+            let lowered = lower_crate(ctx, krate, contains_core)?;
+            let name = if *(krate.id) == CORE_CRATE_NAME {
+                MY_CORE_CRATE_NAME.to_string()
+            } else {
+                (*(krate.id)).clone()
+            };
+            Ok((name, lowered.to_string()))
         })
         .collect()
 }
 
-pub fn lower_crate(ctx: &mut Context, krate: &Crate) -> Fallible<syntax::RustCrate> {
+pub fn lower_crate(
+    ctx: &mut Context,
+    krate: &Crate,
+    add_core_import: bool,
+) -> Fallible<syntax::RustCrate> {
     let mut attrs = Vec::new();
-    let mut items = Vec::new();
+    // Do not import the core crate in itself.
+    let mut items = if add_core_import && *(krate.id) != CORE_CRATE_NAME {
+        vec![syntax::Item::Import((*MY_CORE_IMPORT).clone())]
+    } else {
+        Vec::new()
+    };
 
     for item in &krate.items {
         match item {
@@ -50,7 +67,11 @@ pub fn lower_crate(ctx: &mut Context, krate: &Crate) -> Fallible<syntax::RustCra
                 ));
             }
             CrateItem::Fn(function) => {
-                items.push(syntax::Item::Function(fns::lower_fn(ctx, function)?));
+                items.push(syntax::Item::Function(fns::lower_fn(
+                    ctx,
+                    function,
+                    syntax::Visibility::Public,
+                )?));
             }
             CrateItem::Test(_) => {
                 todo!("lowering `test` crate items is not implemented yet")

--- a/crates/formality-rust/src/to_rust/crates.rs
+++ b/crates/formality-rust/src/to_rust/crates.rs
@@ -5,6 +5,10 @@ use crate::to_rust::{
 use std::{collections::HashMap, ops::Deref};
 
 pub fn build_crates(ctx: &mut Context, crates: &Crates) -> Fallible<HashMap<String, String>> {
+    // TODO: If core crate:
+    // 1. rename it to something like amirformality-core
+    // 2. add it as a dependencie to the other crates
+    // 3. add import statements in other crates.
     crates
         .crates
         .iter()

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -199,7 +199,7 @@ mod test {
                 }
             ],
             r#"
-fn foo() -> u32 {
+pub fn foo() -> u32 {
     let mut x: u32;
     return x;
 }"#
@@ -219,7 +219,7 @@ fn foo() -> u32 {
                 }
             ],
             r#"
-fn foo() -> () {
+pub fn foo() -> () {
     'a: {
         break 'a;
     }
@@ -242,7 +242,7 @@ fn foo() -> () {
                 }
             ],
             r#"
-fn foo() -> u32 {
+pub fn foo() -> u32 {
     {
         let mut v1: u32 = 0_u32;
         let mut v2: &mut u32 = &mut v1;

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -8,7 +8,11 @@ use crate::to_rust::{
     syntax, tys,
 };
 
-pub fn lower_fn(ctx: &mut Context, function: &Fn) -> Fallible<syntax::FunctionItem> {
+pub fn lower_fn(
+    ctx: &mut Context,
+    function: &Fn,
+    visibility: syntax::Visibility,
+) -> Fallible<syntax::FunctionItem> {
     let (term, generics) = open_bounded!(ctx, &function.binder);
     let params = term
         .input_args
@@ -19,6 +23,7 @@ pub fn lower_fn(ctx: &mut Context, function: &Fn) -> Fallible<syntax::FunctionIt
     let body = lower_fn_body(ctx, &term.body)?;
 
     Ok(syntax::FunctionItem {
+        visibility,
         is_unsafe: matches!(function.safety, Safety::Unsafe),
         name: function.id.deref().clone(),
         generics,
@@ -61,7 +66,7 @@ mod test {
                 }
             ],
             r#"
-fn run() -> i32 {
+pub fn run() -> i32 {
     panic!("Trusted Fn Body")
 }
 "#
@@ -77,7 +82,7 @@ fn run() -> i32 {
                 }
             ],
             r#"
-fn run(mut p1: i32, mut p2: i32) -> i32 {
+pub fn run(mut p1: i32, mut p2: i32) -> i32 {
     panic!("Trusted Fn Body")
 }
 "#
@@ -93,7 +98,7 @@ fn run(mut p1: i32, mut p2: i32) -> i32 {
                 }
             ],
             r#"
-fn run<T0>(mut p1: T0) -> T0 {
+pub fn run<T0>(mut p1: T0) -> T0 {
     panic!("Trusted Fn Body")
 }
 "#
@@ -110,9 +115,9 @@ fn run<T0>(mut p1: T0) -> T0 {
                 }
             ],
             r#"
-trait Bar { }
+pub trait Bar { }
 
-fn run<T1>(mut p1: T1) -> T1 where T1: Bar {
+pub fn run<T1>(mut p1: T1) -> T1 where T1: Bar {
     panic!("Trusted Fn Body")
 }
 "#
@@ -129,7 +134,7 @@ fn run<T1>(mut p1: T1) -> T1 where T1: Bar {
                 }
             ],
             r#"
-fn run<const N0: i32>() -> i32 {
+pub fn run<const N0: i32>() -> i32 {
     panic!("Trusted Fn Body")
 }
 "#

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -1,4 +1,5 @@
 use crate::grammar::{Crates, Fallible, ParameterKind, Ty, WhereClause, WhereClauseData};
+use std::cell::LazyCell;
 use std::ops::Deref;
 
 pub mod context;
@@ -11,6 +12,13 @@ pub mod syntax;
 pub mod test_util;
 mod traits_and_impls;
 mod tys;
+
+pub(crate) const CORE_CRATE_NAME: &'static str = "core";
+pub(crate) const MY_CORE_CRATE_NAME: &'static str = "mycore";
+pub(crate) const MY_CORE_IMPORT: LazyCell<syntax::ImportItem> =
+    LazyCell::new(|| syntax::ImportItem {
+        crate_name: MY_CORE_CRATE_NAME.to_string(),
+    });
 
 /// Produces a Cargo workspaces on the file system in the
 /// `root_direcotry`. After sucesfully creating all the files,
@@ -36,6 +44,7 @@ pub fn create_workspace(crates: &Crates, root_directory: &std::path::Path) -> Fa
 
     let mut ctx = context::Context::default();
     let crates = crates::build_crates(&mut ctx, crates)?;
+    let contains_core = crates.get(MY_CORE_CRATE_NAME).is_some();
     let crates_path = root_directory.join("crates");
     let root_toml_path = root_directory.join("Cargo.toml");
 
@@ -61,6 +70,11 @@ pub fn create_workspace(crates: &Crates, root_directory: &std::path::Path) -> Fa
         writeln!(&file, "name = \"{name}\"")?;
         writeln!(&file, "version = \"0.1.0\"")?;
         writeln!(&file, "edition = \"2021\"")?;
+
+        if contains_core && name != MY_CORE_CRATE_NAME {
+            writeln!(&file, "[dependencies]")?;
+            writeln!(&file, "mycore = {{ path = \"../mycore\"}}")?;
+        }
 
         writeln!(&root_toml_file, "    \"crates/{name}\",")?;
     }

--- a/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
+++ b/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
@@ -16,6 +16,7 @@ pub fn lower_struct(ctx: &mut Context, strukt: &Struct) -> Fallible<syntax::Stru
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(syntax::StructItem {
+        visibility: syntax::Visibility::Public,
         name: strukt.id.deref().clone(),
         generics,
         fields,
@@ -30,6 +31,7 @@ pub fn lower_enum(ctx: &mut Context, e: &Enum) -> Fallible<syntax::EnumItem> {
         .map(|variant| lower_variant(ctx, variant))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(syntax::EnumItem {
+        visibility: syntax::Visibility::Public,
         name: e.id.deref().clone(),
         generics,
         variants,
@@ -70,6 +72,7 @@ pub fn lower_variant_fields(
 pub fn lower_named_struct_field(ctx: &mut Context, field: &Field) -> Fallible<syntax::StructField> {
     match &field.name {
         FieldName::Id(id) => Ok(syntax::StructField {
+            visibility: syntax::Visibility::Public,
             name: id.deref().clone(),
             ty: tys::lower_ty(ctx, &field.ty)?,
         }),
@@ -93,9 +96,9 @@ mod test {
                 }
             ],
             r#"
-struct Bar {
-    a: i32,
-    b: i32,
+pub struct Bar {
+    pub a: i32,
+    pub b: i32,
 }
 "#
         );
@@ -116,10 +119,10 @@ struct Bar {
                 }
             ],
             r#"
-trait Baz { }
+pub trait Baz { }
 
-struct Bar<T1> where T1: Baz {
-    a: T1,
+pub struct Bar<T1> where T1: Baz {
+    pub a: T1,
 }
 "#
         );
@@ -137,7 +140,7 @@ struct Bar<T1> where T1: Baz {
                 }
             ],
             r#"
-enum Bar {
+pub enum Bar {
     A,
     B,
 }
@@ -161,9 +164,9 @@ enum Bar {
                 }
             ],
             r#"
-trait Baz { }
+pub trait Baz { }
 
-enum Bar<T1> where T1: Baz {
+pub enum Bar<T1> where T1: Baz {
     A { t: T1 },
     B(T1),
 }

--- a/crates/formality-rust/src/to_rust/syntax.rs
+++ b/crates/formality-rust/src/to_rust/syntax.rs
@@ -54,6 +54,7 @@ impl Display for Attr {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Item {
+    Import(ImportItem),
     Struct(StructItem),
     Enum(EnumItem),
     Trait(TraitItem),
@@ -65,6 +66,7 @@ pub enum Item {
 impl Pretty for Item {
     fn fmt_pretty(&self, f: &mut Formatter<'_>, indent: usize) -> fmt::Result {
         match self {
+            Item::Import(item) => item.fmt_pretty(f, indent),
             Item::Struct(item) => item.fmt_pretty(f, indent),
             Item::Enum(item) => item.fmt_pretty(f, indent),
             Item::Trait(item) => item.fmt_pretty(f, indent),
@@ -332,13 +334,54 @@ impl Display for TypeBound {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Visibility {
+    Public,
+    PublicCrate,
+    /// Represents private visibility.
+    ///
+    /// This variant is also used for functions declared inside trait
+    /// definitions.
+    Private,
+}
+
+impl Visibility {
+    pub fn is_private(&self) -> bool {
+        matches!(self, Visibility::Private)
+    }
+}
+
+impl Display for Visibility {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Visibility::Public => f.write_str("pub"),
+            Visibility::PublicCrate => f.write_str("pub(crate)"),
+            Visibility::Private => Ok(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructField {
+    pub visibility: Visibility,
     pub name: String,
     pub ty: Type,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportItem {
+    pub crate_name: String,
+}
+
+impl Pretty for ImportItem {
+    fn fmt_pretty(&self, f: &mut Formatter<'_>, indent: usize) -> fmt::Result {
+        write_indent(f, indent)?;
+        write!(f, "use {}::*;", self.crate_name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructItem {
+    pub visibility: Visibility,
     pub name: String,
     pub generics: Generics,
     pub fields: Vec<StructField>,
@@ -347,6 +390,9 @@ pub struct StructItem {
 impl Pretty for StructItem {
     fn fmt_pretty(&self, f: &mut Formatter<'_>, indent: usize) -> fmt::Result {
         write_indent(f, indent)?;
+        if !self.visibility.is_private() {
+            write!(f, "{} ", self.visibility)?;
+        }
         write!(f, "struct {}", self.name)?;
         self.generics.fmt_params(f)?;
         self.generics.fmt_where_clauses(f)?;
@@ -356,6 +402,9 @@ impl Pretty for StructItem {
             writeln!(f)?;
             for field in &self.fields {
                 write_indent(f, indent + 1)?;
+                if !field.visibility.is_private() {
+                    write!(f, "{} ", field.visibility)?;
+                }
                 writeln!(f, "{}: {},", field.name, field.ty)?;
             }
             write_indent(f, indent)?;
@@ -367,6 +416,7 @@ impl Pretty for StructItem {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumItem {
+    pub visibility: Visibility,
     pub name: String,
     pub generics: Generics,
     pub variants: Vec<EnumVariant>,
@@ -375,6 +425,9 @@ pub struct EnumItem {
 impl Pretty for EnumItem {
     fn fmt_pretty(&self, f: &mut Formatter<'_>, indent: usize) -> fmt::Result {
         write_indent(f, indent)?;
+        if !self.visibility.is_private() {
+            write!(f, "{} ", self.visibility)?;
+        }
         write!(f, "enum {}", self.name)?;
         self.generics.fmt_params(f)?;
         self.generics.fmt_where_clauses(f)?;
@@ -453,6 +506,7 @@ pub enum FunctionBody {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionItem {
+    pub visibility: Visibility,
     pub is_unsafe: bool,
     pub name: String,
     pub generics: Generics,
@@ -464,6 +518,9 @@ pub struct FunctionItem {
 impl Pretty for FunctionItem {
     fn fmt_pretty(&self, f: &mut Formatter<'_>, indent: usize) -> fmt::Result {
         write_indent(f, indent)?;
+        if !self.visibility.is_private() {
+            write!(f, "{} ", self.visibility)?;
+        }
         if self.is_unsafe {
             f.write_str("unsafe ")?;
         }
@@ -504,6 +561,7 @@ impl Pretty for FunctionItem {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraitItem {
+    pub visibility: Visibility,
     pub is_unsafe: bool,
     pub name: String,
     pub generics: Generics,
@@ -513,6 +571,9 @@ pub struct TraitItem {
 impl Pretty for TraitItem {
     fn fmt_pretty(&self, f: &mut Formatter<'_>, indent: usize) -> fmt::Result {
         write_indent(f, indent)?;
+        if !self.visibility.is_private() {
+            write!(f, "{} ", self.visibility)?;
+        }
         if self.is_unsafe {
             f.write_str("unsafe ")?;
         }

--- a/crates/formality-rust/src/to_rust/syntax.rs
+++ b/crates/formality-rust/src/to_rust/syntax.rs
@@ -211,6 +211,11 @@ pub enum Type {
         inputs: Vec<Type>,
         output: Box<Type>,
     },
+    Alias {
+        ty: Box<Type>,
+        trait_name: String,
+        assoc_name: String,
+    },
     Never,
 }
 
@@ -264,6 +269,13 @@ impl Display for Type {
                     write!(f, "{ty}")?;
                 }
                 write!(f, ") -> {output}")
+            }
+            Type::Alias {
+                ty,
+                trait_name,
+                assoc_name,
+            } => {
+                write!(f, "<{} as {}>::{}", ty, trait_name, assoc_name)
             }
             Type::Never => f.write_char('!'),
         }

--- a/crates/formality-rust/src/to_rust/traits_and_impls.rs
+++ b/crates/formality-rust/src/to_rust/traits_and_impls.rs
@@ -17,7 +17,11 @@ pub fn lower_trait(ctx: &mut Context, t: &Trait) -> Fallible<syntax::TraitItem> 
     let mut items = Vec::new();
     for item in &term.trait_items {
         match item {
-            TraitItem::Fn(f) => items.push(syntax::TraitMember::Function(fns::lower_fn(ctx, f)?)),
+            TraitItem::Fn(f) => items.push(syntax::TraitMember::Function(fns::lower_fn(
+                ctx,
+                f,
+                syntax::Visibility::Private,
+            )?)),
             TraitItem::AssociatedTy(assoc_ty) => items.push(syntax::TraitMember::AssociatedType(
                 lower_assoc_ty(ctx, assoc_ty)?,
             )),
@@ -25,6 +29,7 @@ pub fn lower_trait(ctx: &mut Context, t: &Trait) -> Fallible<syntax::TraitItem> 
     }
 
     Ok(syntax::TraitItem {
+        visibility: syntax::Visibility::Public,
         is_unsafe: matches!(t.safety, Safety::Unsafe),
         name: t.id.deref().clone(),
         generics,
@@ -37,7 +42,11 @@ pub fn lower_trait_impl(ctx: &mut Context, trait_impl: &TraitImpl) -> Fallible<s
     let mut items = Vec::new();
     for item in &term.impl_items {
         match item {
-            ImplItem::Fn(f) => items.push(syntax::ImplMember::Function(fns::lower_fn(ctx, f)?)),
+            ImplItem::Fn(f) => items.push(syntax::ImplMember::Function(fns::lower_fn(
+                ctx,
+                f,
+                syntax::Visibility::Private,
+            )?)),
             ImplItem::AssociatedTyValue(v) => {
                 items.push(syntax::ImplMember::AssociatedTypeValue(
                     lower_assoc_ty_value(ctx, v)?,
@@ -146,7 +155,7 @@ mod test {
                 }
             ],
             r#"
-trait Write {
+pub trait Write {
     fn test() -> i32;
 }
 "#
@@ -165,7 +174,7 @@ trait Write {
                 }
             ],
             r#"
-trait Write {
+pub trait Write {
     type Error;
     fn test() -> i32;
 }
@@ -185,7 +194,7 @@ trait Write {
                 }
             ],
             r#"
-trait Write {
+pub trait Write {
     type Error<T1, T2>: Sized + Bar where T1: Read, T2: Write;
     fn test() -> i32;
 }
@@ -203,9 +212,9 @@ trait Write {
                 }
             ],
             "
-trait Baz { }
+pub trait Baz { }
 
-trait Bar<T2> where T2: Baz { }
+pub trait Bar<T2> where T2: Baz { }
 "
         );
     }
@@ -220,9 +229,9 @@ trait Bar<T2> where T2: Baz { }
                 }
             ],
             "
-trait Baz<T1, T2> { }
+pub trait Baz<T1, T2> { }
 
-trait Bar<T4> where T4: Baz<i32, u8> { }
+pub trait Bar<T4> where T4: Baz<i32, u8> { }
 "
         );
     }
@@ -240,9 +249,9 @@ trait Bar<T4> where T4: Baz<i32, u8> { }
                 }
             ],
             r#"
-trait Baz { }
+pub trait Baz { }
 
-trait Bar<T2> where T2: Baz {
+pub trait Bar<T2> where T2: Baz {
     type Error;
     fn test() -> T2;
 }
@@ -258,7 +267,7 @@ trait Bar<T2> where T2: Baz {
                     trait Bar<const C> where type_of_const C is bool {}
                 }
             ],
-            "trait Bar<const N1: bool> { }"
+            "pub trait Bar<const N1: bool> { }"
         );
     }
 
@@ -278,13 +287,13 @@ trait Bar<T2> where T2: Baz {
                 }
             ],
             r#"
-trait Bar<T1> {
+pub trait Bar<T1> {
     fn run() -> T1;
 }
 
-trait Bur { }
+pub trait Bur { }
 
-struct Baz {}
+pub struct Baz {}
 
 impl<T3> Bar<T3> for Baz where T3: Bur {
     fn run() -> T3 {
@@ -307,11 +316,11 @@ impl<T3> Bar<T3> for Baz where T3: Bur {
                 }
             ],
             r#"
-trait Bar {
+pub trait Bar {
     fn run() -> i32;
 }
 
-struct Baz {}
+pub struct Baz {}
 
 impl Bar for Baz {
     fn run() -> i32 {
@@ -333,9 +342,9 @@ impl Bar for Baz {
                 }
             ],
             r#"
-trait Bar { }
+pub trait Bar { }
 
-struct Baz {}
+pub struct Baz {}
 
 impl !Bar for Baz {}
 "#

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -1,8 +1,8 @@
 use std::ops::Deref;
 
 use crate::grammar::{
-    Const, ConstData, Fallible, Lt, LtData, Parameter, Parameters, PtrKind, RefKind, RigidName,
-    RigidTy, ScalarId, ScalarValue, Ty, Variable,
+    AliasTy, Const, ConstData, Fallible, Lt, LtData, Parameter, Parameters, PtrKind, RefKind,
+    RigidName, RigidTy, ScalarId, ScalarValue, Ty, Variable,
 };
 
 use super::{context::Context, syntax};
@@ -53,13 +53,13 @@ pub fn lower_const(ctx: &mut Context, konst: &Const) -> Fallible<syntax::ConstEx
 
 pub fn lower_ty(ctx: &mut Context, ty: &Ty) -> Fallible<syntax::Type> {
     match ty {
-        Ty::RigidTy(rigid_ty) => lower_rigid_ty(ctx, &rigid_ty),
-        Ty::AliasTy(_) => todo!("lowering alias types is not implemented yet"),
+        Ty::RigidTy(rigid_ty) => lower_rigid_ty(ctx, rigid_ty),
+        Ty::AliasTy(alias) => lower_alias_ty(ctx, alias),
         Ty::PredicateTy(_) => {
             todo!("lowering predicate types is not implemented yet")
         }
         Ty::Variable(core_variable) => Ok(syntax::Type::Path {
-            name: ctx.core_variable_to_string(&core_variable)?,
+            name: ctx.core_variable_to_string(core_variable)?,
             args: Vec::new(),
         }),
     }
@@ -92,6 +92,26 @@ pub fn lower_rigid_ty(ctx: &mut Context, rigid_ty: &RigidTy) -> Fallible<syntax:
         }
         RigidName::Never => Ok(syntax::Type::Never),
     }
+}
+
+pub fn lower_alias_ty(ctx: &mut Context, alias_ty: &AliasTy) -> Fallible<syntax::Type> {
+    let ty = alias_ty
+        .parameters
+        .get(0)
+        .and_then(|p| match p {
+            Parameter::Ty(ty) => lower_ty(ctx, ty).ok(),
+            Parameter::Lt(_lt) => todo!(),
+            Parameter::Const(_) => todo!(),
+        })
+        .ok_or_else(|| anyhow::anyhow!("alias type is missing type argument"))?;
+
+    Ok(match &alias_ty.name {
+        crate::grammar::AliasName::AssociatedTyId(associated_ty_name) => syntax::Type::Alias {
+            ty: Box::new(ty),
+            trait_name: associated_ty_name.trait_id.deref().clone(),
+            assoc_name: associated_ty_name.item_id.deref().clone(),
+        },
+    })
 }
 
 pub fn scalar_to_string(scalar_id: &ScalarId) -> String {
@@ -478,5 +498,31 @@ mod test {
         let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
 
         assert_eq!("fn(u8, i64) -> isize", t);
+    }
+
+    #[test]
+    fn alias_ty() {
+        crate::assert_rust!(
+            [
+                crate Blub {
+                    trait Foo {
+                        type Assoc: [];
+                    }
+                    trait Bar<U> {}
+                    impl<T, U> Bar<U> for T
+                    where
+                        <T as Foo>::Assoc: Bar<U> {}
+                }
+            ],
+            r#"
+trait Foo {
+    type Assoc;
+}
+
+trait Bar<T2> { }
+
+impl<T3, T4> Bar<T4> for T3 where <T3 as Foo>::Assoc: Bar<T4> {}
+"#
+        );
     }
 }

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -515,11 +515,11 @@ mod test {
                 }
             ],
             r#"
-trait Foo {
+pub trait Foo {
     type Assoc;
 }
 
-trait Bar<T2> { }
+pub trait Bar<T2> { }
 
 impl<T3, T4> Bar<T4> for T3 where <T3 as Foo>::Assoc: Bar<T4> {}
 "#


### PR DESCRIPTION
## What does this PR do?

Generates Rust code for the `Ty::AliasTy(_)` variant. The tests using the Alias Ty use multiple crates. Therefore, all language items (traits, enums, functions, structs) are now public. All crates import the core crate, if the core create exists.

## How does it work, what questions do you have?

Appropriate Rust code for `Ty::AliasTy(_)` is generated.
If a core crait exists, it is renamed to `mycore` to prevent name collisions with the Rust `core` crait. 
The `mycore` crait it is added as a dependency to all other crates and all language items are imported.

```rust
// Cargo.toml
[dependencies]
mycore = { path = "../mycore" }

// lib.rs
use mycore::*;
```

## AI disclosure

* I did not use any AI tools

