### PR TITLE
convert `check_adt` to a judgement function

### DIFF
--- a/crates/formality-rust/src/check/adts.rs
+++ b/crates/formality-rust/src/check/adts.rs
@@ -30,7 +30,7 @@ judgment_fn! {
     }
 }
 
-fn check_adt_names_unique(adt: &Adt) -> Fallible<ProofTree> {
+fn check_adt_variant_names_unique(adt: &Adt) -> Fallible<ProofTree> {
     // names is used to check that there are no name conflicts
     let mut names = HashSet::new();
     for Variant { name, fields } in &adt.binder.peek().variants {

--- a/crates/formality-rust/src/check/adts.rs
+++ b/crates/formality-rust/src/check/adts.rs
@@ -15,7 +15,7 @@ judgment_fn! {
     ) => () {
         debug(adt)
         (
-            (check_adt_names_unique(adt) => ())
+            (check_adt_variant_names_unique(adt) => ())
             (let (env, bound_data) = Env::default().instantiate_universally(&adt.binder))
             (let AdtBoundData { where_clauses, variants } = bound_data)
             (prove_where_clauses_well_formed(program, env, where_clauses, where_clauses) => ())

--- a/crates/formality-rust/src/check/adts.rs
+++ b/crates/formality-rust/src/check/adts.rs
@@ -1,15 +1,36 @@
 use std::collections::HashSet;
 
+use crate::check::{prove_goal, where_clauses::prove_where_clauses_well_formed};
 use crate::grammar::Fallible;
 use crate::grammar::{Adt, AdtBoundData, Field, Relation, Variant};
 use crate::prove::prove::{Env, Program};
 use anyhow::bail;
 use formality_core::judgment::ProofTree;
+use formality_core::judgment_fn;
 
-pub(super) fn check_adt(program: &Program, adt: &Adt) -> Fallible<ProofTree> {
-    let Adt { id, binder } = adt;
-    let mut proof_tree = ProofTree::leaf(format!("check_adt({id:?})"));
+judgment_fn! {
+    pub(super) fn check_adt(
+        program: Program,
+        adt: Adt,
+    ) => () {
+        debug(adt)
+        (
+            (check_adt_names_unique(adt) => ())
+            (let (env, bound_data) = Env::default().instantiate_universally(&adt.binder))
+            (let AdtBoundData { where_clauses, variants } = bound_data)
+            (prove_where_clauses_well_formed(program, env, where_clauses, where_clauses) => ())
+            (for_all(variant in variants)
+                (let Variant { fields, .. } = variant)
+                (for_all(field in fields)
+                    (let Field { ty, .. } = field)
+                    (prove_goal(program, env, where_clauses, Relation::well_formed(ty)) => ())))
+            ------------------------------------------------------------ ("check adt")
+            (check_adt(program, adt) => ())
+        )
+    }
+}
 
+fn check_adt_names_unique(adt: &Adt) -> Fallible<ProofTree> {
     // names is used to check that there are no name conflicts
     let mut names = HashSet::new();
     for Variant { name, fields } in &adt.binder.peek().variants {
@@ -24,33 +45,7 @@ pub(super) fn check_adt(program: &Program, adt: &Adt) -> Fallible<ProofTree> {
         }
     }
 
-    let (
-        env,
-        AdtBoundData {
-            where_clauses,
-            variants,
-        },
-    ) = Env::default().instantiate_universally(binder);
-
-    proof_tree
-        .children
-        .push(super::where_clauses::prove_where_clauses_well_formed(
-            program,
-            &env,
-            &where_clauses,
-            &where_clauses,
-        )?);
-
-    for Variant { name: _, fields } in &variants {
-        for Field { name: _, ty } in fields {
-            proof_tree.children.push(super::prove_goal(
-                program,
-                &env,
-                &where_clauses,
-                Relation::well_formed(&ty),
-            )?);
-        }
-    }
-
-    Ok(proof_tree)
+    Ok(ProofTree::leaf(
+        "check_adt_names_unique: all variant and field names unique",
+    ))
 }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -101,8 +101,8 @@ fn basic_adt_variant_dup() {
         }
     }])
     .err(expect_test::expect![[r#"
-            the rule "adt" at (mod.rs) failed because
-              variant "Baz" defined multiple times"#]])
+        the rule "check adt" at (adts.rs) failed because
+          variant "Baz" defined multiple times"#]])
 }
 
 #[test]
@@ -114,8 +114,8 @@ fn basic_adt_field_dup() {
         }
     }])
     .err(expect_test::expect![[r#"
-            the rule "adt" at (mod.rs) failed because
-              field "baz" of variant "struct" defined multiple times"#]])
+        the rule "check adt" at (adts.rs) failed because
+          field "baz" of variant "struct" defined multiple times"#]])
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do?

Implements `check_adt` as a judgment function (along with a helper for name uniqueness a la `check_for_duplicate_items`

closes #292

## How does it work, what questions do you have?

<!-- In your own words (**no LLM usage here**), explain the main idea of why it's correct. It's ok if you're not sure! Please include any questions you have. If you wish to use an LLM for translation, include the original as well as the translated version. Thanks! -->

It is basically a 1:1 conversion of the previous code, and ran all tests to make sure that behavior didn't change (a small bit of failure message *did* change, but it is trivial imo)

## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools

**EDIT**: I constantly misspell judgment