### PR TITLE
Improve duplication check for normal and negative impl

### DIFF
--- a/crates/formality-rust/src/check/coherence.rs
+++ b/crates/formality-rust/src/check/coherence.rs
@@ -13,7 +13,6 @@ judgment_fn! {
 
         (
             (let current_crate_impls = program.trait_impls_in_crate(&current_crate))
-            (ensure_no_duplicate_impls(current_crate_impls) => ())
             (let all_crate_impls = program.trait_impls())
             (for_all(impl_a in current_crate_impls)
                 (for_all(impl_b in all_crate_impls)
@@ -61,16 +60,6 @@ judgment_fn! {
             (orphan_check_neg(program, impl_a) => ())
         )
     }
-}
-
-/// Reject duplicate trait impls in the current crate so overlap pairing cannot match an impl with itself.
-fn ensure_no_duplicate_impls(impls: &[TraitImpl]) -> Fallible<ProofTree> {
-    for (i, impl_a) in impls.iter().enumerate() {
-        if impls[i + 1..].contains(impl_a) {
-            bail!("duplicate impl in current crate: {:?}", impl_a);
-        }
-    }
-    Ok(ProofTree::leaf("no duplicate impls"))
 }
 
 /// Two impls of the same trait prove they do not overlap or report impls may overlap.

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -79,6 +79,7 @@ fn check_for_duplicate_items(program: &Program) -> Fallible<ProofTree> {
         let mut items = Set::new();
         let mut traits = Set::new();
         let mut functions = Set::new();
+        let mut impl_decls = Set::new();
         for item in c.items.iter() {
             match item {
                 CrateItem::AdtItem(s) => {
@@ -96,8 +97,12 @@ fn check_for_duplicate_items(program: &Program) -> Fallible<ProofTree> {
                         bail!("the function name `{:?}` is defined multiple times", f.id);
                     }
                 }
-                CrateItem::TraitImpl(_) | CrateItem::NegTraitImpl(_) | CrateItem::Test(_) => {}
-                CrateItem::FeatureGate(_) => {}
+                CrateItem::TraitImpl(impl_decl) => {
+                    if !impl_decls.insert(impl_decl) {
+                        bail!("`{:?}` is defined multiple times", impl_decl);
+                    }
+                }
+                CrateItem::NegTraitImpl(_) | CrateItem::Test(_) | CrateItem::FeatureGate(_) => {}
             }
         }
     }

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -80,6 +80,7 @@ fn check_for_duplicate_items(program: &Program) -> Fallible<ProofTree> {
         let mut traits = Set::new();
         let mut functions = Set::new();
         let mut impl_decls = Set::new();
+        let mut neg_impl_decls = Set::new();
         for item in c.items.iter() {
             match item {
                 CrateItem::AdtItem(s) => {
@@ -102,7 +103,12 @@ fn check_for_duplicate_items(program: &Program) -> Fallible<ProofTree> {
                         bail!("`{:?}` is defined multiple times", impl_decl);
                     }
                 }
-                CrateItem::NegTraitImpl(_) | CrateItem::Test(_) | CrateItem::FeatureGate(_) => {}
+                CrateItem::NegTraitImpl(neg_impl_decl) => {
+                    if !neg_impl_decls.insert(neg_impl_decl) {
+                        bail!("`{:?}` is defined multiple times", neg_impl_decl);
+                    }
+                }
+                CrateItem::Test(_) | CrateItem::FeatureGate(_) => {}
             }
         }
     }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -195,6 +195,19 @@ fn basic_impl_dup() {
 }
 
 #[test]
+fn basic_neg_impl_dup() {
+    FormalityTest::new(crates![crate core {
+        trait MyTrait {}
+        struct MyStruct {}
+        impl !MyTrait for MyStruct {}
+        impl !MyTrait for MyStruct {}
+    }])
+    .err(expect_test::expect![[r#"
+        the rule "check crate" at (mod.rs) failed because
+          `impl ! MyTrait for MyStruct {}` is defined multiple times"#]]);
+}
+
+#[test]
 fn impl_missing_required_fn() {
     FormalityTest::new(crates![crate core {
         trait Foo {

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -182,6 +182,19 @@ fn crate_with_duplicate_item_names() {
 }
 
 #[test]
+fn basic_impl_dup() {
+    FormalityTest::new(crates![crate core {
+        trait MyTrait {}
+        struct MyStruct {}
+        impl MyTrait for MyStruct {}
+        impl MyTrait for MyStruct {}
+    }])
+    .err(expect_test::expect![[r#"
+        the rule "check crate" at (mod.rs) failed because
+          `impl MyTrait for MyStruct { }` is defined multiple times"#]]);
+}
+
+#[test]
 fn impl_missing_required_fn() {
     FormalityTest::new(crates![crate core {
         trait Foo {

--- a/tests/coherence_overlap.rs
+++ b/tests/coherence_overlap.rs
@@ -212,8 +212,8 @@ fn u32_u32_impls() {
         impl Foo for u32 {}
     }])
     .err(expect_test::expect![[r#"
-            the rule "check_coherence" at (coherence.rs) failed because
-              duplicate impl in current crate: impl Foo for u32 { }"#]])
+        the rule "check crate" at (mod.rs) failed because
+          `impl Foo for u32 { }` is defined multiple times"#]])
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do?

Previously, the duplication check for a normal impl ``impl A for B`` is not done in ``check_for_duplicate_items`` but in ``ensure_no_duplicate_impls`` under ``check_coherence``. It is a bit confusing and I think we can just do it in ``check_for_duplicate_items`` together with other crate items. 

For negative impl, we don't have any duplication check previously so I am just adding them in here. 


## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools
