### PR TITLE
Add positive-test coverage tracking

### DIFF
--- a/crates/formality-core/src/judgment.rs
+++ b/crates/formality-core/src/judgment.rs
@@ -5,6 +5,8 @@ use crate::{fixed_point::FixedPointStack, Fallible, Map};
 mod assertion;
 pub use assertion::JudgmentAssertion;
 
+pub mod coverage;
+
 mod proven_set;
 pub use proven_set::{
     insert_smallest_proof, member_of, CheckProven, EachProof, FailedJudgment, FailedRule,

--- a/crates/formality-core/src/judgment/coverage.rs
+++ b/crates/formality-core/src/judgment/coverage.rs
@@ -1,0 +1,167 @@
+//! Coverage tracking for positive judgment tests.
+//!
+//! When a test successfully proves a judgment, we walk its [`ProofTree`] and
+//! record every `(judgment, rule)` pair that fired. Records are appended,
+//! one JSONL line per test, to `target/test-coverage.jsonl`. The eventual goal
+//! is to identify judgment rules that are not exercised by any positive test.
+//!
+//! Recording is best-effort: I/O errors are swallowed so coverage never fails
+//! a test. Disable entirely with `FORMALITY_COVERAGE=0`. Redirect the output
+//! directory with `FORMALITY_COVERAGE_DIR` (used by the integration tests).
+
+use std::collections::BTreeSet;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::panic::Location;
+use std::path::PathBuf;
+
+use super::ProofTree;
+
+/// A single (judgment, rule) pair as identified in the coverage output.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct RuleId {
+    pub judgment: String,
+    pub rule: String,
+    pub file: String,
+    pub line: u32,
+}
+
+impl ProofTree {
+    /// Walk this proof tree and return every distinct `(judgment, rule)` pair
+    /// that fired. Nodes with no `rule_name` (e.g. `for_all`, `if`, `let` leaves)
+    /// are skipped because they do not correspond to user-defined inference rules.
+    pub fn collect_rules(&self) -> BTreeSet<RuleId> {
+        let mut acc = BTreeSet::new();
+        self.collect_rules_into(&mut acc);
+        acc
+    }
+
+    fn collect_rules_into(&self, acc: &mut BTreeSet<RuleId>) {
+        if let Some(rule) = self.rule_name {
+            acc.insert(RuleId {
+                judgment: self.judgment_name.clone(),
+                rule: rule.to_string(),
+                // `file!()` produces backslashes on Windows in some paths; normalize
+                // so coverage records are portable across platforms.
+                file: self.file.replace('\\', "/"),
+                line: self.line,
+            });
+        }
+        for child in &self.children {
+            child.collect_rules_into(acc);
+        }
+    }
+}
+
+/// Record coverage for the currently-running test from one or more proof trees.
+///
+/// The test is identified by `Location::caller()`, which (because this function
+/// is `#[track_caller]` and the assertion helpers that call it are too) resolves
+/// to the source location of the `#[test]` body that triggered the assertion.
+#[track_caller]
+pub fn record_coverage<'a>(trees: impl IntoIterator<Item = &'a ProofTree>) {
+    if !coverage_enabled() {
+        return;
+    }
+
+    let Some(path) = coverage_file_path() else {
+        return;
+    };
+
+    let caller = Location::caller();
+
+    let mut rules: BTreeSet<RuleId> = BTreeSet::new();
+    for tree in trees {
+        tree.collect_rules_into(&mut rules);
+    }
+
+    let line = format_jsonl(caller, &rules);
+    let _ = append_line(&path, &line);
+}
+
+fn coverage_enabled() -> bool {
+    !matches!(std::env::var("FORMALITY_COVERAGE").as_deref(), Ok("0"))
+}
+
+fn coverage_file_path() -> Option<PathBuf> {
+    let dir = coverage_dir()?;
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir.join("test-coverage.jsonl"))
+}
+
+fn coverage_dir() -> Option<PathBuf> {
+    if let Ok(d) = std::env::var("FORMALITY_COVERAGE_DIR") {
+        return Some(PathBuf::from(d));
+    }
+    if let Ok(d) = std::env::var("CARGO_TARGET_DIR") {
+        return Some(PathBuf::from(d));
+    }
+    // Walk up from CARGO_MANIFEST_DIR until we find a `target/` directory.
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+    let mut cur = PathBuf::from(manifest);
+    loop {
+        let candidate = cur.join("target");
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+        if !cur.pop() {
+            return None;
+        }
+    }
+}
+
+// Append-mode writes of small payloads are atomic under PIPE_BUF on POSIX and
+// have similar guarantees on Windows for ordinary files, so parallel `cargo test`
+// processes can safely append to the same file without locking, provided each
+// line stays small.
+fn append_line(path: &PathBuf, line: &str) -> std::io::Result<()> {
+    let mut f = OpenOptions::new().create(true).append(true).open(path)?;
+    writeln!(f, "{line}")
+}
+
+fn format_jsonl(caller: &Location<'_>, rules: &BTreeSet<RuleId>) -> String {
+    let mut s = String::new();
+    s.push('{');
+    s.push_str("\"test_file\":");
+    push_json_str(&mut s, &caller.file().replace('\\', "/"));
+    s.push_str(",\"test_line\":");
+    s.push_str(&caller.line().to_string());
+    s.push_str(",\"test_column\":");
+    s.push_str(&caller.column().to_string());
+    s.push_str(",\"rules\":[");
+    for (i, r) in rules.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push('{');
+        s.push_str("\"judgment\":");
+        push_json_str(&mut s, &r.judgment);
+        s.push_str(",\"rule\":");
+        push_json_str(&mut s, &r.rule);
+        s.push_str(",\"file\":");
+        push_json_str(&mut s, &r.file);
+        s.push_str(",\"line\":");
+        s.push_str(&r.line.to_string());
+        s.push('}');
+    }
+    s.push_str("]}");
+    s
+}
+
+fn push_json_str(out: &mut String, s: &str) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}

--- a/crates/formality-core/src/judgment/proven_set.rs
+++ b/crates/formality-core/src/judgment/proven_set.rs
@@ -179,6 +179,8 @@ impl<J: Ord + Debug + Clone> ProvenSet<J> {
         match &self.data {
             ProvenSetData::Failure(e) => panic!("expected a successful proof, got {e}"),
             ProvenSetData::Success(map) => {
+                crate::judgment::coverage::record_coverage(map.values());
+
                 // Check values only (not proof trees)
                 let values: Set<_> = map.keys().cloned().collect();
                 expect_values.assert_eq(&format!("{values:?}"));

--- a/crates/formality-core/tests/coverage.rs
+++ b/crates/formality-core/tests/coverage.rs
@@ -1,0 +1,94 @@
+//! Integration test for the coverage tracker. Uses a tiny "dummy language"
+//! (just judgments over plain `Num`s — no `declare_language!` needed since
+//! the coverage tracker is language-independent) to exercise the recording
+//! path end-to-end without depending on `formality-rust`.
+
+use std::path::PathBuf;
+
+use formality_core::{cast_impl, judgment_fn, Fallible};
+
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Debug, Hash)]
+struct Num(u32);
+cast_impl!(Num);
+
+fn is_even(n: &Num) -> Fallible<()> {
+    if n.0 % 2 == 0 {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("{} is not even", n.0))
+    }
+}
+
+judgment_fn! {
+    fn all_even(nums: Vec<Num>) => () {
+        debug(nums)
+
+        (
+            (for_all(n in nums) (if is_even(n).is_ok()))
+            --------------------------------------- ("all_even")
+            (all_even(nums) => ())
+        )
+    }
+}
+
+judgment_fn! {
+    fn is_zero(n: Num) => () {
+        debug(n)
+
+        (
+            (if n.0 == 0)
+            --------------------------------------- ("is_zero")
+            (is_zero(n) => ())
+        )
+    }
+}
+
+#[test]
+fn coverage_records_rules_from_positive_tests() {
+    let tmp = std::env::temp_dir().join(format!("formality-coverage-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::env::set_var("FORMALITY_COVERAGE_DIR", &tmp);
+
+    let all_even_line = line!() + 1;
+    all_even(vec![Num(2), Num(4)]).assert_ok(expect_test::expect!["{()}"]);
+    let is_zero_line = line!() + 1;
+    is_zero(Num(0)).assert_ok(expect_test::expect!["{()}"]);
+
+    let file: PathBuf = tmp.join("test-coverage.jsonl");
+    let contents = std::fs::read_to_string(&file).expect("coverage file written");
+
+    assert!(
+        contents.contains("tests/coverage.rs"),
+        "missing test file in {contents}",
+    );
+    assert!(
+        contents.contains(&format!("\"test_line\":{all_even_line}")),
+        "missing all_even call line {all_even_line} in {contents}",
+    );
+    assert!(
+        contents.contains(&format!("\"test_line\":{is_zero_line}")),
+        "missing is_zero call line {is_zero_line} in {contents}",
+    );
+    assert!(
+        contents.contains("\"judgment\":\"all_even\""),
+        "missing all_even judgment in {contents}",
+    );
+    assert!(
+        contents.contains("\"rule\":\"all_even\""),
+        "missing all_even rule in {contents}",
+    );
+    assert!(
+        contents.contains("\"judgment\":\"is_zero\""),
+        "missing is_zero judgment in {contents}",
+    );
+    assert!(
+        contents.contains("\"rule\":\"is_zero\""),
+        "missing is_zero rule in {contents}",
+    );
+
+    // Each positive `assert_ok` should produce exactly one JSONL line.
+    let line_count = contents.lines().filter(|l| !l.is_empty()).count();
+    assert_eq!(line_count, 2, "expected 2 JSONL lines, got:\n{contents}");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -50,7 +50,8 @@ impl FormalityTest {
             rustc_override,
         } = self;
 
-        let _ = test_program_ok(&input).expect("expected program to pass");
+        let proof_tree = test_program_ok(&input).expect("expected program to pass");
+        formality_core::judgment::coverage::record_coverage(std::iter::once(&proof_tree));
         if let Some(expect) = rustc_override {
             run_rustc_backend(&input, expect);
         } else if run_rustc() {


### PR DESCRIPTION
## What does this PR do?
Adds positive-test coverage tracking. Every time a positive test proves a judgment, we walk the `ProofTree` and append a JSONL line to `target/test-coverage.jsonl` recording the test name and every `(judgment, rule)` pair that fired. First step toward the report/front-end described in the project notes.

- New module `formality_core::judgment::coverage` (generic, language-independent).
- Hooked into `ProvenSet::assert_ok` and the `assert_ok!` macro.
- Integration test under `crates/formality-core/tests/coverage.rs` exercises the recorder with a tiny dummy language.
- Opt-out via `FORMALITY_COVERAGE=0`; output dir overridable via `FORMALITY_COVERAGE_DIR`.

## How does it work, what questions do you have?

The proof tree comes from positive tests as they end up calling either `ProvenSet::assert_ok` or `test_program_ok`, both of which already produce/hold a `ProofTree`, so we just read it. `ProvenSet::assert_ok` is the generic hook and covers most positive tests including `test_where_clause`. The `assert_ok!` macro is the second hook, since it goes through `test_program_ok` which returns a bare `ProofTree` and bypasses `ProvenSet`. JSONL is used because `cargo test` runs in parallel as small append-only writes are atomic, so multiple test processes can append without locking. No questions

## AI disclosure

* I used an AI tool for rote or minor changes (e.g., refactoring, autocomplete)