### PR TITLE
Refactor test macros to builder pattern

### DIFF
--- a/crates/formality-rust/src/to_rust/test_util.rs
+++ b/crates/formality-rust/src/to_rust/test_util.rs
@@ -2,16 +2,12 @@
 //! Formality code behaves the same as equivalent surface-level Rust code.
 
 use crate::{
-    check::check_all_crates,
     rust::term,
     to_rust::{check_workspace, context::Context, crates::build_crates},
 };
 
 /// Asserts that the given Formality input is translated into the expected
 /// Rust code. Only a single crate is supported.
-///
-/// The Formality `input` must be provided as a token tree. The `expected` Rust
-/// output must be given as as string literal.
 #[macro_export]
 macro_rules! assert_rust {
     ($input:tt, $expected:literal) => {{
@@ -33,108 +29,19 @@ pub fn assert_rust(input: &str, expected: &str) {
     assert_eq!(rust, expected);
 }
 
-/// Asserts that compiling the given Formality code as Rust code with `rustc`
-/// succeeds.
-///
-/// By default, the generated Rust workspace is created in a temporary
-/// directory and deleted after the assertion completes. If the environment
-/// variable `FORMALITY_KEEP_DIR` is set to `1`, the temporary workspace is
-/// preserved to allow inspection of the generated Rust code.
-#[macro_export]
-macro_rules! assert_rustc_success {
-    ($input:tt) => {{
-        $crate::to_rust::test_util::assert_rustc_success(stringify!($input));
-    }};
-}
-
-#[track_caller]
-pub fn assert_rustc_success(input: &str) {
-    let mut tmp_dir = tempfile::TempDir::with_prefix("formality-").unwrap();
-    if keep_dir() {
-        tmp_dir.disable_cleanup(true);
-    }
-
-    let crates = term(input);
-    let result = check_workspace(&crates, tmp_dir.path()).unwrap();
-    let stderr = String::from_utf8_lossy(&result.stderr);
-    assert!(result.status.success(), "{stderr}");
-}
-
-/// Asserts that compiling the given Formality code as Rust code with `rustc`
-/// fails.
-///
-/// One or more expected rustc error codes may be provided to assert that the
-/// failure occurs for the anticipated reasons.
-///
-/// By default, the generated Rust workspace is created in a temporary
-/// directory and deleted after the assertion completes. If the environment
-/// variable `FORMALITY_KEEP_DIR` is set to `1`, the temporary workspace is
-/// preserved to allow inspection of the generated Rust code.
-#[macro_export]
-macro_rules! assert_rustc_error {
-    ($input:tt) => {{
-        $crate::to_rust::test_util::assert_rustc_error(stringify!($input), &[], tmp_dir.path());
-    }};
-    ($input:tt, [$($codes:expr),*]) => {{
-        let args: &[&str] = &[
-            $($codes)*
-        ];
-        $crate::to_rust::test_util::assert_rustc_error(stringify!($input), args, tmp_dir.path());
-    }};
-}
-
-#[track_caller]
-pub fn assert_rustc_error(input: &str, codes: &[&str]) {
+/// Runs rustc on the given Formality program and returns the captured
+/// stderr.
+pub fn run_rustc(input: &str) -> (bool, String) {
     let mut tmp_dir = tempfile::TempDir::with_prefix("formality-").unwrap();
     if keep_dir() {
         tmp_dir.disable_cleanup(true);
     }
     let crates = term(input);
     let result = check_workspace(&crates, tmp_dir.path()).unwrap();
-    assert!(!result.status.success());
-
-    let stderr = String::from_utf8_lossy(&result.stderr);
-    for code in codes {
-        assert!(stderr.find(*code).is_some());
-    }
+    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+    (result.status.success(), stderr)
 }
 
-/// Asserts that Formality and `rustc` arrive at the same conclusion about
-/// whether the given program type-checks.
-///
-/// By default, the generated Rust workspace is created in a temporary
-/// directory and deleted after the assertion completes. If the environment
-/// variable `FORMALITY_KEEP_DIR` is set to `1`, the temporary workspace is
-/// preserved to allow inspection of the generated Rust code.
-#[macro_export]
-macro_rules! assert_equivalence {
-    ($input:tt) => {{
-        $crate::to_rust::test_util::assert_equivalence(stringify!($input));
-    }};
-}
-
-pub fn assert_equivalence(input: &str) {
-    let mut tmp_dir = tempfile::TempDir::with_prefix("formality-").unwrap();
-    if keep_dir() {
-        tmp_dir.disable_cleanup(true);
-    }
-    let crates = term(input);
-    let rustc_result = check_workspace(&crates, tmp_dir.path()).unwrap();
-    let formality_result = check_all_crates(crates).check_proven();
-
-    match formality_result {
-        Ok(_) => assert!(rustc_result.status.success()),
-        Err(_) => assert!(!rustc_result.status.success()),
-    }
-}
-
-/// Returns `true` if the environment variable `FORMALITY_KEEP_DIR` is set to
-/// `1`.
-///
-/// Otherwise, returns `false`.
-///
-/// This function is used to determine whether the temporary workspace
-/// generated for Rust compilation should be preserved after running tests.
 fn keep_dir() -> bool {
     0 < std::env::var("FORMALITY_KEEP_DIR")
         .map(|s| s.parse::<i32>())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ use formality_rust::grammar::Crates;
 use formality_rust::prove::prove::{test_util::TestAssertion, Constraints};
 use formality_rust::rust::try_term;
 
+pub mod test_util;
+pub use test_util::FormalityTest;
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -39,24 +42,6 @@ pub fn main() -> anyhow::Result<()> {
 
     let _proof_tree = check_all_crates(&program).check_proven()?;
     Ok(())
-}
-
-#[macro_export]
-macro_rules! assert_ok {
-    ($input:tt) => {{
-        let _ = $crate::test_program_ok(stringify!($input)).expect("expected program to pass");
-        if $crate::run_rustc() {
-            formality_rust::assert_rustc_success!($input);
-        }
-    }};
-}
-
-#[macro_export]
-macro_rules! assert_err {
-    ($input:tt $expect:expr) => {{
-        use formality_core::test_util::AnyhowResultTestExt;
-        $crate::test_program_ok(stringify!($input)).assert_err_leaves($expect);
-    }};
 }
 
 pub fn test_program_ok(input: &str) -> anyhow::Result<ProofTree> {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,97 @@
+use expect_test::Expect;
+use formality_core::test_util::AnyhowResultTestExt;
+
+use crate::{run_rustc, test_program_ok};
+
+/// Stringify a list of crate declarations and wrap them in the `[ ... ]`
+/// brackets that the Crates grammar expects.
+#[macro_export]
+macro_rules! crates {
+    ($($t:tt)*) => { ::core::concat!("[", ::core::stringify!($($t)*), "]") };
+}
+
+enum BackendExpect {
+    Ok,
+    Err(Expect),
+}
+
+/// Builder for a test program and its per-backend expectations.
+pub struct FormalityTest {
+    input: String,
+    rustc_override: Option<BackendExpect>,
+}
+
+impl FormalityTest {
+    pub fn new(input: impl Into<String>) -> Self {
+        Self {
+            input: input.into(),
+            rustc_override: None,
+        }
+    }
+
+    /// Require rustc to accept the program (always runs rustc).
+    pub fn rustc_ok(mut self) -> Self {
+        self.rustc_override = Some(BackendExpect::Ok);
+        self
+    }
+
+    /// Require rustc to reject the program with the given stderr (always runs rustc).
+    pub fn rustc_err(mut self, expect: Expect) -> Self {
+        self.rustc_override = Some(BackendExpect::Err(expect));
+        self
+    }
+
+    /// Assert formality accepts the program. Also runs rustc if overridden,
+    /// or if `FORMALITY_RUN_RUSTC=1` (in which case rustc must also accept).
+    #[track_caller]
+    pub fn ok(self) {
+        let Self {
+            input,
+            rustc_override,
+        } = self;
+
+        let _ = test_program_ok(&input).expect("expected program to pass");
+        if let Some(expect) = rustc_override {
+            run_rustc_backend(&input, expect);
+        } else if run_rustc() {
+            run_rustc_backend(&input, BackendExpect::Ok);
+        }
+    }
+
+    /// Assert formality rejects the program with the given error. Also runs
+    /// rustc if overridden.
+    #[track_caller]
+    pub fn err(self, expect: Expect) {
+        let Self {
+            input,
+            rustc_override,
+        } = self;
+
+        test_program_ok(&input).assert_err_leaves(expect);
+
+        if let Some(rustc) = rustc_override {
+            run_rustc_backend(&input, rustc);
+        }
+    }
+}
+
+#[track_caller]
+fn run_rustc_backend(input: &str, expect: BackendExpect) {
+    let (success, stderr) = formality_rust::to_rust::test_util::run_rustc(input);
+    match expect {
+        BackendExpect::Ok => {
+            assert!(
+                success,
+                "expected `rustc` to succeed but it failed:\n{stderr}"
+            );
+        }
+        BackendExpect::Err(e) => {
+            assert!(
+                !success,
+                "expected `rustc` to fail but it succeeded:\n{stderr}"
+            );
+            let normalized = formality_core::test_util::normalize_paths(&stderr);
+            e.assert_eq(&normalized);
+        }
+    }
+}

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1,16 +1,12 @@
 #![allow(non_snake_case)]
-use a_mir_formality::{assert_err, assert_ok};
+use a_mir_formality::{crates, FormalityTest};
 
 #[test]
 fn parser() {
-    crate::assert_err!(
-        [
-            crate Foo {
-                trait Baz where  cake  {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate Foo {
+        trait Baz where  cake  {}
+    }])
+    .err(expect_test::expect![[r#"
             × expected `:`
                ╭────
              1 │ [crate Foo { trait Baz where cake {} }]
@@ -24,24 +20,18 @@ fn parser() {
                · ││╰── while parsing Crate
                · │╰── while parsing Vec
                · ╰── while parsing Crates
-               ╰────"#]]
-    )
+               ╰────"#]])
 }
 
 #[test]
 fn hello_world_fail() {
-    crate::assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 trait Foo<T> where T: Bar<Self> {}
 
                 trait Bar<T> where T: Baz {}
 
                 trait Baz {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: @ WellFormedTraitRef(Bar(!ty_0, !ty_1)), via: Bar(!ty_0, !ty_1), assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Baz(!ty_1), via: Bar(!ty_0, !ty_1), assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
@@ -52,250 +42,184 @@ fn hello_world_fail() {
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Baz(!ty_1), via: Place(?ty_2), assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Baz(!ty_1), via: PlaceRead(?ty_2, ?ty_3), assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0, ?ty_2, ?ty_3], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Baz(!ty_1), via: PlaceRead(?ty_2, ?ty_3), assumptions: {Bar(!ty_0, !ty_1)}, env: Env { variables: [!ty_1, !ty_0, ?ty_2, ?ty_3], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]])
 }
 
 #[test]
 fn hello_world() {
-    crate::assert_ok!(
+    FormalityTest::new(crates![crate Foo {
+        trait Foo<T> where T: Bar<Self>, Self: Baz {}
 
-        [
-            crate Foo {
-                trait Foo<T> where T: Bar<Self>, Self: Baz {}
+        trait Bar<T> where T: Baz {}
 
-                trait Bar<T> where T: Baz {}
+        trait Baz {}
 
-                trait Baz {}
+        impl Baz for u32 {}
 
-                impl Baz for u32 {}
-
-                impl Bar<u32> for u32 {}
-                impl<T> Bar<T> for () where T: Baz {}
-            }
-        ]
-    )
+        impl Bar<u32> for u32 {}
+        impl<T> Bar<T> for () where T: Baz {}
+    }])
+    .ok()
 }
 
 #[test]
 fn basic_where_clauses_pass() {
-    crate::assert_ok!(
-    [
-        crate core {
-            trait A<T> where T: B { }
+    FormalityTest::new(crates![crate core {
+        trait A<T> where T: B { }
 
-            trait B { }
+        trait B { }
 
-            trait WellFormed where for<T> u32: A<T> { }
+        trait WellFormed where for<T> u32: A<T> { }
 
-            impl <T> B for T {}
-        }
-    ])
+        impl <T> B for T {}
+    }])
+    .ok()
 }
 #[test]
 fn basic_where_clauses_fail() {
-    crate::assert_err!(
-        [
-            crate core {
+    FormalityTest::new(crates![crate core {
                 trait A<T> where T: B { }
 
                 trait B { }
 
                 trait WellFormed where for<T> u32: A<T> { }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: @ WellFormedTraitRef(A(u32, !ty_1)), via: A(u32, ?ty_2), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: B(!ty_0), via: A(u32, ?ty_1), assumptions: {for <ty> A(u32, ^ty0_0)}, env: Env { variables: [!ty_0, ?ty_1], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             the rule "trait implied bound" at (prove_wc.rs) failed because
-              expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
-    )
+              expression evaluated to an empty collection: `decls.trait_invariants()`"#]])
 }
 
 #[test]
 fn basic_adt_variant_dup() {
-    crate::assert_err!(
-        [
-            crate Foo {
-                enum Bar {
-                    Baz{},
-                    Baz{},
-                }
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate Foo {
+        enum Bar {
+            Baz{},
+            Baz{},
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "adt" at (mod.rs) failed because
-              variant "Baz" defined multiple times"#]]
-    )
+              variant "Baz" defined multiple times"#]])
 }
 
 #[test]
 fn basic_adt_field_dup() {
-    crate::assert_err!(
-        [
-            crate Foo {
-                struct Bar {
-                    baz: (),
-                    baz: (),
-                }
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate Foo {
+        struct Bar {
+            baz: (),
+            baz: (),
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "adt" at (mod.rs) failed because
-              field "baz" of variant "struct" defined multiple times"#]]
-    )
+              field "baz" of variant "struct" defined multiple times"#]])
 }
 
 #[test]
 fn trait_items_with_duplicate_fn_names() {
-    crate::assert_err!(
-        [
-            crate core {
-                trait A {
-                    fn a() -> ();
-                    fn a() -> ();
-                }
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate core {
+        trait A {
+            fn a() -> ();
+            fn a() -> ();
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check trait" at (traits.rs) failed because
-              the function name `a` is defined multiple times"#]]
-
-    );
+              the function name `a` is defined multiple times"#]]);
 }
 
 #[test]
 fn trait_items_with_duplicate_associated_type_names() {
-    crate::assert_err!(
-        [
-            crate core {
-                trait A {
-                    type Assoc : [];
-                    type Assoc : [];
-                }
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate core {
+        trait A {
+            type Assoc : [];
+            type Assoc : [];
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check trait" at (traits.rs) failed because
-              the associated type name `Assoc` is defined multiple times"#]]
-    );
+              the associated type name `Assoc` is defined multiple times"#]]);
 }
 
 #[test]
 fn crate_with_duplicate_item_names() {
-    crate::assert_err!(
-        [
-            crate core {
-                struct A {}
+    FormalityTest::new(crates![crate core {
+        struct A {}
 
-                enum A {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+        enum A {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check crate" at (mod.rs) failed because
-              the item name `A` is defined multiple times"#]]
-    );
+              the item name `A` is defined multiple times"#]]);
 
-    crate::assert_err!(
-        [
-            crate core {
-                trait a {}
+    FormalityTest::new(crates![crate core {
+        trait a {}
 
-                trait a {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+        trait a {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check crate" at (mod.rs) failed because
-              the trait name `a` is defined multiple times"#]]
-    );
+              the trait name `a` is defined multiple times"#]]);
 
-    crate::assert_err!(
-        [
-            crate core {
-                fn a() -> () { trusted }
+    FormalityTest::new(crates![crate core {
+        fn a() -> () { trusted }
 
-                fn a() -> () { trusted }
-            }
-        ]
-
-        expect_test::expect![[r#"
+        fn a() -> () { trusted }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check crate" at (mod.rs) failed because
-              the function name `a` is defined multiple times"#]]
-    );
+              the function name `a` is defined multiple times"#]]);
 
-    crate::assert_ok!(
+    FormalityTest::new(crates![crate core {
+        trait a {}
 
-        [
-            crate core {
-                trait a {}
-
-                fn a() -> () { trusted }
-            }
-        ]
-    );
+        fn a() -> () { trusted }
+    }])
+    .ok();
 }
 
 #[test]
 fn impl_missing_required_fn() {
-    crate::assert_err!(
-        [
-            crate core {
-                trait Foo {
-                    fn bar(self_: u32) -> u32;
-                }
-                struct MyStruct {}
-                impl Foo for MyStruct {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate core {
+        trait Foo {
+            fn bar(self_: u32) -> u32;
+        }
+        struct MyStruct {}
+        impl Foo for MyStruct {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check_trait_impl" at (impls.rs) failed because
-              not all trait items implemented, missing: `bar`"#]]
-    );
+              not all trait items implemented, missing: `bar`"#]]);
 }
 
 #[test]
 fn impl_missing_one_of_two_fns() {
-    crate::assert_err!(
-        [
-            crate core {
-                trait Foo {
-                    fn bar(self_: u32) -> u32;
-                    fn baz(self_: u32) -> u32;
-                }
-                struct MyStruct {}
-                impl Foo for MyStruct {
-                    fn bar(self_: u32) -> u32 {trusted}
-                }
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate core {
+        trait Foo {
+            fn bar(self_: u32) -> u32;
+            fn baz(self_: u32) -> u32;
+        }
+        struct MyStruct {}
+        impl Foo for MyStruct {
+            fn bar(self_: u32) -> u32 {trusted}
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check_trait_impl" at (impls.rs) failed because
-              not all trait items implemented, missing: `baz`"#]]
-    );
+              not all trait items implemented, missing: `baz`"#]]);
 }
 
 #[test]
 fn impl_with_default_fn_body_ok() {
-    crate::assert_ok!(
-        [
-            crate core {
-                trait Foo {
-                    fn bar(self_: u32) -> u32 {trusted}
-                }
-                struct MyStruct {}
-                impl Foo for MyStruct {}
-            }
-        ]
-    );
+    FormalityTest::new(crates![crate core {
+        trait Foo {
+            fn bar(self_: u32) -> u32 {trusted}
+        }
+        struct MyStruct {}
+        impl Foo for MyStruct {}
+    }])
+    .ok();
 }

--- a/tests/borrowck.rs
+++ b/tests/borrowck.rs
@@ -1,4 +1,4 @@
-use a_mir_formality::{assert_err, assert_ok};
+use a_mir_formality::{crates, FormalityTest};
 use formality_core::test;
 
 // ===================================================================
@@ -21,18 +21,13 @@ use formality_core::test;
 #[test]
 #[ignore = "needs initialization tracking (#296)"]
 fn use_of_uninitialized_variable() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    let x: u32;
-                    return x;
-                }
-            }
-        ]
-
-        expect_test::expect![[""]]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            let x: u32;
+            return x;
+        }
+    }])
+    .err(expect_test::expect![[""]])
 }
 
 /// Use of a moved variable should be an error.
@@ -49,24 +44,19 @@ fn use_of_uninitialized_variable() {
 #[test]
 #[ignore = "needs move tracking (#296)"]
 fn use_of_moved_variable() {
-    assert_err!(
-        [
-            crate Foo {
-                struct Datum {
-                    value: u32,
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Datum {
+            value: u32,
+        }
 
-                fn foo() -> Datum {
-                    let x: Datum = Datum { value: 0 _ u32 };
-                    let y: Datum = x;
-                    let z: Datum = x;
-                    return z;
-                }
-            }
-        ]
-
-        expect_test::expect![[""]]
-    )
+        fn foo() -> Datum {
+            let x: Datum = Datum { value: 0 _ u32 };
+            let y: Datum = x;
+            let z: Datum = x;
+            return z;
+        }
+    }])
+    .err(expect_test::expect![[""]])
 }
 
 /// Re-initialization after move should be OK.
@@ -83,23 +73,20 @@ fn use_of_moved_variable() {
 /// ```
 #[test]
 fn reinit_after_move() {
-    assert_ok!(
-        [
-            crate Foo {
-                struct Datum {
-                    value: u32,
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Datum {
+            value: u32,
+        }
 
-                fn foo() -> Datum {
-                    let x: Datum = Datum { value: 0 _ u32 };
-                    let y: Datum = x;
-                    x = Datum { value: 1 _ u32 };
-                    let z: Datum = x;
-                    return z;
-                }
-            }
-        ]
-    )
+        fn foo() -> Datum {
+            let x: Datum = Datum { value: 0 _ u32 };
+            let y: Datum = x;
+            x = Datum { value: 1 _ u32 };
+            let z: Datum = x;
+            return z;
+        }
+    }])
+    .ok()
 }
 
 /// Conditional initialization in only one branch should be an error.
@@ -116,22 +103,17 @@ fn reinit_after_move() {
 #[test]
 #[ignore = "needs initialization tracking (#296)"]
 fn conditional_init_one_branch() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    let x: u32;
-                    if true {
-                        x = 1 _ u32;
-                    } else {
-                    }
-                    return x;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            let x: u32;
+            if true {
+                x = 1 _ u32;
+            } else {
             }
-        ]
-
-        expect_test::expect![[""]]
-    )
+            return x;
+        }
+    }])
+    .err(expect_test::expect![[""]])
 }
 
 /// Conditional initialization in both branches should be OK.
@@ -149,21 +131,18 @@ fn conditional_init_one_branch() {
 /// ```
 #[test]
 fn conditional_init_both_branches() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    let x: u32;
-                    if true {
-                        x = 1 _ u32;
-                    } else {
-                        x = 2 _ u32;
-                    }
-                    return x;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            let x: u32;
+            if true {
+                x = 1 _ u32;
+            } else {
+                x = 2 _ u32;
             }
-        ]
-    )
+            return x;
+        }
+    }])
+    .ok()
 }
 
 /// Assigning to a field of an uninitialized variable should be an error.
@@ -178,24 +157,19 @@ fn conditional_init_both_branches() {
 #[test]
 #[ignore = "needs initialization tracking (#296)"]
 fn assign_field_of_uninitialized() {
-    assert_err!(
-        [
-            crate Foo {
-                struct Pair {
-                    first: u32,
-                    second: u32,
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Pair {
+            first: u32,
+            second: u32,
+        }
 
-                fn foo() -> u32 {
-                    let x: Pair;
-                    x.first = 1 _ u32;
-                    return 0 _ u32;
-                }
-            }
-        ]
-
-        expect_test::expect![[""]]
-    )
+        fn foo() -> u32 {
+            let x: Pair;
+            x.first = 1 _ u32;
+            return 0 _ u32;
+        }
+    }])
+    .err(expect_test::expect![[""]])
 }
 
 /// After a partial move, sibling fields should still be usable.
@@ -212,9 +186,7 @@ fn assign_field_of_uninitialized() {
 /// ```
 #[test]
 fn partial_move_use_sibling() {
-    assert_ok!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 struct Datum {
                     value: u32,
                 }
@@ -230,9 +202,7 @@ fn partial_move_use_sibling() {
                     let b: Datum = x.second;
                     return b;
                 }
-            }
-        ]
-    )
+            }]).ok()
 }
 
 /// After a partial move, using the whole struct should be an error.
@@ -250,9 +220,7 @@ fn partial_move_use_sibling() {
 #[test]
 #[ignore = "needs move tracking (#296)"]
 fn partial_move_use_whole() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 struct Datum {
                     value: u32,
                 }
@@ -268,11 +236,7 @@ fn partial_move_use_whole() {
                     let b: Pair = x;
                     return 0 _ u32;
                 }
-            }
-        ]
-
-        expect_test::expect![[""]]
-    )
+            }]).err(expect_test::expect![[""]])
 }
 
 /// Moving the same field twice should be an error.
@@ -290,9 +254,7 @@ fn partial_move_use_whole() {
 #[test]
 #[ignore = "needs move tracking (#296)"]
 fn move_same_field_twice() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 struct Datum {
                     value: u32,
                 }
@@ -308,11 +270,7 @@ fn move_same_field_twice() {
                     let b: Datum = x.first;
                     return b;
                 }
-            }
-        ]
-
-        expect_test::expect![[""]]
-    )
+            }]).err(expect_test::expect![[""]])
 }
 
 /// Moving the whole variable should make fields inaccessible.
@@ -330,9 +288,7 @@ fn move_same_field_twice() {
 #[test]
 #[ignore = "needs move tracking (#296)"]
 fn move_whole_then_access_field() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 struct Datum {
                     value: u32,
                 }
@@ -348,11 +304,7 @@ fn move_whole_then_access_field() {
                     let b: Datum = x.first;
                     return b;
                 }
-            }
-        ]
-
-        expect_test::expect![[""]]
-    )
+            }]).err(expect_test::expect![[""]])
 }
 
 /// Moving a parent field should make child fields inaccessible.
@@ -368,28 +320,23 @@ fn move_whole_then_access_field() {
 #[test]
 #[ignore = "needs move tracking (#296)"]
 fn move_parent_then_access_child() {
-    assert_err!(
-        [
-            crate Foo {
-                struct Inner {
-                    bar: u32,
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Inner {
+            bar: u32,
+        }
 
-                struct Outer {
-                    foo: Inner,
-                }
+        struct Outer {
+            foo: Inner,
+        }
 
-                fn foo() -> u32 {
-                    let x: Outer = Outer { foo: Inner { bar: 1 _ u32 } };
-                    let a: Inner = x.foo;
-                    let b: u32 = x.foo.bar;
-                    return b;
-                }
-            }
-        ]
-
-        expect_test::expect![[""]]
-    )
+        fn foo() -> u32 {
+            let x: Outer = Outer { foo: Inner { bar: 1 _ u32 } };
+            let a: Inner = x.foo;
+            let b: u32 = x.foo.bar;
+            return b;
+        }
+    }])
+    .err(expect_test::expect![[""]])
 }
 
 /// Cannot move out of a shared reference.
@@ -405,9 +352,7 @@ fn move_parent_then_access_child() {
 /// ```
 #[test]
 fn move_out_of_shared_ref() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 struct Datum {
                     value: u32,
                 }
@@ -420,10 +365,7 @@ fn move_out_of_shared_ref() {
                         return y;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Copy(Datum), via: @ wf(?lt_0), assumptions: {@ wf(?lt_0), @ wf(?lt_1)}, env: Env { variables: [?lt_0, ?lt_1], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Copy(Datum), via: @ wf(?lt_1), assumptions: {@ wf(?lt_0), @ wf(?lt_1)}, env: Env { variables: [?lt_0, ?lt_1], bias: Soundness, pending: [], allow_pending_outlives: true } }
@@ -650,8 +592,7 @@ fn move_out_of_shared_ref() {
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Copy(Datum), via: Place(?ty_2), assumptions: {@ wf(?lt_0), @ wf(?lt_1)}, env: Env { variables: [?lt_0, ?lt_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Copy(Datum), via: PlaceRead(?ty_2, ?ty_3), assumptions: {@ wf(?lt_0), @ wf(?lt_1)}, env: Env { variables: [?lt_0, ?lt_1, ?ty_2, ?ty_3], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Copy(Datum), via: PlaceRead(?ty_2, ?ty_3), assumptions: {@ wf(?lt_0), @ wf(?lt_1)}, env: Env { variables: [?lt_0, ?lt_1, ?ty_2, ?ty_3], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]])
 }
 
 /// Cannot move out of a mutable reference.
@@ -667,9 +608,7 @@ fn move_out_of_shared_ref() {
 /// ```
 #[test]
 fn move_out_of_mut_ref() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 struct Datum {
                     value: u32,
                 }
@@ -682,10 +621,7 @@ fn move_out_of_mut_ref() {
                         return y;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Copy(Datum), via: @ wf(?lt_0), assumptions: {@ wf(?lt_0), @ wf(?lt_1)}, env: Env { variables: [?lt_0, ?lt_1], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Copy(Datum), via: @ wf(?lt_1), assumptions: {@ wf(?lt_0), @ wf(?lt_1)}, env: Env { variables: [?lt_0, ?lt_1], bias: Soundness, pending: [], allow_pending_outlives: true } }
@@ -912,8 +848,7 @@ fn move_out_of_mut_ref() {
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Copy(Datum), via: Place(?ty_2), assumptions: {@ wf(?lt_0), @ wf(?lt_1)}, env: Env { variables: [?lt_0, ?lt_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Copy(Datum), via: PlaceRead(?ty_2, ?ty_3), assumptions: {@ wf(?lt_0), @ wf(?lt_1)}, env: Env { variables: [?lt_0, ?lt_1, ?ty_2, ?ty_3], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Copy(Datum), via: PlaceRead(?ty_2, ?ty_3), assumptions: {@ wf(?lt_0), @ wf(?lt_1)}, env: Env { variables: [?lt_0, ?lt_1, ?ty_2, ?ty_3], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]])
 }
 
 /// Cannot move a place that has an active loan.
@@ -929,25 +864,21 @@ fn move_out_of_mut_ref() {
 /// ```
 #[test]
 fn move_out_of_borrowed_place() {
-    assert_err!(
-        [
-            crate Foo {
-                struct Datum {
-                    value: u32,
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Datum {
+            value: u32,
+        }
 
-                fn foo() -> Datum {
-                    exists<'r0, 'r1> {
-                        let x: Datum = Datum { value: 0 _ u32 };
-                        let r: &'r0 Datum = &'r1 x;
-                        let y: Datum = x;
-                        return *r;
-                    }
-                }
+        fn foo() -> Datum {
+            exists<'r0, 'r1> {
+                let x: Datum = Datum { value: 0 _ u32 };
+                let r: &'r0 Datum = &'r1 x;
+                let y: Datum = x;
+                return *r;
             }
-        ]
-
-        expect_test::expect![[r#"
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = x : Datum
@@ -956,8 +887,7 @@ fn move_out_of_borrowed_place() {
             the rule "loan_cannot_outlive" at (nll.rs) failed because
               condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
                 outlived_by_loan = {?lt_1, ?lt_2}
-                &lifetime.upcast() = ?lt_1"#]]
-    )
+                &lifetime.upcast() = ?lt_1"#]])
 }
 
 /// A move in a loop should be an error on the second iteration.
@@ -976,26 +906,21 @@ fn move_out_of_borrowed_place() {
 #[test]
 #[ignore = "needs move tracking (#296)"]
 fn move_in_loop() {
-    assert_err!(
-        [
-            crate Foo {
-                struct Datum {
-                    value: u32,
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Datum {
+            value: u32,
+        }
 
-                fn foo() -> u32 {
-                    let x: Datum = Datum { value: 0 _ u32 };
-                    'l: loop {
-                        let y: Datum = x;
-                        break 'l;
-                    }
-                    return 0 _ u32;
-                }
+        fn foo() -> u32 {
+            let x: Datum = Datum { value: 0 _ u32 };
+            'l: loop {
+                let y: Datum = x;
+                break 'l;
             }
-        ]
-
-        expect_test::expect![[""]]
-    )
+            return 0 _ u32;
+        }
+    }])
+    .err(expect_test::expect![[""]])
 }
 
 /// Uninitialized return place should be an error.
@@ -1009,18 +934,13 @@ fn move_in_loop() {
 #[test]
 #[ignore = "needs initialization tracking (#296, #209)"]
 fn uninitialized_return() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    let x: u32;
-                    return x;
-                }
-            }
-        ]
-
-        expect_test::expect![[""]]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            let x: u32;
+            return x;
+        }
+    }])
+    .err(expect_test::expect![[""]])
 }
 /// Test the holding a shared reference to a local
 /// integer variable prevents it from being incremented.
@@ -1036,9 +956,7 @@ fn uninitialized_return() {
 /// ```
 #[test]
 fn mutable_ref_prevents_mutation() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> i32 {
                     exists<'r0, 'r1> {
                         let v1: i32 = 0 _ i32;
@@ -1048,10 +966,7 @@ fn mutable_ref_prevents_mutation() {
                         return *v2;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v1 : i32
@@ -1063,8 +978,7 @@ fn mutable_ref_prevents_mutation() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v1`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v1`"#]])
 }
 
 /// Test the holding a shared reference to a local
@@ -1081,9 +995,7 @@ fn mutable_ref_prevents_mutation() {
 /// ```
 #[test]
 fn shared_ref_prevents_mutation() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> i32 {
                     exists<'r0, 'r1> {
                         let v1: i32 = 0 _ i32;
@@ -1092,10 +1004,7 @@ fn shared_ref_prevents_mutation() {
                         return *v2;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v1 : i32
@@ -1107,8 +1016,7 @@ fn shared_ref_prevents_mutation() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v1`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v1`"#]])
 }
 
 /// Test the holding a shared reference to a local
@@ -1129,25 +1037,22 @@ fn shared_ref_prevents_mutation() {
 #[test]
 fn min_problem_case_3() {
     // This doesn't pass in Rust, but it does in our formulation.
-    assert_ok!(
-        [
-            crate Foo {
-                struct Map { }
+    FormalityTest::new(crates![crate Foo {
+        struct Map { }
 
-                fn min_problem_case_3<'a>(m: &mut 'a Map) -> &mut 'a Map {
-                    exists<'r0, 'r1> {
-                        let n: &mut 'r0 Map = &mut 'r0 *m;
-                        if true {
-                            return n;
-                        } else {
-                            let o: &mut 'r1 Map = &mut 'r1 *m;
-                            return o;
-                        }
-                    }
+        fn min_problem_case_3<'a>(m: &mut 'a Map) -> &mut 'a Map {
+            exists<'r0, 'r1> {
+                let n: &mut 'r0 Map = &mut 'r0 *m;
+                if true {
+                    return n;
+                } else {
+                    let o: &mut 'r1 Map = &mut 'r1 *m;
+                    return o;
                 }
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Test that dropping a borrowed variable is an error.
@@ -1165,9 +1070,7 @@ fn min_problem_case_3() {
 /// ```
 #[test]
 fn drop_while_borrowed() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> i32 {
                     exists<'r0, 'r1> {
                         let v2: &'r0 i32;
@@ -1178,10 +1081,7 @@ fn drop_while_borrowed() {
                         return *v2;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v1 : i32
@@ -1193,8 +1093,7 @@ fn drop_while_borrowed() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v1`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v1`"#]])
 }
 
 /// Test that dropping a variable is fine when the borrow is no longer live.
@@ -1212,23 +1111,20 @@ fn drop_while_borrowed() {
 /// ```
 #[test]
 fn drop_after_borrow_dead() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> i32 {
-                    exists<'r0, 'r1> {
-                        let result: i32;
-                        {
-                            let v1: i32 = 22 _ i32;
-                            let v2: &'r0 i32 = &'r1 v1;
-                            result = *v2;
-                        }
-                        return result;
-                    }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> i32 {
+            exists<'r0, 'r1> {
+                let result: i32;
+                {
+                    let v1: i32 = 22 _ i32;
+                    let v2: &'r0 i32 = &'r1 v1;
+                    result = *v2;
                 }
+                return result;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Test that dropping a mutably borrowed variable is an error.
@@ -1245,9 +1141,7 @@ fn drop_after_borrow_dead() {
 /// ```
 #[test]
 fn drop_while_mutably_borrowed() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> i32 {
                     exists<'r0, 'r1> {
                         let v2: &mut 'r0 i32;
@@ -1258,10 +1152,7 @@ fn drop_while_mutably_borrowed() {
                         return *v2;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v1 : i32
@@ -1273,8 +1164,7 @@ fn drop_while_mutably_borrowed() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v1`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v1`"#]])
 }
 
 /// Test that break out of a block drops locals in the exited scopes.
@@ -1292,9 +1182,7 @@ fn drop_while_mutably_borrowed() {
 /// ```
 #[test]
 fn drop_on_break_while_borrowed() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> i32 {
                     exists<'r0, 'r1> {
                         let v2: &'r0 i32;
@@ -1306,10 +1194,7 @@ fn drop_on_break_while_borrowed() {
                         return *v2;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v1 : i32
@@ -1321,8 +1206,7 @@ fn drop_on_break_while_borrowed() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v1`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v1`"#]])
 }
 
 /// A variant of Problem Case #3 which actually passes NLL
@@ -1340,47 +1224,38 @@ fn drop_on_break_while_borrowed() {
 /// ```
 #[test]
 fn too_min_problem_case_3() {
-    assert_ok!(
-        [
-            crate Foo {
-                struct Map { }
+    FormalityTest::new(crates![crate Foo {
+        struct Map { }
 
-                fn min_problem_case_3<'a>(m: &mut 'a Map) -> &mut 'a Map {
-                    exists<'r0, 'r1> {
-                        let n: &mut 'r0 Map = &mut 'r0 *m;
-                        if true {
-                        } else {
-                        }
-                        let o: &mut 'r1 Map = &mut 'r1 *m;
-                        return o;
-                    }
+        fn min_problem_case_3<'a>(m: &mut 'a Map) -> &mut 'a Map {
+            exists<'r0, 'r1> {
+                let n: &mut 'r0 Map = &mut 'r0 *m;
+                if true {
+                } else {
                 }
+                let o: &mut 'r1 Map = &mut 'r1 *m;
+                return o;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Upcasting from `'a` to `'b` errors because
 /// there is no declared relationship.
 #[formality_core::test]
 fn undeclared_universal_region_relationship() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo<'a, 'b>(v1: &'a u32) -> &'b u32 {
                     exists<'r0> {
                         let v2: &'r0 u32 = v1;
                         return v2;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: !lt_1 : !lt_2, via: @ wf(?lt_0), assumptions: {@ wf(?lt_0)}, env: Env { variables: [!lt_1, !lt_2, ?lt_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_1, b: !lt_2, assumptions: {@ wf(?lt_0)}, env: Env { variables: [!lt_1, !lt_2, ?lt_0], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_1, b: !lt_2, assumptions: {@ wf(?lt_0)}, env: Env { variables: [!lt_1, !lt_2, ?lt_0], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]])
 }
 
 /// Same as `undeclared_universal_region_relationship`, but the function
@@ -1388,109 +1263,88 @@ fn undeclared_universal_region_relationship() {
 /// outlives check fires even when there is no return terminator.
 #[formality_core::test]
 fn undeclared_universal_region_relationship_no_return() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo<'a, 'b>(v1: &'a u32, v2: &'b u32) -> () {
                     let output: &'b u32 = v2;
                     loop {
                         output = v1;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_0, b: !lt_1, assumptions: {}, env: Env { variables: [!lt_0, !lt_1], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_0, b: !lt_1, assumptions: {}, env: Env { variables: [!lt_0, !lt_1], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_0, b: !lt_1, assumptions: {}, env: Env { variables: [!lt_0, !lt_1], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]])
 }
 
 /// Upcasting from `'a` to `'b` is allowed because
 /// there is a declared relationship.
 #[formality_core::test]
 fn declared_universal_region_relationship() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo<'a, 'b>(v1: &'a u32) -> &'b u32
-                where
-                    'a: 'b,
-                {
-                    exists<'r0> {
-                        let v2: &'r0 u32 = v1;
-                        return v2;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo<'a, 'b>(v1: &'a u32) -> &'b u32
+        where
+            'a: 'b,
+        {
+            exists<'r0> {
+                let v2: &'r0 u32 = v1;
+                return v2;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Upcasting from `'a` to `'c` should be allowed because of
 /// the transitive relationship.
 #[formality_core::test]
 fn declared_transitive_universal_region_relationship() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo<'a, 'b, 'c>(v1: &'a u32) -> &'c u32
-                where
-                    'a: 'b,
-                    'b: 'c,
-                {
-                    return v1;
-                }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo<'a, 'b, 'c>(v1: &'a u32) -> &'c u32
+        where
+            'a: 'b,
+            'b: 'c,
+        {
+            return v1;
+        }
+    }])
+    .ok()
 }
 
 /// Upcasting from `'a` to `'c` errors because of a missing
 /// declared relationship to complete the transitive chain.
 #[formality_core::test]
 fn undeclared_transitive_universal_region_relationship() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo<'a, 'b, 'c>(v1: &'a u32) -> &'c u32
                 where
                     'a: 'b,
                 {
                     return v1;
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: !lt_0 : !lt_2, via: !lt_0 : !lt_1, assumptions: {!lt_0 : !lt_1}, env: Env { variables: [!lt_0, !lt_1, !lt_2], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_0, b: !lt_2, assumptions: {!lt_0 : !lt_1}, env: Env { variables: [!lt_0, !lt_1, !lt_2], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_0, b: !lt_2, assumptions: {!lt_0 : !lt_1}, env: Env { variables: [!lt_0, !lt_1, !lt_2], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]])
 }
 
 // For `list: &mut Map`, borrow `&mut (*list).value` then assign to `list`.
 #[test]
 fn problem_case_4() {
-    assert_ok!(
-        [
-            crate Foo {
-                struct Map {
-                    value: u32,
-                 }
+    FormalityTest::new(crates![crate Foo {
+        struct Map {
+            value: u32,
+         }
 
-                fn min_problem_case_4<'a>(list: &mut 'a Map, list2: &mut 'a Map) -> u32 {
-                    exists<'r0> {
-                        let num: &mut 'r0 u32 = &mut 'r0 (*list).value;
-                        list = &mut 'a *list2;
-                        num;
-                        return 0 _ u32;
-                    }
-                }
+        fn min_problem_case_4<'a>(list: &mut 'a Map, list2: &mut 'a Map) -> u32 {
+            exists<'r0> {
+                let num: &mut 'r0 u32 = &mut 'r0 (*list).value;
+                list = &mut 'a *list2;
+                num;
+                return 0 _ u32;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Test that StorageDead on a borrowed variable is an error.
@@ -1507,29 +1361,25 @@ fn problem_case_4() {
 #[test]
 #[ignore = "needs block scoping for storage dead semantics"]
 fn storage_dead_while_borrowed() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo() -> i32 = minirust {
-                    exists<'r0> {
-                        let v1: i32;
-                        let v2: &'r0 i32;
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> i32 = minirust {
+            exists<'r0> {
+                let v1: i32;
+                let v2: &'r0 i32;
 
-                        bb0: {
-                            statements {
-                                local(v1) = constant(0: i32);
-                                local(v2) = &'r0 local(v1);
-                                StorageDead(v1);
-                                local(_return) = load(*(local(v2)));
-                            }
-                            return;
-                        }
+                bb0: {
+                    statements {
+                        local(v1) = constant(0: i32);
+                        local(v2) = &'r0 local(v1);
+                        StorageDead(v1);
+                        local(_return) = load(*(local(v2)));
                     }
-                };
+                    return;
+                }
             }
-        ]
-
-        expect_test::expect![[r#"
+        };
+    }])
+    .err(expect_test::expect![[r#"
             MaybeFnBody expected
 
             Caused by:
@@ -1564,8 +1414,7 @@ fn storage_dead_while_borrowed() {
                                }
                            }
                        };
-                   }]"#]]
-    )
+                   }]"#]])
 }
 
 /// In this test, the write to `*(q.0)` is in fact safe,
@@ -1606,31 +1455,28 @@ fn cfg_union_approx_cause_false_error() {
         true
     }
      */
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo () -> u32 {
-                    exists<'l_p, 'l_q, 'loan_0, 'loan_1, 'loan_2, 'loan_3> {
-                        let a: u32 = 0 _ u32;
-                        let b: u32 = 0 _ u32;
-                        // In Rustc, the 1-tuple is needed for some reason
-                        // Niko does not 100% understand, else rustc is able to
-                        // see that this program is safe.
-                        let q: &mut 'l_q u32 = &mut 'loan_0 a;
-                        let p: &mut 'l_p u32 = &mut 'loan_1 a;
-                        if true {
-                            p = &mut 'loan_1 a;
-                            q = &mut 'loan_2 b;
-                        } else {
-                            p = &mut 'loan_3 b;
-                        }
-                        *q = 1 _ u32;
-                        return *p;
-                    }
+    FormalityTest::new(crates![crate Foo {
+        fn foo () -> u32 {
+            exists<'l_p, 'l_q, 'loan_0, 'loan_1, 'loan_2, 'loan_3> {
+                let a: u32 = 0 _ u32;
+                let b: u32 = 0 _ u32;
+                // In Rustc, the 1-tuple is needed for some reason
+                // Niko does not 100% understand, else rustc is able to
+                // see that this program is safe.
+                let q: &mut 'l_q u32 = &mut 'loan_0 a;
+                let p: &mut 'l_p u32 = &mut 'loan_1 a;
+                if true {
+                    p = &mut 'loan_1 a;
+                    q = &mut 'loan_2 b;
+                } else {
+                    p = &mut 'loan_3 b;
                 }
+                *q = 1 _ u32;
+                return *p;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// `continue` drops locals declared inside the loop body.
@@ -1638,9 +1484,7 @@ fn cfg_union_approx_cause_false_error() {
 /// borrow escapes to a variable outside the loop.
 #[test]
 fn continue_drops_borrowed_local_false_edge() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> i32 {
                     exists<'r0, 'r1> {
                         let r: &'r0 i32;
@@ -1652,10 +1496,7 @@ fn continue_drops_borrowed_local_false_edge() {
                         r; // only an error because of false edges, assumption that all loops terminate
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = y : i32
@@ -1680,8 +1521,7 @@ fn continue_drops_borrowed_local_false_edge() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `y`"#]]
-    );
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `y`"#]]);
 }
 
 /// `continue` drops locals declared inside the loop body.
@@ -1689,9 +1529,7 @@ fn continue_drops_borrowed_local_false_edge() {
 /// borrow escapes to a variable outside the loop.
 #[test]
 fn continue_drops_borrowed_local_loop_carried() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> i32 {
                     exists<'r0, 'r1> {
                         let x: i32 = 0 _ i32;
@@ -1704,10 +1542,7 @@ fn continue_drops_borrowed_local_loop_carried() {
                         }
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = y : i32
@@ -1732,8 +1567,7 @@ fn continue_drops_borrowed_local_loop_carried() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `y`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `y`"#]])
 }
 
 /// `break` drops locals declared inside the loop body.
@@ -1753,9 +1587,7 @@ fn continue_drops_borrowed_local_loop_carried() {
 /// ```
 #[test]
 fn break_drops_borrowed_local() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> i32 {
                     exists<'r0, 'r1> {
                         let r: &'r0 i32;
@@ -1767,10 +1599,7 @@ fn break_drops_borrowed_local() {
                         return *r;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = x : i32
@@ -1795,8 +1624,7 @@ fn break_drops_borrowed_local() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `x`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `x`"#]])
 }
 
 /// Locals declared inside a loop are properly scoped:
@@ -1814,22 +1642,19 @@ fn break_drops_borrowed_local() {
 /// ```
 #[test]
 fn continue_drops_local_borrow_dead() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    exists<'r0, 'r1> {
-                        'a: loop {
-                            let x: i32 = 0 _ i32;
-                            let r: &'r0 i32 = &'r1 x;
-                            let _y: i32 = *r;
-                            continue 'a;
-                        }
-                    }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            exists<'r0, 'r1> {
+                'a: loop {
+                    let x: i32 = 0 _ i32;
+                    let r: &'r0 i32 = &'r1 x;
+                    let _y: i32 = *r;
+                    continue 'a;
                 }
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Locals declared inside a loop are properly scoped:
@@ -1847,19 +1672,16 @@ fn continue_drops_local_borrow_dead() {
 /// ```
 #[test]
 fn integer_in_outer_scope() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    'a: {
-                        {
-                            let 'a: v: i32 = 0 _ i32;
-                        }
-                    }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            'a: {
+                {
+                    let 'a: v: i32 = 0 _ i32;
                 }
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Writing to a borrowed variable inside a loop before `continue`
@@ -1886,9 +1708,7 @@ fn integer_in_outer_scope() {
 /// ```
 #[test]
 fn write_to_borrowed_before_continue() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> u32 {
                     exists<'r0, 'r1> {
                         let a: u32 = 22 _ u32;
@@ -1904,10 +1724,7 @@ fn write_to_borrowed_before_continue() {
                         return *p;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = a : u32
@@ -1932,8 +1749,7 @@ fn write_to_borrowed_before_continue() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `a`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `a`"#]])
 }
 
 /// Test that `false` works as a condition in `if` with borrow checking.
@@ -1954,25 +1770,22 @@ fn write_to_borrowed_before_continue() {
 /// ```
 #[test]
 fn if_false_borrowck() {
-    assert_ok!(
-        [
-            crate Foo {
-                struct Map { }
+    FormalityTest::new(crates![crate Foo {
+        struct Map { }
 
-                fn foo<'a>(m: &mut 'a Map) -> &mut 'a Map {
-                    exists<'r0, 'r1> {
-                        let n: &mut 'r0 Map = &mut 'r0 *m;
-                        if false {
-                            return n;
-                        } else {
-                            let o: &mut 'r1 Map = &mut 'r1 *m;
-                            return o;
-                        }
-                    }
+        fn foo<'a>(m: &mut 'a Map) -> &mut 'a Map {
+            exists<'r0, 'r1> {
+                let n: &mut 'r0 Map = &mut 'r0 *m;
+                if false {
+                    return n;
+                } else {
+                    let o: &mut 'r1 Map = &mut 'r1 *m;
+                    return o;
                 }
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Writing to a borrowed variable before a loop that might not execute
@@ -1990,9 +1803,7 @@ fn if_false_borrowck() {
 /// ```
 #[test]
 fn write_to_borrowed_before_zero_iteration_loop() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> u32 {
                     exists<'r0, 'r1, 'r2> {
                         let a: u32 = 22 _ u32;
@@ -2006,10 +1817,7 @@ fn write_to_borrowed_before_zero_iteration_loop() {
                         return *p;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = a : u32
@@ -2021,8 +1829,7 @@ fn write_to_borrowed_before_zero_iteration_loop() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `a`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `a`"#]])
 }
 
 /// Test call to a generic function using turbofish syntax.
@@ -2038,46 +1845,40 @@ fn write_to_borrowed_before_zero_iteration_loop() {
 /// ```
 #[test]
 fn call_generic_fn_with_turbofish() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn identity<T>(v1: T) -> T {
-                    return v1;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn identity<T>(v1: T) -> T {
+            return v1;
+        }
 
-                fn foo<'a>(a: &'a u32) -> &'a u32 {
-                    exists<'r0> {
-                        let r: &'r0 u32 = identity::<&'r0 u32>(a);
-                        return r;
-                    }
-                }
+        fn foo<'a>(a: &'a u32) -> &'a u32 {
+            exists<'r0> {
+                let r: &'r0 u32 = identity::<&'r0 u32>(a);
+                return r;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// pass &T to generic foo.
 #[test]
 fn call_pass_ref() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo<'a>(x: &'a u32) -> u32 {
-                    exists {
-                        return *x;
-                    }
-                }
-
-                fn bar() -> u32 {
-                    exists<'r1> {
-                        let v: u32 = 7 _ u32;
-                        let r: u32 = foo::<'r1>(&'r1 v);
-                        return r;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo<'a>(x: &'a u32) -> u32 {
+            exists {
+                return *x;
             }
-        ]
-    )
+        }
+
+        fn bar() -> u32 {
+            exists<'r1> {
+                let v: u32 = 7 _ u32;
+                let r: u32 = foo::<'r1>(&'r1 v);
+                return r;
+            }
+        }
+    }])
+    .ok()
 }
 
 /// Test call to a generic function using turbofish syntax and upcasting.
@@ -2093,21 +1894,18 @@ fn call_pass_ref() {
 /// ```
 #[test]
 fn call_generic_fn_with_turbofish_upcast() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn identity<T>(v1: T) -> T {
-                    return v1;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn identity<T>(v1: T) -> T {
+            return v1;
+        }
 
-                fn foo<'a, 'b>(a: &'a u32) -> &'b u32
-                where 'a: 'b {
-                    let r: &'b u32 = identity::<&'b u32>(a);
-                    return r;
-                }
-            }
-        ]
-    )
+        fn foo<'a, 'b>(a: &'a u32) -> &'b u32
+        where 'a: 'b {
+            let r: &'b u32 = identity::<&'b u32>(a);
+            return r;
+        }
+    }])
+    .ok()
 }
 
 /// Test call to a generic function using turbofish syntax and wrong lifetime.
@@ -2123,9 +1921,7 @@ fn call_generic_fn_with_turbofish_upcast() {
 /// ```
 #[test]
 fn call_generic_fn_with_turbofish_missing_relation_upcast() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn identity<T>(v1: T) -> T {
                     return v1;
                 }
@@ -2134,61 +1930,49 @@ fn call_generic_fn_with_turbofish_missing_relation_upcast() {
                     let r: &'b u32 = identity::<&'b u32>(a);
                     return r;
                 }
-            }
-        ]
-
-        expect_test::expect!["crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_0, b: !lt_1, assumptions: {}, env: Env { variables: [!lt_0, !lt_1], bias: Soundness, pending: [], allow_pending_outlives: false } }"]
-    )
+            }]).err(expect_test::expect!["crates/formality-rust/src/prove/prove/prove/prove_outlives.rs:8:1: no applicable rules for prove_outlives { a: !lt_0, b: !lt_1, assumptions: {}, env: Env { variables: [!lt_0, !lt_1], bias: Soundness, pending: [], allow_pending_outlives: false } }"])
 }
 
 /// Test call to a generic function using turbofish syntax with lifetime and type.
 #[test]
 fn call_generic_fn_with_turbofish_lifetime_type() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn bar<'a, T>(v1: T) -> T where T : 'a{
-                    return v1;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn bar<'a, T>(v1: T) -> T where T : 'a{
+            return v1;
+        }
 
-                fn foo<'b>(a: &'b u32) -> &'b u32 {
-                    let r: &'b u32 = bar::<'b, &'b u32>(a);
-                    return r;
-                }
-            }
-        ]
-    )
+        fn foo<'b>(a: &'b u32) -> &'b u32 {
+            let r: &'b u32 = bar::<'b, &'b u32>(a);
+            return r;
+        }
+    }])
+    .ok()
 }
 
 /// Call foo while p, &v is live then use p.
 #[test]
 fn call_while_borrow_live() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo(x: u32) -> u32 {
-                    return x;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo(x: u32) -> u32 {
+            return x;
+        }
 
-                fn bar() -> u32 {
-                    exists<'r0, 'r1> {
-                        let v: u32 = 1 _ u32;
-                        let p: &'r0 u32 = &'r1 v;
-                        foo(0 _ u32);
-                        return *p;
-                    }
-                }
+        fn bar() -> u32 {
+            exists<'r0, 'r1> {
+                let v: u32 = 1 _ u32;
+                let p: &'r0 u32 = &'r1 v;
+                foo(0 _ u32);
+                return *p;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// shared &v passing &mut v into foo in the same scope is a borrow error.
 #[test]
 fn call_mut_under_shared_borrow() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo<'a>(x: &mut 'a u32) -> u32 {
                     exists {
                         *x = 1 _ u32;
@@ -2204,10 +1988,7 @@ fn call_mut_under_shared_borrow() {
                         return *p;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = v : u32
@@ -2219,39 +2000,32 @@ fn call_mut_under_shared_borrow() {
                 &lifetime.upcast() = ?lt_1
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v`"#]]
-
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `v`"#]])
 }
 
 // mutably borrowing two distinct fields of a struct -> assert_ok!
 #[test]
 fn struct_disjoint_field_borrows() {
-    assert_ok!(
-        [
-            crate Foo {
-                struct Point { x: u32, y: u32 }
-                fn foo() -> u32 {
-                    exists<'r0, 'r1, 'r2, 'r3> {
-                        let p: Point = Point { x: 0 _ u32, y: 0 _ u32 };
-                        let b1: &mut 'r0 u32 = &mut 'r1 p.x;
-                        let b2: &mut 'r2 u32 = &mut 'r3 p.y;
-                        *b1 = 1 _ u32;
-                        *b2 = 2 _ u32;
-                        return 0 _ u32;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Point { x: u32, y: u32 }
+        fn foo() -> u32 {
+            exists<'r0, 'r1, 'r2, 'r3> {
+                let p: Point = Point { x: 0 _ u32, y: 0 _ u32 };
+                let b1: &mut 'r0 u32 = &mut 'r1 p.x;
+                let b2: &mut 'r2 u32 = &mut 'r3 p.y;
+                *b1 = 1 _ u32;
+                *b2 = 2 _ u32;
+                return 0 _ u32;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// accessing a field while it is already mutably borrowed -> borrow error
 #[test]
 fn struct_conflicting_field_borrows() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 struct Point { x: u32, y: u32 }
                 fn foo() -> u32 {
                     exists<'r0, 'r1> {
@@ -2261,9 +2035,7 @@ fn struct_conflicting_field_borrows() {
                         return *b1;
                     }
                 }
-            }
-        ]
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = p : Point . x : u32
@@ -2278,30 +2050,26 @@ fn struct_conflicting_field_borrows() {
               pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `p`
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `p : Point . x`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `p : Point . x`"#]])
 }
 
 // constructing a struct reading a local variable that is mutably borrowed -> borrow error
 #[test]
 fn struct_construction_with_borrowed_local() {
-    assert_err!(
-    [
-        crate Foo {
-            struct Wrapper {
-                value: u32,
-            }
-            fn foo() -> u32 {
-                exists<'r0, 'r1> {
-                    let v1: u32 = 22 _ u32;
-                    let v2: &mut 'r0 u32 = &mut 'r1 v1;
-                    let w: Wrapper = Wrapper { value: v1 };
-                    return *v2;
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Wrapper {
+            value: u32,
+        }
+        fn foo() -> u32 {
+            exists<'r0, 'r1> {
+                let v1: u32 = 22 _ u32;
+                let v2: &mut 'r0 u32 = &mut 'r1 v1;
+                let w: Wrapper = Wrapper { value: v1 };
+                return *v2;
             }
         }
-    ]
-    expect_test::expect![[r#"
+    }])
+    .err(expect_test::expect![[r#"
         the rule "borrow of disjoint places" at (nll.rs) failed because
           condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
             &loan.place = v1 : u32
@@ -2320,16 +2088,13 @@ fn struct_construction_with_borrowed_local() {
         the rule "loan_cannot_outlive" at (nll.rs) failed because
           condition evaluated to false: `!outlived_by_loan.contains(&lifetime.upcast())`
             outlived_by_loan = {?lt_1, ?lt_2}
-            &lifetime.upcast() = ?lt_1"#]]
-    )
+            &lifetime.upcast() = ?lt_1"#]])
 }
 
 /// placing a mutable reference inside a struct -> locks the underlying local variable
 #[test]
 fn struct_with_mutable_reference_locks_local() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 struct Wrapper<'a> {
                     value: &mut 'a u32,
                 }
@@ -2341,103 +2106,88 @@ fn struct_with_mutable_reference_locks_local() {
                         return *(w.value);
                     }
                 }
-            }
-        ]
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: @ wf(Wrapper<?lt_0>), via: @ wf(?lt_0), assumptions: {@ wf(?lt_0)}, env: Env { variables: [?lt_0], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_wf.rs:14:1: no applicable rules for prove_wf { goal: ?lt_0, assumptions: {@ wf(?lt_0)}, env: Env { variables: [?lt_0], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_wf.rs:14:1: no applicable rules for prove_wf { goal: ?lt_0, assumptions: {@ wf(?lt_0)}, env: Env { variables: [?lt_0], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]])
 }
 
 // Divergent paths (aka return) should not propagate outlives, liveness
 #[test]
 fn loan_before_return_does_not_affect_merged_paths() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn reborrow<'a>(a: &mut 'a u8) -> &mut 'a u8 {
-                    exists<'r0, 'r1, 'r2, 'r3> {
-                        if true {
-                            let b: &mut 'r1 u8 = &mut 'r0 *a;
-                            return b;
-                        } else { }
+    FormalityTest::new(crates![crate Foo {
+        fn reborrow<'a>(a: &mut 'a u8) -> &mut 'a u8 {
+            exists<'r0, 'r1, 'r2, 'r3> {
+                if true {
+                    let b: &mut 'r1 u8 = &mut 'r0 *a;
+                    return b;
+                } else { }
 
-                        let c: &mut 'r3 u8 = &mut 'r2 *a;
-                        return c;
-                    }
-                }
+                let c: &mut 'r3 u8 = &mut 'r2 *a;
+                return c;
             }
-        ]
-    );
+        }
+    }])
+    .ok();
 }
 
 // Divergent paths (aka return) should not propagate outlives, liveness
 #[test]
 fn outlive_before_return_does_not_affect_merged_paths() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn reborrow<'a>(a: &mut 'a u8) -> &mut 'a u8 {
-                    exists<'r0, 'r1, 'r2, 'r3> {
-                        // This creates an outlives constraint
-                        let b: &mut 'r1 u8 = &mut 'r0 *a;
-                        if true {
-                            return b;
-                        } else {
-                            // this means the loan remains live
-                        }
-
-                        // If the outlives constraint propagated here,
-                        // we would get an error.
-                        let c: &mut 'r3 u8 = &mut 'r2 *a;
-                        return c;
-                    }
+    FormalityTest::new(crates![crate Foo {
+        fn reborrow<'a>(a: &mut 'a u8) -> &mut 'a u8 {
+            exists<'r0, 'r1, 'r2, 'r3> {
+                // This creates an outlives constraint
+                let b: &mut 'r1 u8 = &mut 'r0 *a;
+                if true {
+                    return b;
+                } else {
+                    // this means the loan remains live
                 }
+
+                // If the outlives constraint propagated here,
+                // we would get an error.
+                let c: &mut 'r3 u8 = &mut 'r2 *a;
+                return c;
             }
-        ]
-    );
+        }
+    }])
+    .ok();
 }
 
 // Divergent paths (aka return) should not propagate outlives, liveness
 #[test]
 fn loan_before_return_does_not_affect_dead_code_after() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn reborrow<'a>(a: &mut 'a u8) -> &mut 'a u8 {
-                    exists<'r0, 'r1, 'r2, 'r3> {
-                        let b: &mut 'r1 u8 = &mut 'r0 *a;
-                        return b;
-                        let c: &mut 'r3 u8 = &mut 'r2 *a;
-                        return c;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn reborrow<'a>(a: &mut 'a u8) -> &mut 'a u8 {
+            exists<'r0, 'r1, 'r2, 'r3> {
+                let b: &mut 'r1 u8 = &mut 'r0 *a;
+                return b;
+                let c: &mut 'r3 u8 = &mut 'r2 *a;
+                return c;
             }
-        ]
-    );
+        }
+    }])
+    .ok();
 }
 
 // Divergent paths (aka return) should not propagate outlives, liveness
 #[test]
 fn if_else_paths_independent() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn reborrow<'a>(a: &mut 'a u8) -> &mut 'a u8 {
-                    exists<'r0, 'r1, 'r2, 'r3> {
-                        if true {
-                            let b: &mut 'r1 u8 = &mut 'r0 *a;
-                            return b;
-                        } else {
-                            let c: &mut 'r3 u8 = &mut 'r2 *a;
-                            return c;
-                        }
-                    }
+    FormalityTest::new(crates![crate Foo {
+        fn reborrow<'a>(a: &mut 'a u8) -> &mut 'a u8 {
+            exists<'r0, 'r1, 'r2, 'r3> {
+                if true {
+                    let b: &mut 'r1 u8 = &mut 'r0 *a;
+                    return b;
+                } else {
+                    let c: &mut 'r3 u8 = &mut 'r2 *a;
+                    return c;
                 }
             }
-        ]
-    );
+        }
+    }])
+    .ok();
 }
 
 #[test]
@@ -2454,9 +2204,7 @@ fn if_else_paths_independent() {
 /// }
 /// ```
 fn loan_cannot_outlive_lifetime_fail() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> u32 {
                     exists<'r0, 'r1, 'r2> {
                         let x: u32 = 22 _ u32;
@@ -2467,10 +2215,7 @@ fn loan_cannot_outlive_lifetime_fail() {
                         return 0 _ u32;
                     }
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "borrow of disjoint places" at (nll.rs) failed because
               condition evaluated to false: `place_disjoint_from_place(&loan.place, &access.place)`
                 &loan.place = x : u32
@@ -2482,8 +2227,7 @@ fn loan_cannot_outlive_lifetime_fail() {
                 &lifetime.upcast() = ?lt_3
 
             the rule "write-indirect" at (nll.rs) failed because
-              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `x`"#]]
-    )
+              pattern `TypedPlaceExpressionData::Deref(place_loaned_ref)` did not match value `x`"#]])
 }
 
 /// Pass test for loan_cannot_outlive's "lifetime" rule.
@@ -2499,19 +2243,16 @@ fn loan_cannot_outlive_lifetime_fail() {
 /// ```
 #[formality_core::test]
 fn loan_cannot_outlive_lifetime_pass() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    exists<'r0, 'r1, 'r2> {
-                        let x: u32 = 22 _ u32;
-                        let p: &'r1 u32 = &'r0 x;
-                        let q: &'r2 u32 = p;
-                        x = 1 _ u32;
-                        return 0 _ u32;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            exists<'r0, 'r1, 'r2> {
+                let x: u32 = 22 _ u32;
+                let p: &'r1 u32 = &'r0 x;
+                let q: &'r2 u32 = p;
+                x = 1 _ u32;
+                return 0 _ u32;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }

--- a/tests/coherence_orphan.rs
+++ b/tests/coherence_orphan.rs
@@ -1,20 +1,15 @@
 #![allow(non_snake_case)]
-use a_mir_formality::{assert_err, assert_ok};
+use a_mir_formality::{crates, FormalityTest};
 
 #[test]
 fn neg_CoreTrait_for_CoreStruct_in_Foo() {
-    assert_err!(
-        [
-            crate core {
+    FormalityTest::new(crates![crate core {
                 trait CoreTrait {}
                 struct CoreStruct {}
             },
             crate foo {
                 impl !CoreTrait for CoreStruct {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "fundamental rigid type" at (is_local.rs) failed because
               condition evaluated to false: `is_fundamental(decls, name)`
                 decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl ! CoreTrait for CoreStruct {} }], 222)
@@ -30,15 +25,12 @@ fn neg_CoreTrait_for_CoreStruct_in_Foo() {
             the rule "local trait" at (is_local.rs) failed because
               condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
                 decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl ! CoreTrait for CoreStruct {} }], 222)
-                &goal.trait_id = CoreTrait"#]]
-    )
+                &goal.trait_id = CoreTrait"#]])
 }
 
 #[test]
 fn mirror_CoreStruct() {
-    assert_err!(
-        [
-            crate core {
+    FormalityTest::new(crates![crate core {
                 trait CoreTrait {}
                 struct CoreStruct {}
 
@@ -52,10 +44,7 @@ fn mirror_CoreStruct() {
             },
             crate foo {
                 impl CoreTrait for <CoreStruct as Mirror>::Assoc {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "fundamental rigid type" at (is_local.rs) failed because
               condition evaluated to false: `is_fundamental(decls, name)`
                 decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } trait Mirror <ty> { type Assoc : [] ; } impl <ty> Mirror for ^ty0_0 { type Assoc = ^ty1_0 ; } }, crate foo { impl CoreTrait for <CoreStruct as Mirror>::Assoc { } }], 222)
@@ -71,63 +60,51 @@ fn mirror_CoreStruct() {
             the rule "local trait" at (is_local.rs) failed because
               condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
                 decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } trait Mirror <ty> { type Assoc : [] ; } impl <ty> Mirror for ^ty0_0 { type Assoc = ^ty1_0 ; } }, crate foo { impl CoreTrait for <CoreStruct as Mirror>::Assoc { } }], 222)
-                &goal.trait_id = CoreTrait"#]]
-    )
+                &goal.trait_id = CoreTrait"#]])
 }
 
 #[test]
 fn mirror_FooStruct() {
-    assert_ok!(
-        [
-            crate core {
-                trait CoreTrait {}
+    FormalityTest::new(crates![crate core {
+        trait CoreTrait {}
 
-                trait Mirror {
-                    type Assoc : [];
-                }
+        trait Mirror {
+            type Assoc : [];
+        }
 
-                impl<T> Mirror for T {
-                    type Assoc = T;
-                }
-            },
-            crate foo {
-                struct FooStruct {}
-                impl CoreTrait for <FooStruct as Mirror>::Assoc {}
-            }
-        ]
-    )
+        impl<T> Mirror for T {
+            type Assoc = T;
+        }
+    },
+    crate foo {
+        struct FooStruct {}
+        impl CoreTrait for <FooStruct as Mirror>::Assoc {}
+    }])
+    .ok()
 }
 
 #[test]
 fn covered_VecT() {
-    assert_ok!(
-        [
-            crate core {
-                trait CoreTrait<T> {}
-                struct Vec<T> {}
-            },
-            crate foo {
-                struct FooStruct {}
-                impl<T> CoreTrait<FooStruct> for Vec<T> {}
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate core {
+        trait CoreTrait<T> {}
+        struct Vec<T> {}
+    },
+    crate foo {
+        struct FooStruct {}
+        impl<T> CoreTrait<FooStruct> for Vec<T> {}
+    }])
+    .ok()
 }
 
 #[test]
 fn uncovered_T() {
-    assert_err!(
-        [
-            crate core {
+    FormalityTest::new(crates![crate core {
                 trait CoreTrait<T> {}
             },
             crate foo {
                 struct FooStruct {}
                 impl<T> CoreTrait<FooStruct> for T {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: !ty_0, assumptions: {}, env: Env { variables: [!ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: !ty_0, assumptions: {}, env: Env { variables: [!ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
@@ -135,15 +112,12 @@ fn uncovered_T() {
             the rule "local trait" at (is_local.rs) failed because
               condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
                 decls = program([crate core { trait CoreTrait <ty, ty> { } }, crate foo { struct FooStruct { } impl <ty> CoreTrait <FooStruct> for ^ty0_0 { } }], 222)
-                &goal.trait_id = CoreTrait"#]]
-    )
+                &goal.trait_id = CoreTrait"#]])
 }
 
 #[test]
 fn alias_to_unit() {
-    assert_err!(
-        [
-            crate core {
+    FormalityTest::new(crates![crate core {
                 trait CoreTrait {}
 
                 trait Unit {
@@ -157,10 +131,7 @@ fn alias_to_unit() {
             crate foo {
                 struct FooStruct {}
                 impl CoreTrait for <FooStruct as Unit>::Assoc {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "fundamental rigid type" at (is_local.rs) failed because
               condition evaluated to false: `is_fundamental(decls, name)`
                 decls = program([crate core { trait CoreTrait <ty> { } trait Unit <ty> { type Assoc : [] ; } impl <ty> Unit for ^ty0_0 { type Assoc = () ; } }, crate foo { struct FooStruct { } impl CoreTrait for <FooStruct as Unit>::Assoc { } }], 222)
@@ -171,24 +142,18 @@ fn alias_to_unit() {
             the rule "local trait" at (is_local.rs) failed because
               condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
                 decls = program([crate core { trait CoreTrait <ty> { } trait Unit <ty> { type Assoc : [] ; } impl <ty> Unit for ^ty0_0 { type Assoc = () ; } }, crate foo { struct FooStruct { } impl CoreTrait for <FooStruct as Unit>::Assoc { } }], 222)
-                &goal.trait_id = CoreTrait"#]]
-    )
+                &goal.trait_id = CoreTrait"#]])
 }
 
 #[test]
 fn CoreTrait_for_CoreStruct_in_Foo() {
-    assert_err!(
-        [
-            crate core {
+    FormalityTest::new(crates![crate core {
                 trait CoreTrait {}
                 struct CoreStruct {}
             },
             crate foo {
                 impl CoreTrait for CoreStruct {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "fundamental rigid type" at (is_local.rs) failed because
               condition evaluated to false: `is_fundamental(decls, name)`
                 decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl CoreTrait for CoreStruct { } }], 222)
@@ -204,30 +169,26 @@ fn CoreTrait_for_CoreStruct_in_Foo() {
             the rule "local trait" at (is_local.rs) failed because
               condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
                 decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl CoreTrait for CoreStruct { } }], 222)
-                &goal.trait_id = CoreTrait"#]]
-    )
+                &goal.trait_id = CoreTrait"#]])
 }
 
 #[test]
 fn CoreTraitLocal_for_AliasToKnown_in_Foo() {
     // TODO: see comment in `orphan_check` from prev commit
-    assert_ok!(
-    [
-        crate core {
-            trait CoreTrait<T> {}
+    FormalityTest::new(crates![crate core {
+        trait CoreTrait<T> {}
 
-            trait Unit {
-                type Assoc : [];
-            }
-
-            impl<T> Unit for T {
-                type Assoc = ();
-            }
-        },
-        crate foo {
-            struct FooStruct {}
-            impl CoreTrait<FooStruct> for <() as Unit>::Assoc {}
+        trait Unit {
+            type Assoc : [];
         }
-    ]
-    )
+
+        impl<T> Unit for T {
+            type Assoc = ();
+        }
+    },
+    crate foo {
+        struct FooStruct {}
+        impl CoreTrait<FooStruct> for <() as Unit>::Assoc {}
+    }])
+    .ok()
 }

--- a/tests/coherence_overlap.rs
+++ b/tests/coherence_overlap.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)] // we embed type names into the names for our test functions
 
-use a_mir_formality::{assert_err, assert_ok, test_program_ok};
+use a_mir_formality::{crates, test_program_ok, FormalityTest};
 use formality_core::test_util::ResultTestExt;
 use formality_macros::test;
 
@@ -122,265 +122,191 @@ fn test_overlap_alias_not_normalizable() {
 
 #[test]
 fn u32_not_u32_impls() {
-    assert_err!(
-        // Test that a positive and negative impl for the same type (`u32`, here) is rejected.
-        [
-            crate core {
+    FormalityTest::new(crates![crate core {
                 trait Foo {}
                 impl Foo for u32 {}
                 impl !Foo for u32 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             failed at (proven_set.rs) because
-              found an unconditionally true solution Constraints { env: Env { variables: [], bias: Completeness, pending: [], allow_pending_outlives: false }, known_true: true, substitution: {} }"#]]
-    )
+              found an unconditionally true solution Constraints { env: Env { variables: [], bias: Completeness, pending: [], allow_pending_outlives: false }, known_true: true, substitution: {} }"#]])
 }
 
 #[test]
 fn neg_CoreTrait_for_CoreStruct_implies_no_overlap() {
-    assert_ok!(
-
-
-
-        [
-            crate core {
-                trait CoreTrait {}
-                struct CoreStruct {}
-                impl !CoreTrait for CoreStruct {}
-            },
-            crate foo {
-                trait FooTrait {}
-                impl<T> FooTrait for T where T: CoreTrait {}
-                impl FooTrait for CoreStruct {}
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate core {
+        trait CoreTrait {}
+        struct CoreStruct {}
+        impl !CoreTrait for CoreStruct {}
+    },
+    crate foo {
+        trait FooTrait {}
+        impl<T> FooTrait for T where T: CoreTrait {}
+        impl FooTrait for CoreStruct {}
+    }])
+    .ok()
 }
 
 #[test]
 fn foo_crate_cannot_assume_CoreStruct_does_not_impl_CoreTrait() {
-    assert_err!(
-        [
-            crate core {
-                trait CoreTrait {}
-                struct CoreStruct {}
-            },
-            crate foo {
-                trait FooTrait {}
-                impl<T> FooTrait for T where T: CoreTrait {}
-                impl FooTrait for CoreStruct {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate core {
+        trait CoreTrait {}
+        struct CoreStruct {}
+    },
+    crate foo {
+        trait FooTrait {}
+        impl<T> FooTrait for T where T: CoreTrait {}
+        impl FooTrait for CoreStruct {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check_coherence" at (coherence.rs) failed because
               impls may overlap:
               impl <ty> FooTrait for ^ty0_0 where ^ty0_0 : CoreTrait { }
-              impl FooTrait for CoreStruct { }"#]]
-    )
+              impl FooTrait for CoreStruct { }"#]])
 }
 
 #[test]
 fn T_where_Foo_not_u32_impls() {
-    assert_err!(
-        // Test positive impl that has a where-clause which checks for itself,
-        // i.e., `T: Foo where T: Foo`. This `T: Foo` where-clause isn't harmful
-        // in the coinductive interpretation of trait matching, it actually
-        // doesn't change the meaning of the impl at all. However, this formulation
-        // was erroneously accepted by an earlier variant of negative impls.
-        [
-            crate core {
+    FormalityTest::new(crates![crate core {
                 trait Foo {}
                 impl<T> Foo for T where T: Foo {}
                 impl !Foo for u32 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "check_trait_impl" at (impls.rs) failed because
-              failed to prove {! Foo(!ty_1)} given {Foo(!ty_1)}, got [Constraints { env: Env { variables: [!ty_1], bias: Soundness, pending: [], allow_pending_outlives: false }, known_true: false, substitution: {} }]"#]]
-    )
+              failed to prove {! Foo(!ty_1)} given {Foo(!ty_1)}, got [Constraints { env: Env { variables: [!ty_1], bias: Soundness, pending: [], allow_pending_outlives: false }, known_true: false, substitution: {} }]"#]])
 }
 
 #[test]
 fn u32_T_where_T_Is_impls() {
-    assert_err!(
-        // Test that we detect "indirect" overlap -- here `Foo` is implemented for `u32`
-        // and also all `T: Is`, and `u32: Is`.
-        [
-            crate core {
-                trait Foo {}
-                impl Foo for u32 {}
-                impl<T> Foo for T where T: Is {}
+    FormalityTest::new(crates![crate core {
+        trait Foo {}
+        impl Foo for u32 {}
+        impl<T> Foo for T where T: Is {}
 
-                trait Is {}
-                impl Is for u32 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+        trait Is {}
+        impl Is for u32 {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check_coherence" at (coherence.rs) failed because
               impls may overlap:
               impl Foo for u32 { }
-              impl <ty> Foo for ^ty0_0 where ^ty0_0 : Is { }"#]]
-    )
+              impl <ty> Foo for ^ty0_0 where ^ty0_0 : Is { }"#]])
 }
 
 #[test]
 fn u32_T_where_T_Not_impls() {
-    assert_ok!(
+    FormalityTest::new(crates![crate core {
+        trait Foo {}
+        impl Foo for u32 {}
+        impl<T> Foo for T where T: Not {}
 
-
-
-
-
-
-        [
-            crate core {
-                trait Foo {}
-                impl Foo for u32 {}
-                impl<T> Foo for T where T: Not {}
-
-                trait Not {}
-            }
-        ]
-    )
+        trait Not {}
+    }])
+    .ok()
 }
 
 #[test]
 fn u32_u32_impls() {
-    assert_err!(
-        [
-            crate core {
-                trait Foo {}
-                impl Foo for u32 {}
-                impl Foo for u32 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate core {
+        trait Foo {}
+        impl Foo for u32 {}
+        impl Foo for u32 {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check_coherence" at (coherence.rs) failed because
-              duplicate impl in current crate: impl Foo for u32 { }"#]]
-    )
+              duplicate impl in current crate: impl Foo for u32 { }"#]])
 }
 
 #[test]
 fn u32_i32_impls() {
-    assert_ok!(
-
-        [
-            crate core {
-                trait Foo {}
-                impl Foo for u32 {}
-                impl Foo for i32 {}
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate core {
+        trait Foo {}
+        impl Foo for u32 {}
+        impl Foo for i32 {}
+    }])
+    .ok()
 }
 
 #[test]
 fn u32_T_impls() {
-    assert_err!(
-        [
-            crate core {
-                trait Foo {}
-                impl Foo for u32 {}
-                impl<T> Foo for T {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate core {
+        trait Foo {}
+        impl Foo for u32 {}
+        impl<T> Foo for T {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check_coherence" at (coherence.rs) failed because
               impls may overlap:
               impl Foo for u32 { }
-              impl <ty> Foo for ^ty0_0 { }"#]]
-    )
+              impl <ty> Foo for ^ty0_0 { }"#]])
 }
 
 #[test]
 fn T_and_T_bar() {
-    assert_err! {
-        [
-            crate core {
-                trait Foo { }
+    FormalityTest::new(crates![crate core {
+        trait Foo { }
 
-                trait Bar { }
+        trait Bar { }
 
-                impl<T> Foo for T { }
+        impl<T> Foo for T { }
 
-                impl<T> Foo for T where T: Bar { }
-            }
-        ]
-
-        expect_test::expect![[r#"
+        impl<T> Foo for T where T: Bar { }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check_coherence" at (coherence.rs) failed because
               impls may overlap:
               impl <ty> Foo for ^ty0_0 { }
-              impl <ty> Foo for ^ty0_0 where ^ty0_0 : Bar { }"#]]
-    }
+              impl <ty> Foo for ^ty0_0 where ^ty0_0 : Bar { }"#]])
 }
 
 #[test]
 fn T_and_Local_Bar_T() {
-    assert_err! {
-        [
-            crate core {
-                trait Foo { }
+    FormalityTest::new(crates![crate core {
+        trait Foo { }
 
-                trait Bar<U> { }
+        trait Bar<U> { }
 
-                impl<T> Foo for T { }
+        impl<T> Foo for T { }
 
-                impl<T> Foo for T where LocalType: Bar<T> { }
+        impl<T> Foo for T where LocalType: Bar<T> { }
 
-                struct LocalType { }
-            }
-        ]
-
-        expect_test::expect![[r#"
+        struct LocalType { }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "check_coherence" at (coherence.rs) failed because
               impls may overlap:
               impl <ty> Foo for ^ty0_0 { }
-              impl <ty> Foo for ^ty0_0 where LocalType : Bar <^ty0_0> { }"#]]
-    }
+              impl <ty> Foo for ^ty0_0 where LocalType : Bar <^ty0_0> { }"#]])
 }
 
 #[test]
 fn is_local_unknowable_trait_ref() {
-    assert_ok! {
-        [
-            crate core {
-                trait Project {
-                    type Assoc: [];
-                }
+    FormalityTest::new(crates![crate core {
+        trait Project {
+            type Assoc: [];
+        }
 
-                impl<T> Project for T {
-                    type Assoc = T;
-                }
+        impl<T> Project for T {
+            type Assoc = T;
+        }
 
-                trait Foo<U> { }
-            },
-            crate foo {
-                struct LocalType {}
+        trait Foo<U> { }
+    },
+    crate foo {
+        struct LocalType {}
 
-                trait Overlap<U> {}
-                impl<T, U> Overlap<U> for T
-                where
-                    <T as Project>::Assoc: Foo<U> {}
-                impl<T> Overlap<LocalType> for () {}
-            }
-        ]
-    }
+        trait Overlap<U> {}
+        impl<T, U> Overlap<U> for T
+        where
+            <T as Project>::Assoc: Foo<U> {}
+        impl<T> Overlap<LocalType> for () {}
+    }])
+    .ok()
 }
 
 #[test]
 fn is_local_with_unconstrained_self_ty_blanket_impl() {
     // TODO: this test should pass imho
-    assert_err! {
-        [
-            crate core {
+    FormalityTest::new(crates![crate core {
                 trait Project {
                     type Assoc: [];
                 }
@@ -400,13 +326,9 @@ fn is_local_with_unconstrained_self_ty_blanket_impl() {
                 where
                     <T as Project>::Assoc: Foo<U> {}
                 impl<T> Overlap<LocalType> for T {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "check_coherence" at (coherence.rs) failed because
               impls may overlap:
               impl <ty, ty> Overlap <^ty0_1> for ^ty0_0 where <^ty0_0 as Project>::Assoc : Foo <^ty0_1> { }
-              impl <ty> Overlap <LocalType> for ^ty0_0 { }"#]]
-    }
+              impl <ty> Overlap <LocalType> for ^ty0_0 { }"#]])
 }

--- a/tests/const_generics_rv_tsv_parse.rs
+++ b/tests/const_generics_rv_tsv_parse.rs
@@ -1,14 +1,11 @@
-use a_mir_formality::assert_ok;
+use a_mir_formality::{crates, FormalityTest};
 use formality_core::test;
 
 #[test]
 fn parse_minirust_22() {
-    assert_ok!(
-        [
-            crate Foo {
-                trait Trait<const N> where type_of_const N is usize {}
-                impl Trait<usize(22)> for u32 {}
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        trait Trait<const N> where type_of_const N is usize {}
+        impl Trait<usize(22)> for u32 {}
+    }])
+    .ok()
 }

--- a/tests/consts.rs
+++ b/tests/consts.rs
@@ -1,45 +1,33 @@
 #![allow(non_snake_case)]
-use a_mir_formality::{assert_err, assert_ok};
+use a_mir_formality::{crates, FormalityTest};
 
 #[test]
 fn nonsense_rigid_const_bound() {
-    assert_ok!(
-        [
-            crate Foo {
-                // This where-clause is not *provable*, but it is well-formed.
-                trait Foo where type_of_const true is u32 {}
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        // This where-clause is not *provable*, but it is well-formed.
+        trait Foo where type_of_const true is u32 {}
+    }])
+    .ok()
 }
 
 #[test]
 fn ok() {
-    assert_ok!(
+    FormalityTest::new(crates![crate Foo {
+        trait Foo<const C> where type_of_const C is bool {}
+        trait Bar<const C> where type_of_const C is u32 {}
 
-        [
-            crate Foo {
-                trait Foo<const C> where type_of_const C is bool {}
-                trait Bar<const C> where type_of_const C is u32 {}
-
-                impl<const C> Foo<C> for u32 where type_of_const C is bool {}
-            }
-        ]
-    )
+        impl<const C> Foo<C> for u32 where type_of_const C is bool {}
+    }])
+    .ok()
 }
 
 #[test]
 fn mismatch() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 trait Foo<const C> where type_of_const C is bool {}
 
                 impl Foo<u32(42)> for u32 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: bool, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false } }
@@ -50,48 +38,35 @@ fn mismatch() {
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Foo(u32, u32(42)), via: Place(?ty_1), assumptions: {}, env: Env { variables: [?ty_1], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Foo(u32, u32(42)), via: PlaceRead(?ty_1, ?ty_2), assumptions: {}, env: Env { variables: [?ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Foo(u32, u32(42)), via: PlaceRead(?ty_1, ?ty_2), assumptions: {}, env: Env { variables: [?ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]])
 }
 
 #[test]
 fn holds() {
-    assert_ok!(
+    FormalityTest::new(crates![crate Foo {
+        trait Foo<const C> where type_of_const C is bool {}
 
-        [
-            crate Foo {
-                trait Foo<const C> where type_of_const C is bool {}
-
-                impl Foo<true> for u32 {}
-            }
-        ]
-    )
+        impl Foo<true> for u32 {}
+    }])
+    .ok()
 }
 
 #[test]
 fn rigid_const_bound() {
-    assert_ok!(
-        [
-            crate Foo {
-                trait Foo where type_of_const true is bool {}
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        trait Foo where type_of_const true is bool {}
+    }])
+    .ok()
 }
 
 #[test]
 fn generic_mismatch() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 trait Foo<const C> where type_of_const C is bool {}
 
                 // Here, the impl is assuming C is u32, which mismatches the trait bound.
                 impl<const C> Foo<C> for u32 where type_of_const C is u32 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Foo(u32, !const_0), via: @ ConstHasType(!const_0 , u32), assumptions: {@ ConstHasType(!const_0 , u32)}, env: Env { variables: [!const_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: u32 = bool, via: @ ConstHasType(!const_0 , u32), assumptions: {@ ConstHasType(!const_0 , u32)}, env: Env { variables: [!const_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
@@ -108,31 +83,24 @@ fn generic_mismatch() {
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Foo(u32, !const_0), via: Place(?ty_1), assumptions: {@ ConstHasType(!const_0 , u32)}, env: Env { variables: [!const_0, ?ty_1], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Foo(u32, !const_0), via: PlaceRead(?ty_1, ?ty_2), assumptions: {@ ConstHasType(!const_0 , u32)}, env: Env { variables: [!const_0, ?ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Foo(u32, !const_0), via: PlaceRead(?ty_1, ?ty_2), assumptions: {@ ConstHasType(!const_0 , u32)}, env: Env { variables: [!const_0, ?ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]])
 }
 
 #[test]
 fn generic_match() {
-    assert_ok!(
-        [
-            crate Foo {
-                trait Foo<const C> where type_of_const C is bool {}
+    FormalityTest::new(crates![crate Foo {
+        trait Foo<const C> where type_of_const C is bool {}
 
-                // Here, the impl matches the trait bound.
-                impl<const C> Foo<C> for u32 where type_of_const C is bool {}
-            }
-        ]
-    )
+        // Here, the impl matches the trait bound.
+        impl<const C> Foo<C> for u32 where type_of_const C is bool {}
+    }])
+    .ok()
 }
 
 #[test]
 fn multiple_type_of_const() {
-    assert_ok!(
-        [
-            crate Foo {
-                trait Foo<const C> where type_of_const C is bool, type_of_const C is u32 {}
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        trait Foo<const C> where type_of_const C is bool, type_of_const C is u32 {}
+    }])
+    .ok()
 }

--- a/tests/decl_safety.rs
+++ b/tests/decl_safety.rs
@@ -1,112 +1,80 @@
 #![allow(non_snake_case)]
 
-use a_mir_formality::{assert_err, assert_ok};
+use a_mir_formality::{crates, FormalityTest};
 
 #[test]
 fn unsafe_trait() {
-    assert_ok!(
-
-        [
-            crate baguette {
-                unsafe trait Foo {}
-                unsafe impl Foo for u32 {}
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate baguette {
+        unsafe trait Foo {}
+        unsafe impl Foo for u32 {}
+    }])
+    .ok()
 }
 
 #[test]
 fn safe_trait() {
-    assert_ok!(
-
-        [
-            crate baguette {
-                safe trait Foo {}
-                safe impl Foo for u32 {}
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate baguette {
+        safe trait Foo {}
+        safe impl Foo for u32 {}
+    }])
+    .ok()
 }
 
 #[test]
 fn unsafe_trait_negative_impl() {
-    assert_ok!(
-
-        [
-            crate baguette {
-                unsafe trait Foo {}
-                impl !Foo for u32 {}
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate baguette {
+        unsafe trait Foo {}
+        impl !Foo for u32 {}
+    }])
+    .ok()
 }
 
 #[test]
 fn unsafe_trait_negative_impl_mismatch() {
-    assert_err!(
-        [
-            crate baguette {
-                unsafe trait Foo {}
-                unsafe impl !Foo for u32 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate baguette {
+        unsafe trait Foo {}
+        unsafe impl !Foo for u32 {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "neg trait impl" at (mod.rs) failed because
               check_neg_trait_impl(unsafe impl ! Foo for u32 {})
 
               Caused by:
-                  negative impls cannot be unsafe"#]]
-    )
+                  negative impls cannot be unsafe"#]])
 }
 
 #[test]
 fn safe_trait_negative_impl_mismatch() {
-    assert_err!(
-        [
-            crate baguette {
-                trait Foo {}
-                unsafe impl !Foo for u32 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate baguette {
+        trait Foo {}
+        unsafe impl !Foo for u32 {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "neg trait impl" at (mod.rs) failed because
               check_neg_trait_impl(unsafe impl ! Foo for u32 {})
 
               Caused by:
-                  negative impls cannot be unsafe"#]]
-    )
+                  negative impls cannot be unsafe"#]])
 }
 
 #[test]
 fn unsafe_trait_mismatch() {
-    assert_err!(
-        [
-            crate baguette {
-                unsafe trait Foo {}
-                impl Foo for u32 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate baguette {
+        unsafe trait Foo {}
+        impl Foo for u32 {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "safety matches" at (impls.rs) failed because
-              condition evaluated to false: `trait_decl.safety == trait_impl.safety`"#]]
-    )
+              condition evaluated to false: `trait_decl.safety == trait_impl.safety`"#]])
 }
 
 #[test]
 fn safe_trait_mismatch() {
-    assert_err!(
-        [
-            crate baguette {
-                trait Foo {}
-                unsafe impl Foo for u32 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate baguette {
+        trait Foo {}
+        unsafe impl Foo for u32 {}
+    }])
+    .err(expect_test::expect![[r#"
             the rule "safety matches" at (impls.rs) failed because
-              condition evaluated to false: `trait_decl.safety == trait_impl.safety`"#]]
-    )
+              condition evaluated to false: `trait_decl.safety == trait_impl.safety`"#]])
 }

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -1,45 +1,36 @@
 #![allow(non_snake_case)]
 
-use a_mir_formality::assert_ok;
+use a_mir_formality::{crates, FormalityTest};
 
 #[test]
 fn ok() {
-    assert_ok!(
+    FormalityTest::new(crates![crate Foo {
+        // fn simple_fn() {}
+        fn simple_fn() -> () { trusted }
 
+        // fn one_arg<T>(_: T) {}
+        fn one_arg<T>(v0: T) -> () { trusted }
 
-        [
-            crate Foo {
-                // fn simple_fn() {}
-                fn simple_fn() -> () { trusted }
+        // fn one_ret<T>(_: T) {}
+        fn one_ret<T>() -> T { trusted }
 
-                // fn one_arg<T>(_: T) {}
-                fn one_arg<T>(v0: T) -> () { trusted }
+        // fn arg_ret<T, U>(_: T) -> U {}
+        fn arg_ret<T, U>(v0: T) -> U { trusted }
 
-                // fn one_ret<T>(_: T) {}
-                fn one_ret<T>() -> T { trusted }
-
-                // fn arg_ret<T, U>(_: T) -> U {}
-                fn arg_ret<T, U>(v0: T) -> U { trusted }
-
-                // fn multi_arg_ret<T, Y, U, I>(_: T, _: Y) -> (U, I) {}
-                fn multi_arg_ret<T, Y, U, I>(v0: T, v1: Y) -> (U, I) { trusted }
-            }
-        ]
-    )
+        // fn multi_arg_ret<T, Y, U, I>(_: T, _: Y) -> (U, I) {}
+        fn multi_arg_ret<T, Y, U, I>(v0: T, v1: Y) -> (U, I) { trusted }
+    }])
+    .ok()
 }
 
 #[test]
 fn lifetime() {
-    assert_ok!(
-
-        [
-            crate Foo {
-                // fn one_lt_arg<'a, T>(_: &'a T) -> () {}
-                fn one_lt_arg<'a, T>(v0: &'a T) -> ()
-                where
-                    T: 'a, // FIXME(#202): Implied bounds should not have to be explicit
-                { trusted }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        // fn one_lt_arg<'a, T>(_: &'a T) -> () {}
+        fn one_lt_arg<'a, T>(v0: &'a T) -> ()
+        where
+            T: 'a, // FIXME(#202): Implied bounds should not have to be explicit
+        { trusted }
+    }])
+    .ok()
 }

--- a/tests/mir_typeck.rs
+++ b/tests/mir_typeck.rs
@@ -1,158 +1,135 @@
-use a_mir_formality::{assert_err, assert_ok};
+use a_mir_formality::{crates, FormalityTest};
 use formality_core::test;
 
 /// Test assign statement with locals at rhs.
 #[test]
 fn test_assign_statement_local_only() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo (v1: u32) -> u32 {
-                    return v1;
-                }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo (v1: u32) -> u32 {
+            return v1;
+        }
+    }])
+    .ok()
 }
 
 // Test assign statement with constant at rhs.
 #[test]
 fn test_assign_constant() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo () -> u8 {
-                    let v1: u16 = 5 _ u16;
-                    let v2: u32 = 5 _ u32;
-                    let v3: u64 = 5 _ u64;
-                    let v4: usize = 5 _ usize;
-                    let v5: i8 = 5 _ i8;
-                    let v6: i16 = 5 _ i16;
-                    let v7: i32 = 5 _ i32;
-                    let v8: i64 = 5 _ i64;
-                    let v9: isize = 5 _ isize;
-                    let v10: bool = false;
-                    return 5 _ u8;
-                }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo () -> u8 {
+            let v1: u16 = 5 _ u16;
+            let v2: u32 = 5 _ u32;
+            let v3: u64 = 5 _ u64;
+            let v4: usize = 5 _ usize;
+            let v5: i8 = 5 _ i8;
+            let v6: i16 = 5 _ i16;
+            let v7: i32 = 5 _ i32;
+            let v8: i64 = 5 _ i64;
+            let v9: isize = 5 _ isize;
+            let v10: bool = false;
+            return 5 _ u8;
+        }
+    }])
+    .ok()
 }
 
 // Test valid program with Terminator::Switch.
 #[test]
 #[ignore = "needs switch/branching constructs in expr grammar"]
 fn test_switch_statment() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo () -> u32 = minirust {
-                    exists {
-                        let v1: u32;
+    FormalityTest::new(crates![crate Foo {
+        fn foo () -> u32 = minirust {
+            exists {
+                let v1: u32;
 
-                        bb0: {
-                            statements {
-                                local(v1) = constant(0: u32);
-                            }
-                            switch(load(local(v1))) -> [(0: bb1), (1: bb2)] otherwise: bb3;
-                        }
-
-                        bb1: {
-                            statements {
-                                local(_return) = constant(1: u32);
-                            }
-                            return;
-                        }
-
-                        bb2: {
-                            statements {
-                                local(_return) = constant(2: u32);
-                            }
-                            return;
-                        }
-
-                        bb3: {
-                            statements {
-                            }
-                            return;
-                        }
+                bb0: {
+                    statements {
+                        local(v1) = constant(0: u32);
                     }
-                };
+                    switch(load(local(v1))) -> [(0: bb1), (1: bb2)] otherwise: bb3;
+                }
+
+                bb1: {
+                    statements {
+                        local(_return) = constant(1: u32);
+                    }
+                    return;
+                }
+
+                bb2: {
+                    statements {
+                        local(_return) = constant(2: u32);
+                    }
+                    return;
+                }
+
+                bb3: {
+                    statements {
+                    }
+                    return;
+                }
             }
-        ]
-    )
+        };
+    }])
+    .ok()
 }
 
 /// Test returning a parameter (previously tested goto terminator in MIR).
 #[test]
 fn test_goto_terminator() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo (v1: u32) -> u32 {
-                    return v1;
-                }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo (v1: u32) -> u32 {
+            return v1;
+        }
+    }])
+    .ok()
 }
 
 /// Test cyclic control flow (a loop).
 /// A silly but valid infinite loop that reads and writes a variable.
 #[test]
 fn test_cyclic_goto() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    let v0: u32 = 0 _ u32;
-                    loop {
-                        v0 = v0;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            let v0: u32 = 0 _ u32;
+            loop {
+                v0 = v0;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Returns true (Expr::True) type-checking coverage
 #[test]
 fn test_ret_true() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo () -> bool {
-                    return true;
-                }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo () -> bool {
+            return true;
+        }
+    }])
+    .ok()
 }
 
 // if / else (Stmt::If) bool condition, each arm returns a u32.
 #[test]
 fn if_else() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo (b: bool) -> u32 {
-                    if b {
-                        return 1 _ u32;
-                    } else {
-                        return 2 _ u32;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo (b: bool) -> u32 {
+            if b {
+                return 1 _ u32;
+            } else {
+                return 2 _ u32;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 // if / else (Stmt::If) with different return types.
 #[test]
 fn if_else_different_return_types() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo (b: bool) -> u32 {
                     if b {
                         return 1 _ u32;
@@ -160,32 +137,26 @@ fn if_else_different_return_types() {
                         return false;
                     }
                 }
-            }
-        ]
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: bool, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]])
 }
 
 /// Test valid call: bar calls foo.
 #[test]
 fn test_call_terminator() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo(v1: u32) -> u32 {
-                    return v1;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo(v1: u32) -> u32 {
+            return v1;
+        }
 
-                fn bar(v1: u32) -> u32 {
-                    let v0: u32 = foo(v1);
-                    return v0;
-                }
-            }
-        ]
-    )
+        fn bar(v1: u32) -> u32 {
+            let v0: u32 = foo(v1);
+            return v0;
+        }
+    }])
+    .ok()
 }
 
 /// Test valid place mention statement.
@@ -199,88 +170,74 @@ fn test_call_terminator() {
 /// ```
 #[test]
 fn test_place_mention_statement() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo (v1: u32) -> u32 {
-                    return v1;
-                }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo (v1: u32) -> u32 {
+            return v1;
+        }
+    }])
+    .ok()
 }
 
 /// Test valid StorageLive and StorageDead statements.
 #[test]
 #[ignore = "needs StorageLive/StorageDead in expr grammar"]
 fn test_storage_live_dead() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo (v1: u32) -> u32 = minirust {
-                    exists {
-                        let v2: u32;
+    FormalityTest::new(crates![crate Foo {
+        fn foo (v1: u32) -> u32 = minirust {
+            exists {
+                let v2: u32;
 
-                        bb0: {
-                            statements {
-                                local(_return) = load(local(v1));
-                                StorageLive(v2);
-                                StorageDead(v2);
-                            }
-                            return;
-                        }
+                bb0: {
+                    statements {
+                        local(_return) = load(local(v1));
+                        StorageLive(v2);
+                        StorageDead(v2);
                     }
-                };
+                    return;
+                }
             }
-        ]
-    )
+        };
+    }])
+    .ok()
 }
 
 /// Test valid program that uses struct.
 #[test]
 fn test_struct() {
-    assert_ok!(
-        [
-            crate Foo {
-                struct Dummy {
-                    value: u32,
-                    is_true: bool,
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Dummy {
+            value: u32,
+            is_true: bool,
+        }
 
-                fn foo (v1: u32) -> u32 {
-                    let v2: Dummy = Dummy { value: 1 _ u32, is_true: false };
-                    v2.value = 2 _ u32;
-                    return v1;
-                }
-            }
-        ]
-    )
+        fn foo (v1: u32) -> u32 {
+            let v2: Dummy = Dummy { value: 1 _ u32, is_true: false };
+            v2.value = 2 _ u32;
+            return v1;
+        }
+    }])
+    .ok()
 }
 
 /// Test let statement with well-formed type
 #[test]
 fn test_let_with_well_formed_type() {
-    assert_ok!(
-        [
-            crate Foo {
-                trait Trait1 {}
-                struct S1<T> {
-                    t: T,
-                }
-                fn foo() -> () {
-                    let s1: S1<u8>;
-                }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        trait Trait1 {}
+        struct S1<T> {
+            t: T,
+        }
+        fn foo() -> () {
+            let s1: S1<u8>;
+        }
+    }])
+    .ok()
 }
 
 /// Test let statement with ill-formed type
 #[test]
 fn test_let_with_ill_formed_type() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 trait Trait1 {}
                 struct S1 {}
                 struct S2<T> where T: Trait1 {
@@ -289,46 +246,37 @@ fn test_let_with_ill_formed_type() {
                 fn foo() -> () {
                     let s2: S2<S1>;
                 }
-            }
-        ]
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait1(S1), via: Place(?ty_1), assumptions: {}, env: Env { variables: [?ty_1, ?ty_2, ?ty_3], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait1(S1), via: Place(?ty_1), assumptions: {}, env: Env { variables: [?ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait1(S1), via: Place(?ty_1), assumptions: {}, env: Env { variables: [?ty_1], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait1(S1), via: PlaceRead(?ty_1, ?ty_2), assumptions: {}, env: Env { variables: [?ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait1(S1), via: PlaceRead(?ty_1, ?ty_2), assumptions: {}, env: Env { variables: [?ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]])
 }
 
 // Test calling a function that does not exist.
 #[test]
 fn test_call_invalid_fn() {
-    assert_err!(
-        [
-            crate Foo {
-                fn bar() -> u32 {
-                    let v1: u32 = foo(0 _ u32);
-                    return v1;
-                }
-            }
-        ]
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate Foo {
+        fn bar() -> u32 {
+            let v1: u32 = foo(0 _ u32);
+            return v1;
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "fn-name" at (nll.rs) failed because
               no fn named `foo`
 
             the rule "local" at (nll.rs) failed because
-              unknown local variable `foo`"#]]
-    )
+              unknown local variable `foo`"#]])
 }
 
 #[test]
 // Test what will happen if the type of arguments passed in is not subtype of what is expected.
 fn test_pass_non_subtype_arg() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo(v1: u32) -> u32 {
                     return v1;
                 }
@@ -337,65 +285,53 @@ fn test_pass_non_subtype_arg() {
                     let v0: () = foo(v1);
                     return v0;
                 }
-            }
-        ]
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: (), assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]])
 }
 
 /// Test calling a generic function without turbofish (wrong number of type args: 0 vs 1).
 #[test]
 fn test_call_generic_fn_without_turbofish() {
-    assert_err!(
-        [
-            crate Foo {
-                fn identity<T>(v1: T) -> T {
-                    return v1;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn identity<T>(v1: T) -> T {
+            return v1;
+        }
 
-                fn bar(v1: u32) -> u32 {
-                    let v0: u32 = identity(v1);
-                    return v0;
-                }
-            }
-        ]
-        expect_test::expect![[r#"
+        fn bar(v1: u32) -> u32 {
+            let v0: u32 = identity(v1);
+            return v0;
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "fn-name" at (nll.rs) failed because
               condition evaluated to false: `fn_decl.binder.len() == 0`
 
             the rule "local" at (nll.rs) failed because
-              unknown local variable `identity`"#]]
-    )
+              unknown local variable `identity`"#]])
 }
 
 /// Test calling a generic function with correct turbofish.
 #[test]
 fn test_call_generic_fn_with_turbofish() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn identity<T>(v1: T) -> T {
-                    return v1;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn identity<T>(v1: T) -> T {
+            return v1;
+        }
 
-                fn bar(v1: u32) -> u32 {
-                    let v0: u32 = identity::<u32>(v1);
-                    return v0;
-                }
-            }
-        ]
-    )
+        fn bar(v1: u32) -> u32 {
+            let v0: u32 = identity::<u32>(v1);
+            return v0;
+        }
+    }])
+    .ok()
 }
 
 /// Test calling a generic function with incorrect turbofish type.
 #[test]
 fn test_call_generic_fn_wrong_type_with_turbofish() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn identity<T>(v1: T) -> T {
                     return v1;
                 }
@@ -404,57 +340,46 @@ fn test_call_generic_fn_wrong_type_with_turbofish() {
                     let v0: u32 = identity::<bool>(v1);
                     return v0;
                 }
-            }
-        ]
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: bool, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: bool, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]])
 }
 
 /// Test calling a generic function using turbofish syntax with an incorrect number of parameters.
 #[test]
 fn test_call_generic_fn_wrong_parameters_number_with_turbofish() {
-    assert_err!(
-        [
-            crate Foo {
-                fn identity<T>(v1: T) -> T {
-                    return v1;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn identity<T>(v1: T) -> T {
+            return v1;
+        }
 
-                fn bar(v1: u32) -> u32 {
-                    let v0: u32 = identity::<u32>(v1, v1);
-                    return v0;
-                }
-            }
-        ]
-        expect_test::expect![[r#"
+        fn bar(v1: u32) -> u32 {
+            let v0: u32 = identity::<u32>(v1, v1);
+            return v0;
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "call" at (nll.rs) failed because
-              condition evaluated to false: `input_tys.len() == args.len()`"#]]
-    )
+              condition evaluated to false: `input_tys.len() == args.len()`"#]])
 }
 
 /// Test calling a generic function with wrong number of type args via turbofish.
 #[test]
 fn test_call_generic_fn_wrong_arity() {
-    assert_err!(
-        [
-            crate Foo {
-                fn identity<T>(v1: T) -> T {
-                    return v1;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn identity<T>(v1: T) -> T {
+            return v1;
+        }
 
-                fn bar(v1: u32) -> u32 {
-                    let v0: u32 = identity::<u32, u32>(v1);
-                    return v0;
-                }
-            }
-        ]
-        expect_test::expect![[r#"
+        fn bar(v1: u32) -> u32 {
+            let v0: u32 = identity::<u32, u32>(v1);
+            return v0;
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "turbofish" at (nll.rs) failed because
-              condition evaluated to false: `fn_decl.binder.len() == args.len()`"#]]
-    )
+              condition evaluated to false: `fn_decl.binder.len() == args.len()`"#]])
 }
 
 /// Test what will happen if the declared and actual return type are not compatible.
@@ -468,20 +393,14 @@ fn test_call_generic_fn_wrong_arity() {
 /// ```
 #[test]
 fn test_incompatible_return_type() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo (v1: ()) -> u32 {
                     return v1;
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: (), assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]])
 }
 
 // Test the behaviour of having unitialised return local variable.
@@ -489,61 +408,55 @@ fn test_incompatible_return_type() {
 #[test]
 #[ignore = "needs uninitialized return detection in expr grammar"]
 fn test_uninitialised_return_type() {
-    assert_ok!( // Changed from assert_err! - should be reverted when #209 is fixed
-        [
-            crate Foo {
-                fn foo () -> u32 = minirust {
-                    exists {
-                        bb0: {
-                            statements {
-                            }
-                            return;
-                        }
+    FormalityTest::new(crates![crate Foo {
+        fn foo () -> u32 = minirust {
+            exists {
+                bb0: {
+                    statements {
                     }
-                };
+                    return;
+                }
             }
-        ]
-    )
+        };
+    }])
+    .ok()
 }
 
 /// Test switch terminator with invalid type in Terminator::Switch.
 #[test]
 #[ignore = "needs switch/branching constructs in expr grammar"]
 fn test_invalid_value_in_switch_terminator() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo () -> bool = minirust {
-                    exists {
-                        bb0: {
-                            statements {
-                                local(_return) = constant(false);
-                            }
-                            switch(load(local(_return))) -> [(0: bb1), (1: bb2)] otherwise: bb3;
-                        }
-
-                        bb1: {
-                            statements {
-                            }
-                            return;
-                        }
-
-                        bb2: {
-                            statements {
-                            }
-                            return;
-                        }
-
-                        bb3: {
-                            statements {
-                            }
-                            return;
-                        }
+    FormalityTest::new(crates![crate Foo {
+        fn foo () -> bool = minirust {
+            exists {
+                bb0: {
+                    statements {
+                        local(_return) = constant(false);
                     }
-                };
+                    switch(load(local(_return))) -> [(0: bb1), (1: bb2)] otherwise: bb3;
+                }
+
+                bb1: {
+                    statements {
+                    }
+                    return;
+                }
+
+                bb2: {
+                    statements {
+                    }
+                    return;
+                }
+
+                bb3: {
+                    statements {
+                    }
+                    return;
+                }
             }
-        ]
-        expect_test::expect![[r#"
+        };
+    }])
+    .err(expect_test::expect![[r#"
             MaybeFnBody expected
 
             Caused by:
@@ -576,30 +489,26 @@ fn test_invalid_value_in_switch_terminator() {
                                bb3: { statements {} return; }
                            }
                        };
-                   }]"#]]
-    )
+                   }]"#]])
 }
 
 /// Test the behaviour of having return place in StorageDead.
 #[test]
 #[ignore = "needs StorageDead in expr grammar"]
 fn test_ret_place_storage_dead() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo (v1: u32) -> u32 = minirust {
-                    exists {
-                        bb0: {
-                            statements {
-                                StorageDead(v1);
-                            }
-                            return;
-                        }
+    FormalityTest::new(crates![crate Foo {
+        fn foo (v1: u32) -> u32 = minirust {
+            exists {
+                bb0: {
+                    statements {
+                        StorageDead(v1);
                     }
-                };
+                    return;
+                }
             }
-        ]
-        expect_test::expect![[r#"
+        };
+    }])
+    .err(expect_test::expect![[r#"
             MaybeFnBody expected
 
             Caused by:
@@ -610,30 +519,26 @@ fn test_ret_place_storage_dead() {
                    {
                        fn foo(v1: u32) -> u32 = minirust
                        { exists { bb0: { statements { StorageDead(v1); } return; } } };
-                   }]"#]]
-    )
+                   }]"#]])
 }
 
 /// Test the behaviour of having function argument in StorageDead.
 #[test]
 #[ignore = "needs StorageDead in expr grammar"]
 fn test_fn_arg_storage_dead() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo (v1: u32) -> u32 = minirust {
-                    exists {
-                        bb0: {
-                            statements {
-                                StorageDead(_return);
-                            }
-                            return;
-                        }
+    FormalityTest::new(crates![crate Foo {
+        fn foo (v1: u32) -> u32 = minirust {
+            exists {
+                bb0: {
+                    statements {
+                        StorageDead(_return);
                     }
-                };
+                    return;
+                }
             }
-        ]
-        expect_test::expect![[r#"
+        };
+    }])
+    .err(expect_test::expect![[r#"
             MaybeFnBody expected
 
             Caused by:
@@ -644,39 +549,32 @@ fn test_fn_arg_storage_dead() {
                    {
                        fn foo(v1: u32) -> u32 = minirust
                        { exists { bb0: { statements { StorageDead(_return); } return; } } };
-                   }]"#]]
-    )
+                   }]"#]])
 }
 
 /// Test the behaviour of using invalid field name for the struct field.
 #[test]
 fn test_invalid_struct_field() {
-    assert_err!(
-        [
-            crate Foo {
-                struct Dummy {
-                    value: u32,
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Dummy {
+            value: u32,
+        }
 
-                fn foo (v1: u32) -> u32 {
-                    let v2: Dummy = Dummy { value: 1 _ u32 };
-                    v2.nonexistent = 2 _ u32;
-                    return v1;
-                }
-            }
-        ]
-        expect_test::expect![[r#"
+        fn foo (v1: u32) -> u32 {
+            let v2: Dummy = Dummy { value: 1 _ u32 };
+            v2.nonexistent = 2 _ u32;
+            return v1;
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "struct field" at (nll.rs) failed because
-              condition evaluated to false: `field.name == *field_name`"#]]
-    )
+              condition evaluated to false: `field.name == *field_name`"#]])
 }
 
 /// Test the behaviour of using non-adt local for field projection.
 #[test]
 fn test_field_projection_root_non_adt() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 struct Dummy {
                     value: u32,
                 }
@@ -686,20 +584,15 @@ fn test_field_projection_root_non_adt() {
                     v1.value = 2 _ u32;
                     return v1;
                 }
-            }
-        ]
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             the rule "struct field" at (nll.rs) failed because
-              pattern `(RigidTy { name: RigidName::AdtId(adt_id), parameters }, state)` did not match value `(u32, flow_state([scope(none, None, {}, None, [(v1, u32)], [v1 : u32]), scope(none, None, {}, None, [(v2, Dummy)], [v2 : Dummy])], point_flow_state({}, {}), {}, {}))`"#]]
-    )
+              pattern `(RigidTy { name: RigidName::AdtId(adt_id), parameters }, state)` did not match value `(u32, flow_state([scope(none, None, {}, None, [(v1, u32)], [v1 : u32]), scope(none, None, {}, None, [(v2, Dummy)], [v2 : Dummy])], point_flow_state({}, {}), {}, {}))`"#]])
 }
 
 /// Test the behaviour of initialising the struct with wrong type.
 #[test]
 fn test_struct_wrong_type_in_initialisation() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 struct Dummy {
                     value: u32,
                 }
@@ -708,13 +601,10 @@ fn test_struct_wrong_type_in_initialisation() {
                     let v2: Dummy = Dummy { value: false };
                     return v1;
                 }
-            }
-        ]
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: bool, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_normalize.rs:19:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]])
 }
 
 /// Test the behaviour of having non-adt as the type for struct construction.
@@ -723,19 +613,15 @@ fn test_struct_wrong_type_in_initialisation() {
 /// We keep the intent of the test by using a made-up ADT name that doesn't exist.
 #[test]
 fn test_non_adt_ty_for_struct() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo (v1: u32) -> u32 {
-                    let v2: u32 = Nonexistent { value: false };
-                    return v1;
-                }
-            }
-        ]
-        expect_test::expect![[r#"
+    FormalityTest::new(crates![crate Foo {
+        fn foo (v1: u32) -> u32 {
+            let v2: u32 = Nonexistent { value: false };
+            return v1;
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "struct" at (nll.rs) failed because
-              no ADT named `Nonexistent`"#]]
-    )
+              no ADT named `Nonexistent`"#]])
 }
 
 /// Test that the `false` literal type-checks as `bool`.
@@ -748,16 +634,13 @@ fn test_non_adt_ty_for_struct() {
 /// ```
 #[test]
 fn test_false_literal() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> bool {
-                    let v1: bool = false;
-                    return v1;
-                }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> bool {
+            let v1: bool = false;
+            return v1;
+        }
+    }])
+    .ok()
 }
 
 /// Basic pass test for lifetime.
@@ -771,58 +654,49 @@ fn test_false_literal() {
 /// ```
 #[test]
 fn test_ref_identity() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo<'a>(v1: &'a u32) -> &'a u32 {
-                    exists<'r0> {
-                        let v2: &'r0 u32 = v1;
-                        return v2;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo<'a>(v1: &'a u32) -> &'a u32 {
+            exists<'r0> {
+                let v2: &'r0 u32 = v1;
+                return v2;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Test ref and deref
 #[test]
 fn test_ref_deref() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo () -> u32 {
-                    exists<'a> {
-                        let v0: u32 = 0 _ u32;
-                        let v1: &'a u32 = &'a v0;
-                        let v2: u32 = *v1;
-                        return v2;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo () -> u32 {
+            exists<'a> {
+                let v0: u32 = 0 _ u32;
+                let v1: &'a u32 = &'a v0;
+                let v2: u32 = *v1;
+                return v2;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// Test generic deref should be permitted when the pointee type is known Copy.
 #[test]
 fn test_ref_deref_generic_copy_bound() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo<'a, T>(v1: &'a T) -> T
-                where
-                    T: Copy,
-                    T: 'a,
-                {
-                    exists<'r0> {
-                        let v2: T = *v1;
-                        return v2;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo<'a, T>(v1: &'a T) -> T
+        where
+            T: Copy,
+            T: 'a,
+        {
+            exists<'r0> {
+                let v2: T = *v1;
+                return v2;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 // ---- Scoping tests ----
@@ -839,18 +713,15 @@ fn test_ref_deref_generic_copy_bound() {
 /// ```
 #[test]
 fn test_break_valid_loop_label() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    'a: loop {
-                        break 'a;
-                    }
-                    return 0 _ u32;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            'a: loop {
+                break 'a;
             }
-        ]
-    )
+            return 0 _ u32;
+        }
+    }])
+    .ok()
 }
 
 /// `break` targeting a non-existent label should fail.
@@ -864,25 +735,17 @@ fn test_break_valid_loop_label() {
 /// ```
 #[test]
 fn test_break_nonexistent_label() {
-    assert_err!(
-        [
-            crate Foo {
+    FormalityTest::new(crates![crate Foo {
                 fn foo() -> u32 {
                     loop {
                         break 'nonexistent;
                     }
                     return 0 _ u32;
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/check/borrow_check/nll.rs:175:1: no applicable rules for borrow_check_statement { state: flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(none, None, {}, Some({}), [], []), scope(none, None, {}, None, [], [])], point_flow_state({}, {}), {}, {}), statement: break 'nonexistent ;, places_live_on_exit: {}, assumptions: {}, env: TypeckEnv { env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false }, output_ty: Some(u32), program: program([crate core { trait Copy <ty> { } impl Copy for u8 { } impl Copy for u16 { } impl Copy for u32 { } impl Copy for u64 { } impl Copy for i8 { } impl Copy for i16 { } impl Copy for i32 { } impl Copy for i64 { } impl Copy for bool { } impl Copy for usize { } impl Copy for isize { } impl <lt, ty> Copy for &^lt0_0 ^ty0_1 { } trait Place <ty> { type Target : [] ; } unsafe trait Subplace <ty> { type Source : [] ; type Target : [] ; fn offset (self : ^ty1_0) -> usize ; } unsafe trait PlaceRead <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { unsafe fn read (this : *const ^ty1_0, proj : ^ty1_1) -> <^ty1_1 as Subplace>::Target ; } unsafe trait PlaceWrite <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { unsafe fn write (this : *const ^ty1_0, sub : ^ty1_1, value : <^ty1_1 as Subplace>::Target) -> () ; } unsafe trait PlaceMove <ty, ty> where ^ty0_0 : PlaceRead <^ty0_1>, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { } unsafe trait PlaceDrop <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { unsafe fn drop (this : *const ^ty1_0, sub : ^ty1_1) -> () ; } unsafe trait DropHusk <ty> where ^ty0_0 : Place { unsafe fn drop_husk (this : *const ^ty1_0) -> () ; } unsafe trait PlaceBorrow <ty, ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { type BorrowDuration : [BorrowDuration] ; unsafe fn borrow (this : *const ^ty1_0, sub : ^ty1_1) -> ^ty1_2 ; } trait BorrowDuration <ty> { } struct Instant { } struct Lifetime <lt> { } struct Indefinite { } impl BorrowDuration for Instant { } impl <lt> BorrowDuration for Lifetime<^lt0_0> { } impl BorrowDuration for Indefinite { } unsafe trait PlaceDeref <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target, <^ty0_1 as Subplace>::Target : Place { unsafe fn deref (ptr : *mut ^ty1_0, sub : ^ty1_1) -> *const <^ty1_1 as Subplace>::Target ; } unsafe trait PlaceWrapper <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { type Wrapped : [Subplace] where <<^ty1_0 as PlaceWrapper<^ty1_1>>::Wrapped as Subplace>::Source => ^ty1_0 ; fn wrap (sub : ^ty1_1) -> <^ty1_0 as PlaceWrapper<^ty1_1>>::Wrapped ; } }, crate Foo { fn foo () -> u32 { loop { break 'nonexistent ; } return 0 _ u32 ; } }], 222) } }
 
-            crates/formality-rust/src/check/borrow_check/nll.rs:175:1: no applicable rules for borrow_check_statement { state: flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(none, None, {}, Some({}), [], []), scope(none, None, {}, None, [], [])], point_flow_state({}, {}), {}, {}), statement: break 'nonexistent ;, places_live_on_exit: {}, assumptions: {}, env: TypeckEnv { env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false }, output_ty: Some(u32), program: program([crate core { trait Copy <ty> { } impl Copy for u8 { } impl Copy for u16 { } impl Copy for u32 { } impl Copy for u64 { } impl Copy for i8 { } impl Copy for i16 { } impl Copy for i32 { } impl Copy for i64 { } impl Copy for bool { } impl Copy for usize { } impl Copy for isize { } impl <lt, ty> Copy for &^lt0_0 ^ty0_1 { } trait Place <ty> { type Target : [] ; } unsafe trait Subplace <ty> { type Source : [] ; type Target : [] ; fn offset (self : ^ty1_0) -> usize ; } unsafe trait PlaceRead <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { unsafe fn read (this : *const ^ty1_0, proj : ^ty1_1) -> <^ty1_1 as Subplace>::Target ; } unsafe trait PlaceWrite <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { unsafe fn write (this : *const ^ty1_0, sub : ^ty1_1, value : <^ty1_1 as Subplace>::Target) -> () ; } unsafe trait PlaceMove <ty, ty> where ^ty0_0 : PlaceRead <^ty0_1>, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { } unsafe trait PlaceDrop <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { unsafe fn drop (this : *const ^ty1_0, sub : ^ty1_1) -> () ; } unsafe trait DropHusk <ty> where ^ty0_0 : Place { unsafe fn drop_husk (this : *const ^ty1_0) -> () ; } unsafe trait PlaceBorrow <ty, ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { type BorrowDuration : [BorrowDuration] ; unsafe fn borrow (this : *const ^ty1_0, sub : ^ty1_1) -> ^ty1_2 ; } trait BorrowDuration <ty> { } struct Instant { } struct Lifetime <lt> { } struct Indefinite { } impl BorrowDuration for Instant { } impl <lt> BorrowDuration for Lifetime<^lt0_0> { } impl BorrowDuration for Indefinite { } unsafe trait PlaceDeref <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target, <^ty0_1 as Subplace>::Target : Place { unsafe fn deref (ptr : *mut ^ty1_0, sub : ^ty1_1) -> *const <^ty1_1 as Subplace>::Target ; } unsafe trait PlaceWrapper <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { type Wrapped : [Subplace] where <<^ty1_0 as PlaceWrapper<^ty1_1>>::Wrapped as Subplace>::Source => ^ty1_0 ; fn wrap (sub : ^ty1_1) -> <^ty1_0 as PlaceWrapper<^ty1_1>>::Wrapped ; } }, crate Foo { fn foo () -> u32 { loop { break 'nonexistent ; } return 0 _ u32 ; } }], 222) } }"#]]
-
-
-    )
+            crates/formality-rust/src/check/borrow_check/nll.rs:175:1: no applicable rules for borrow_check_statement { state: flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(none, None, {}, Some({}), [], []), scope(none, None, {}, None, [], [])], point_flow_state({}, {}), {}, {}), statement: break 'nonexistent ;, places_live_on_exit: {}, assumptions: {}, env: TypeckEnv { env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false }, output_ty: Some(u32), program: program([crate core { trait Copy <ty> { } impl Copy for u8 { } impl Copy for u16 { } impl Copy for u32 { } impl Copy for u64 { } impl Copy for i8 { } impl Copy for i16 { } impl Copy for i32 { } impl Copy for i64 { } impl Copy for bool { } impl Copy for usize { } impl Copy for isize { } impl <lt, ty> Copy for &^lt0_0 ^ty0_1 { } trait Place <ty> { type Target : [] ; } unsafe trait Subplace <ty> { type Source : [] ; type Target : [] ; fn offset (self : ^ty1_0) -> usize ; } unsafe trait PlaceRead <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { unsafe fn read (this : *const ^ty1_0, proj : ^ty1_1) -> <^ty1_1 as Subplace>::Target ; } unsafe trait PlaceWrite <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { unsafe fn write (this : *const ^ty1_0, sub : ^ty1_1, value : <^ty1_1 as Subplace>::Target) -> () ; } unsafe trait PlaceMove <ty, ty> where ^ty0_0 : PlaceRead <^ty0_1>, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { } unsafe trait PlaceDrop <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { unsafe fn drop (this : *const ^ty1_0, sub : ^ty1_1) -> () ; } unsafe trait DropHusk <ty> where ^ty0_0 : Place { unsafe fn drop_husk (this : *const ^ty1_0) -> () ; } unsafe trait PlaceBorrow <ty, ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { type BorrowDuration : [BorrowDuration] ; unsafe fn borrow (this : *const ^ty1_0, sub : ^ty1_1) -> ^ty1_2 ; } trait BorrowDuration <ty> { } struct Instant { } struct Lifetime <lt> { } struct Indefinite { } impl BorrowDuration for Instant { } impl <lt> BorrowDuration for Lifetime<^lt0_0> { } impl BorrowDuration for Indefinite { } unsafe trait PlaceDeref <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target, <^ty0_1 as Subplace>::Target : Place { unsafe fn deref (ptr : *mut ^ty1_0, sub : ^ty1_1) -> *const <^ty1_1 as Subplace>::Target ; } unsafe trait PlaceWrapper <ty, ty> where ^ty0_0 : Place, ^ty0_1 : Subplace, <^ty0_1 as Subplace>::Source => <^ty0_0 as Place>::Target { type Wrapped : [Subplace] where <<^ty1_0 as PlaceWrapper<^ty1_1>>::Wrapped as Subplace>::Source => ^ty1_0 ; fn wrap (sub : ^ty1_1) -> <^ty1_0 as PlaceWrapper<^ty1_1>>::Wrapped ; } }, crate Foo { fn foo () -> u32 { loop { break 'nonexistent ; } return 0 _ u32 ; } }], 222) } }"#]])
 }
 
 /// `continue` targeting a valid loop label should pass.
@@ -896,18 +759,15 @@ fn test_break_nonexistent_label() {
 /// ```
 #[test]
 fn test_continue_valid_loop_label() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    'a: loop {
-                        continue 'a;
-                    }
-                    return 0 _ u32;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            'a: loop {
+                continue 'a;
             }
-        ]
-    )
+            return 0 _ u32;
+        }
+    }])
+    .ok()
 }
 
 /// `continue` targeting a block (not a loop) should fail.
@@ -922,22 +782,17 @@ fn test_continue_valid_loop_label() {
 /// ```
 #[test]
 fn test_continue_block_label() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    'a: {
-                        continue 'a;
-                    }
-                    return 0 _ u32;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            'a: {
+                continue 'a;
             }
-        ]
-
-        expect_test::expect![[r#"
+            return 0 _ u32;
+        }
+    }])
+    .err(expect_test::expect![[r#"
             the rule "continue" at (nll.rs) failed because
-              pattern `Some(places_live_on_continue)` did not match value `None`"#]]
-    )
+              pattern `Some(places_live_on_continue)` did not match value `None`"#]])
 }
 
 /// Test parenthesized place expression: `(*v).field`.
@@ -954,22 +809,19 @@ fn test_continue_block_label() {
 /// ```
 #[test]
 fn test_parens_place_expr() {
-    assert_ok!(
-        [
-            crate Foo {
-                struct Pair {
-                    value: u32,
-                }
+    FormalityTest::new(crates![crate Foo {
+        struct Pair {
+            value: u32,
+        }
 
-                fn foo<'a>(v1: &'a Pair) -> u32 {
-                    exists<'r0> {
-                        let v2: u32 = (*v1).value;
-                        return v2;
-                    }
-                }
+        fn foo<'a>(v1: &'a Pair) -> u32 {
+            exists<'r0> {
+                let v2: u32 = (*v1).value;
+                return v2;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// `break` targeting a block label (not a loop) should pass.
@@ -985,16 +837,13 @@ fn test_parens_place_expr() {
 /// ```
 #[test]
 fn test_break_block_label() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    'a: {
-                        break 'a;
-                    }
-                    return 0 _ u32;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            'a: {
+                break 'a;
             }
-        ]
-    )
+            return 0 _ u32;
+        }
+    }])
+    .ok()
 }

--- a/tests/references.rs
+++ b/tests/references.rs
@@ -1,43 +1,34 @@
-use a_mir_formality::{assert_err, assert_ok};
+use a_mir_formality::{crates, FormalityTest};
 
 /// See <https://github.com/rust-lang/a-mir-formality/issues/312> for more information.
 #[test]
 fn recursive_reference_validity() {
-    assert_err!(
-        [
-            crate core {
+    FormalityTest::new(crates![crate core {
                 trait Trait {}
                 struct A<X> where X: Trait {}
                 fn invalid<'a, X>(x: &'a A<X>) -> ()
                 where
                     X: 'a,
                 {}
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: @ wf(&!lt_1 A<!ty_0>), via: !ty_0 : !lt_1, assumptions: {!ty_0 : !lt_1}, env: Env { variables: [!lt_1, !ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait(!ty_0), via: !ty_0 : !lt_1, assumptions: {!ty_0 : !lt_1}, env: Env { variables: [!lt_1, !ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             the rule "trait implied bound" at (prove_wc.rs) failed because
-              expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
-    );
+              expression evaluated to an empty collection: `decls.trait_invariants()`"#]]);
 }
 
 #[test]
 fn reference_validity() {
-    assert_ok!(
-        [
-            crate core {
-                trait Trait {}
-                struct A<X> where X: Trait {}
-                fn valid<'a, X>(x: &'a A<X>) -> ()
-                where
-                    X: 'a,
-                    X: Trait,
-                {}
-            }
-        ]
-    );
+    FormalityTest::new(crates![crate core {
+        trait Trait {}
+        struct A<X> where X: Trait {}
+        fn valid<'a, X>(x: &'a A<X>) -> ()
+        where
+            X: 'a,
+            X: Trait,
+        {}
+    }])
+    .ok();
 }

--- a/tests/return_validation.rs
+++ b/tests/return_validation.rs
@@ -1,4 +1,4 @@
-use a_mir_formality::{assert_err, assert_ok};
+use a_mir_formality::{crates, FormalityTest};
 
 /// Tests for issue #209: ensuring functions return a value on all paths.
 ///
@@ -12,48 +12,38 @@ use a_mir_formality::{assert_err, assert_ok};
 #[test]
 #[ignore = "needs return validation (#209)"]
 fn empty_body_non_unit_return() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                }
-            }
-        ]
-        expect_test::expect![[r#"function may not return a value"#]]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+        }
+    }])
+    .err(expect_test::expect![[r#"function may not return a value"#]])
 }
 
 /// A function returning () with an empty body is fine — unit is implicit.
 /// rustc: compiles with no error
 #[test]
 fn empty_body_unit_return() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> () {
-                }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> () {
+        }
+    }])
+    .ok()
 }
 
 /// If/else where both branches return — all paths return, so this is fine.
 /// rustc: compiles with no error
 #[test]
 fn if_else_both_branches_return() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo(b: bool) -> u32 {
-                    if b {
-                        return 1 _ u32;
-                    } else {
-                        return 2 _ u32;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo(b: bool) -> u32 {
+            if b {
+                return 1 _ u32;
+            } else {
+                return 2 _ u32;
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// If/else where only one branch returns — the other path falls through
@@ -62,35 +52,28 @@ fn if_else_both_branches_return() {
 #[test]
 #[ignore = "needs return validation (#209)"]
 fn if_else_one_branch_returns() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo(b: bool) -> u32 {
-                    if b {
-                        return 1 _ u32;
-                    } else {
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo(b: bool) -> u32 {
+            if b {
+                return 1 _ u32;
+            } else {
             }
-        ]
-        expect_test::expect![[r#"function may not return a value"#]]
-    )
+        }
+    }])
+    .err(expect_test::expect![[r#"function may not return a value"#]])
 }
 
 /// An infinite loop never terminates, so it never needs to return.
 /// rustc: compiles with no error (loop {} has type !)
 #[test]
 fn infinite_loop_no_return_needed() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    loop {
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            loop {
             }
-        ]
-    )
+        }
+    }])
+    .ok()
 }
 
 /// A loop with break exits the loop, but then there's no return after it.
@@ -99,49 +82,39 @@ fn infinite_loop_no_return_needed() {
 #[test]
 #[ignore = "needs return validation (#209)"]
 fn loop_with_break_no_return() {
-    assert_err!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    'a: loop {
-                        break 'a;
-                    }
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            'a: loop {
+                break 'a;
             }
-        ]
-        expect_test::expect![[r#"function may not return a value"#]]
-    )
+        }
+    }])
+    .err(expect_test::expect![[r#"function may not return a value"#]])
 }
 
 /// A loop with break followed by a return is fine — all paths return.
 /// rustc: compiles with no error
 #[test]
 fn loop_with_break_then_return() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    'a: loop {
-                        break 'a;
-                    }
-                    return 0 _ u32;
-                }
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            'a: loop {
+                break 'a;
             }
-        ]
-    )
+            return 0 _ u32;
+        }
+    }])
+    .ok()
 }
 
 /// A simple function that returns a value on all paths.
 /// rustc: compiles with no error
 #[test]
 fn simple_return() {
-    assert_ok!(
-        [
-            crate Foo {
-                fn foo() -> u32 {
-                    return 42 _ u32;
-                }
-            }
-        ]
-    )
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> u32 {
+            return 42 _ u32;
+        }
+    }])
+    .ok()
 }

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -1,44 +1,42 @@
+use a_mir_formality::{crates, FormalityTest};
+
 #[test]
 fn trait_with_valid_fn() {
-    a_mir_formality::assert_ok!(
-        [
-            crate core {
-                trait A {
-                    fn a() -> ();
-                }
+    FormalityTest::new(crates![
+        crate core {
+            trait A {
+                fn a() -> ();
             }
-        ]
-    );
+        }
+    ])
+    .ok();
 }
 
 #[test]
 fn trait_with_valid_associated_type() {
-    a_mir_formality::assert_ok!(
-        [
-            crate core {
-                trait A {
-                    type Assoc : [];
-                }
+    FormalityTest::new(crates![
+        crate core {
+            trait A {
+                type Assoc : [];
             }
-        ]
-    );
+        }
+    ])
+    .ok();
 }
 
 #[test]
 #[ignore = "ensures bounds WF check not yet implemented, see FIXME(#228)"]
 fn trait_with_ill_formed_where_clause() {
-    a_mir_formality::assert_err!(
-        [
-            crate core {
-                trait A<T> where T: B {}
-                trait B {}
-                trait C {
-                    type Assoc : [ A<u32> ];
-                }
+    FormalityTest::new(crates![
+        crate core {
+            trait A<T> where T: B {}
+            trait B {}
+            trait C {
+                type Assoc : [ A<u32> ];
             }
-        ]
-        expect_test::expect![[r#"
+        }
+    ])
+    .err(expect_test::expect![[r#"
             the rule "trait implied bound" at (prove_wc.rs) failed because
-              expression evaluated to an empty collection: `decls.trait_invariants()`"#]]
-    );
+              expression evaluated to an empty collection: `decls.trait_invariants()`"#]]);
 }

--- a/tests/well_formed_trait_ref.rs
+++ b/tests/well_formed_trait_ref.rs
@@ -1,32 +1,26 @@
-use a_mir_formality::{assert_err, assert_ok, test_program_ok};
+use a_mir_formality::{crates, test_program_ok, FormalityTest};
 
 #[test]
 fn dependent_where_clause() {
-    assert_ok!(
+    FormalityTest::new(crates![crate foo {
+        trait Trait1 {}
 
-        [
-            crate foo {
-                trait Trait1 {}
+        trait Trait2 {}
 
-                trait Trait2 {}
+        struct S1<T> where T: Trait1 {
+            dummy: T,
+        }
 
-                struct S1<T> where T: Trait1 {
-                    dummy: T,
-                }
-
-                struct S2<T> where T: Trait1, S1<T> : Trait2 {
-                    dummy: T,
-                }
-            }
-        ]
-    )
+        struct S2<T> where T: Trait1, S1<T> : Trait2 {
+            dummy: T,
+        }
+    }])
+    .ok()
 }
 
 #[test]
 fn missing_dependent_where_clause() {
-    assert_err!(
-        [
-            crate foo {
+    FormalityTest::new(crates![crate foo {
                 trait Trait1 {}
 
                 trait Trait2 {}
@@ -38,10 +32,7 @@ fn missing_dependent_where_clause() {
                 struct S2<T> where S1<T> : Trait2 {
                     dummy: T,
                 }
-            }
-        ]
-
-        expect_test::expect![[r#"
+            }]).err(expect_test::expect![[r#"
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: @ WellFormedTraitRef(Trait2(S1<!ty_0>)), via: Trait2(S1<!ty_0>), assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait1(!ty_0), via: Trait2(S1<!ty_0>), assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
@@ -52,60 +43,47 @@ fn missing_dependent_where_clause() {
 
             crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait1(!ty_0), via: Place(?ty_1), assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0, ?ty_1], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
-            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait1(!ty_0), via: PlaceRead(?ty_1, ?ty_2), assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0, ?ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]]
-    )
+            crates/formality-rust/src/prove/prove/prove/prove_via.rs:9:1: no applicable rules for prove_via { goal: Trait1(!ty_0), via: PlaceRead(?ty_1, ?ty_2), assumptions: {Trait2(S1<!ty_0>)}, env: Env { variables: [!ty_0, ?ty_1, ?ty_2], bias: Soundness, pending: [], allow_pending_outlives: false } }"#]])
 }
 
 #[test]
 fn lifetime_param() {
-    assert_ok!(
+    FormalityTest::new(crates![crate foo {
+        trait Trait1<'a> {}
 
-        [
-            crate foo {
-                trait Trait1<'a> {}
+        struct S1 {}
 
-                struct S1 {}
-
-                struct S2<'a> where S1: Trait1<'a> {}
-            }
-        ]
-    )
+        struct S2<'a> where S1: Trait1<'a> {}
+    }])
+    .ok()
 }
 
 #[test]
 fn static_lifetime_param() {
-    assert_ok!(
+    FormalityTest::new(crates![crate foo {
+        trait Trait1<'a> {}
 
-        [
-            crate foo {
-                trait Trait1<'a> {}
+        struct S1 {}
 
-                struct S1 {}
+        impl Trait1<'static> for S1 {}
 
-                impl Trait1<'static> for S1 {}
-
-                struct S2 where S1: Trait1<'static> {}
-            }
-        ]
-    )
+        struct S2 where S1: Trait1<'static> {}
+    }])
+    .ok()
 }
 
 #[test]
 fn const_param() {
-    assert_ok!(
+    FormalityTest::new(crates![crate foo {
+        trait Trait1<const C> where type_of_const C is u32 {}
 
-        [
-            crate foo {
-                trait Trait1<const C> where type_of_const C is u32 {}
+        struct S1 {}
 
-                struct S1 {}
+        impl Trait1<u32(3)> for S1 {}
 
-                impl Trait1<u32(3)> for S1 {}
-
-                struct S2 where S1: Trait1<u32(3)> {}
-            }
-        ]
-    )
+        struct S2 where S1: Trait1<u32(3)> {}
+    }])
+    .ok()
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do?
This PR refactor test macros to builder pattern as discussed in https://github.com/rust-lang/a-mir-formality/issues/350

e.g., closes #350

## How does it work, what questions do you have?
Replaces the `assert_ok!` / `assert_err!` test macros with a `FormalityTest` builder that uses method chaining and supports per-backend expectation overrides. 
Thus the legacy `assert_ok!` / `assert_err!` macros are removed.

In `crates/formality-rust/src/to_rust/test_util.rs` added run_rustc() helper that drives check_workspace against a temp dir  switch assert_rust to the free standing build_crates API because RustBuilder was removed.

## AI disclosure

* I used an AI tool for research.

