### PR TITLE
Add formality-coverage crate to generate markdown coverage report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "formality-coverage"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "expect-test",
+ "regex",
+ "serde_json",
+ "walkdir",
+]
+
+[[package]]
 name = "formality-macros"
 version = "0.1.0"
 dependencies = [
@@ -914,6 +926,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1315,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,6 @@ members = [
     "crates/formality-core",
     "crates/formality-rust",
     "crates/formality-mdbook",
+    "crates/formality-coverage",
     "crates/minirust-rs",
 ]

--- a/crates/formality-coverage/Cargo.toml
+++ b/crates/formality-coverage/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "formality-coverage"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Coverage report generator for a-mir-formality judgment rules"
+homepage = "https://rust-lang.github.io/a-mir-formality/"
+repository = "https://github.com/rust-lang/a-mir-formality/"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4.0.9", features = ["derive"] }
+regex = "1.10.2"
+serde_json = "1"
+walkdir = "2"
+
+[dev-dependencies]
+expect-test = "1.4.1"
+
+[[bin]]
+name = "formality-coverage"
+path = "src/bin/formality-coverage.rs"

--- a/crates/formality-coverage/src/bin/formality-coverage.rs
+++ b/crates/formality-coverage/src/bin/formality-coverage.rs
@@ -1,0 +1,47 @@
+//! CLI that scrapes the source tree, reads the positive-coverage JSONL,
+//! and writes a markdown report.
+
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
+
+use formality_coverage::{jsonl, report, scrape};
+
+#[derive(Parser, Debug)]
+#[command(about = "Generate a markdown coverage report for a-mir-formality judgments")]
+struct Args {
+    /// Directory to scan for `judgment_fn!` invocations.
+    #[arg(long, default_value = "crates")]
+    src_root: PathBuf,
+
+    /// Path to the JSONL coverage file produced by positive tests.
+    #[arg(long, default_value = "target/test-coverage.jsonl")]
+    jsonl: PathBuf,
+
+    /// Directory where the markdown report will be written.
+    #[arg(long, default_value = "target/coverage-report")]
+    out_dir: PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let judgments = scrape::scrape_dir(&args.src_root)?;
+
+    if !args.jsonl.exists() {
+        eprintln!(
+            "note: no coverage data at {}; did you run `cargo test` first? \
+             Continuing with empty coverage.",
+            args.jsonl.display(),
+        );
+    }
+    let covered = jsonl::read_positive(&args.jsonl)?;
+
+    report::write_all(&args.out_dir, &judgments, &covered)?;
+    eprintln!(
+        "wrote {} judgments ({} rules covered) to {}",
+        judgments.len(),
+        covered.len(),
+        args.out_dir.display(),
+    );
+    Ok(())
+}

--- a/crates/formality-coverage/src/jsonl.rs
+++ b/crates/formality-coverage/src/jsonl.rs
@@ -1,0 +1,58 @@
+//! Read the `test-coverage.jsonl` file produced by positive tests and
+//! collapse it to the set of `(judgment, rule)` pairs that fired at least once.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// A `(judgment, rule)` pair as it appears in coverage data.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct CoveredRule {
+    pub judgment: String,
+    pub rule: String,
+}
+
+/// Parse the JSONL file at `path`, returning the deduplicated set of rules
+/// that fired across all recorded tests. If the file does not exist, returns
+/// an empty set (positive coverage is opt-in via `cargo test`).
+pub fn read_positive(path: &Path) -> Result<BTreeSet<CoveredRule>> {
+    let mut out = BTreeSet::new();
+    if !path.exists() {
+        return Ok(out);
+    }
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    for (i, line) in text.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        // Tolerate corrupted lines: parallel `cargo test` processes append
+        // to this file concurrently, and on rare occasions two writes can
+        // interleave. A bad line should never abort the report.
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            eprintln!(
+                "warning: skipping malformed JSONL line {} in {}",
+                i + 1,
+                path.display(),
+            );
+            continue;
+        };
+        let Some(rules) = value.get("rules").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for rule in rules {
+            let (Some(j), Some(r)) = (
+                rule.get("judgment").and_then(|v| v.as_str()),
+                rule.get("rule").and_then(|v| v.as_str()),
+            ) else {
+                continue;
+            };
+            out.insert(CoveredRule {
+                judgment: j.to_string(),
+                rule: r.to_string(),
+            });
+        }
+    }
+    Ok(out)
+}

--- a/crates/formality-coverage/src/lib.rs
+++ b/crates/formality-coverage/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod jsonl;
+pub mod report;
+pub mod scrape;

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -1,0 +1,126 @@
+//! Render scraped judgments + positive-coverage data into markdown.
+//!
+//! Coverage marks are emitted as mdbook emoji shortcodes (`:check:` / `:x:`)
+//! so they render correctly through the mdbook preprocessor that wires this
+//! report into the formality book.
+
+use crate::jsonl::CoveredRule;
+use crate::scrape::Judgment;
+use anyhow::{Context, Result};
+use std::collections::{BTreeSet, HashSet};
+use std::path::Path;
+
+/// Render the top-level coverage table.
+pub fn render_index(judgments: &[Judgment], covered: &BTreeSet<CoveredRule>) -> String {
+    let mut s = String::new();
+    s.push_str("# Coverage report\n\n");
+    s.push_str("| Judgment/Rule | Positive coverage |\n");
+    s.push_str("| --- | --- |\n");
+    for j in judgments {
+        let slug = slug(&j.name);
+        s.push_str(&format!(
+            "| **[{name}](./{slug}.md)** | - |\n",
+            name = j.name,
+            slug = slug,
+        ));
+        for r in &j.rules {
+            let mark = covered_mark(covered, &j.name, &r.name);
+            s.push_str(&format!(
+                "| ↳ [{rname}](./{slug}.md#{anchor}) | {mark} |\n",
+                rname = r.name,
+                slug = slug,
+                anchor = anchor(&r.name),
+                mark = mark,
+            ));
+        }
+    }
+    s
+}
+
+/// Render one subpage per judgment.
+pub fn render_subpage(j: &Judgment, covered: &BTreeSet<CoveredRule>) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        "# Judgment `{}` at {}:{}\n\n",
+        j.name, j.file, j.line,
+    ));
+    if j.rules.is_empty() {
+        s.push_str("_No rules discovered._\n");
+        return s;
+    }
+    s.push_str("| Rule | Line | Positive coverage |\n");
+    s.push_str("| --- | --- | --- |\n");
+    for r in &j.rules {
+        let mark = covered_mark(covered, &j.name, &r.name);
+        s.push_str(&format!(
+            "| <a id=\"{anchor}\"></a>`{rname}` | {line} | {mark} |\n",
+            anchor = anchor(&r.name),
+            rname = r.name,
+            line = r.line,
+            mark = mark,
+        ));
+    }
+    s
+}
+
+fn covered_mark(covered: &BTreeSet<CoveredRule>, judgment: &str, rule: &str) -> &'static str {
+    let hit = covered.contains(&CoveredRule {
+        judgment: judgment.to_string(),
+        rule: rule.to_string(),
+    });
+    if hit {
+        ":check:"
+    } else {
+        ":x:"
+    }
+}
+
+/// Write the index and per-judgment subpages into `out_dir`.
+pub fn write_all(
+    out_dir: &Path,
+    judgments: &[Judgment],
+    covered: &BTreeSet<CoveredRule>,
+) -> Result<()> {
+    std::fs::create_dir_all(out_dir).with_context(|| format!("creating {}", out_dir.display()))?;
+    let index = render_index(judgments, covered);
+    std::fs::write(out_dir.join("coverage.md"), index)?;
+
+    // Two judgments with the same name (or names that differ only by characters
+    // we collapse into `_`) would clobber each other's subpage. Warn so the
+    // collision is at least visible.
+    let mut seen_slugs: HashSet<String> = HashSet::new();
+    for j in judgments {
+        let slug = slug(&j.name);
+        if !seen_slugs.insert(slug.clone()) {
+            eprintln!(
+                "warning: slug collision for judgment `{}` at {}:{} — subpage will overwrite a sibling",
+                j.name, j.file, j.line,
+            );
+        }
+        let body = render_subpage(j, covered);
+        std::fs::write(out_dir.join(format!("{}.md", slug)), body)?;
+    }
+    Ok(())
+}
+
+fn slug(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn anchor(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            c if c.is_ascii_alphanumeric() => c.to_ascii_lowercase(),
+            ' ' | '-' | '_' => '-',
+            _ => '-',
+        })
+        .collect()
+}

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -1,8 +1,4 @@
 //! Render scraped judgments + positive-coverage data into markdown.
-//!
-//! Coverage marks are emitted as mdbook emoji shortcodes (`:check:` / `:x:`)
-//! so they render correctly through the mdbook preprocessor that wires this
-//! report into the formality book.
 
 use crate::jsonl::CoveredRule;
 use crate::scrape::Judgment;
@@ -69,9 +65,9 @@ fn covered_mark(covered: &BTreeSet<CoveredRule>, judgment: &str, rule: &str) -> 
         rule: rule.to_string(),
     });
     if hit {
-        ":check:"
+        "✓"
     } else {
-        ":x:"
+        "✗"
     }
 }
 

--- a/crates/formality-coverage/src/scrape.rs
+++ b/crates/formality-coverage/src/scrape.rs
@@ -1,0 +1,111 @@
+//! Discover the full set of judgments and rules in the source tree by
+//! regex-scraping `judgment_fn!` macro invocations.
+//!
+//! This is intentionally lightweight: we do not parse Rust, we just find
+//! `judgment_fn!` blocks and the `--- ("rule-name")` lines inside them. If
+//! the macro syntax changes, the regexes here must follow.
+//!
+//! Block boundary caveat: each judgment's body is taken as the text from
+//! `judgment_fn!` up to the next `judgment_fn!` (or EOF). A rule-shaped line
+//! (`--- ("name")`) sitting outside a macro invocation would be misattributed.
+//! In practice this pattern only appears inside `judgment_fn!`, so we accept
+//! the trade-off and avoid Rust-aware brace balancing.
+
+use anyhow::Result;
+use regex::Regex;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use walkdir::WalkDir;
+
+static INVOCATION_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"judgment_fn!\s*\{").unwrap());
+static FN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b(?:pub\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(").unwrap());
+static RULE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"^\s*-{3,}\s*\(\s*"([^"]+)"\s*\)\s*$"#).unwrap());
+
+/// A single judgment discovered by the scraper.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Judgment {
+    pub name: String,
+    pub file: String,
+    pub line: u32,
+    pub rules: Vec<Rule>,
+}
+
+/// A single inference rule inside a judgment.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Rule {
+    pub name: String,
+    pub line: u32,
+}
+
+/// Walk `root` recursively and scrape every `.rs` file for `judgment_fn!`
+/// blocks. Results are sorted by `(file, line)` for stable output.
+pub fn scrape_dir(root: &Path) -> Result<Vec<Judgment>> {
+    let mut out = Vec::new();
+    for entry in WalkDir::new(root) {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(err) => {
+                eprintln!("warning: skipping entry under {}: {err}", root.display());
+                continue;
+            }
+        };
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+        let contents = std::fs::read_to_string(path)?;
+        let rel = normalize_path(path, root);
+        out.extend(scrape_text(&contents, &rel));
+    }
+    out.sort_by(|a, b| (a.file.as_str(), a.line).cmp(&(b.file.as_str(), b.line)));
+    Ok(out)
+}
+
+fn normalize_path(path: &Path, root: &Path) -> String {
+    let rel: PathBuf = path.strip_prefix(root).unwrap_or(path).to_path_buf();
+    rel.to_string_lossy().replace('\\', "/")
+}
+
+/// Scrape one file's text. `file` is the path string to record in results.
+pub fn scrape_text(text: &str, file: &str) -> Vec<Judgment> {
+    let starts: Vec<usize> = INVOCATION_RE.find_iter(text).map(|m| m.start()).collect();
+    let mut out = Vec::new();
+    for (i, &start) in starts.iter().enumerate() {
+        let end = starts.get(i + 1).copied().unwrap_or(text.len());
+        let block = &text[start..end];
+
+        let Some(cap) = FN_RE.captures(block) else {
+            continue;
+        };
+        let name = cap.get(1).unwrap().as_str().to_string();
+        let fn_offset_in_block = cap.get(0).unwrap().start();
+        let fn_abs = start + fn_offset_in_block;
+        let header_line = line_number(text, fn_abs);
+
+        let mut rules = Vec::new();
+        for (rel_line_idx, line) in block.lines().enumerate() {
+            if let Some(c) = RULE_RE.captures(line) {
+                let line_no = line_number(text, start) + rel_line_idx as u32;
+                rules.push(Rule {
+                    name: c.get(1).unwrap().as_str().to_string(),
+                    line: line_no,
+                });
+            }
+        }
+
+        out.push(Judgment {
+            name,
+            file: file.to_string(),
+            line: header_line,
+            rules,
+        });
+    }
+    out
+}
+
+fn line_number(text: &str, byte_offset: usize) -> u32 {
+    let upto = &text[..byte_offset.min(text.len())];
+    (upto.bytes().filter(|&b| b == b'\n').count() as u32) + 1
+}

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -113,10 +113,10 @@ fn markdown_index_snapshot() {
         | Judgment/Rule | Positive coverage |
         | --- | --- |
         | **[prove_thing](./prove_thing.md)** | - |
-        | ↳ [positive](./prove_thing.md#positive) | :check: |
-        | ↳ [zero](./prove_thing.md#zero) | :x: |
+        | ↳ [positive](./prove_thing.md#positive) | ✓ |
+        | ↳ [zero](./prove_thing.md#zero) | ✗ |
         | **[only_one](./only_one.md)** | - |
-        | ↳ [one](./only_one.md#one) | :x: |
+        | ↳ [one](./only_one.md#one) | ✗ |
     "#]]
     .assert_eq(&md);
 }
@@ -150,8 +150,8 @@ fn markdown_subpage_snapshot() {
 
         | Rule | Line | Positive coverage |
         | --- | --- | --- |
-        | <a id="positive"></a>`positive` | 10 | :check: |
-        | <a id="zero"></a>`zero` | 16 | :x: |
+        | <a id="positive"></a>`positive` | 10 | ✓ |
+        | <a id="zero"></a>`zero` | 16 | ✗ |
     "#]]
     .assert_eq(&md);
 }

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -1,0 +1,207 @@
+//! End-to-end-ish tests for the scraper + report generator. Uses inline
+//! fixtures (a fake `judgment_fn!` source snippet) so the tests don't depend
+//! on the live `formality-rust` source layout.
+
+use std::collections::BTreeSet;
+
+use expect_test::expect;
+use formality_coverage::jsonl::{self, CoveredRule};
+use formality_coverage::report;
+use formality_coverage::scrape::{scrape_text, Judgment, Rule};
+
+const FIXTURE: &str = r#"
+use formality_core::judgment_fn;
+
+judgment_fn! {
+    /// doc comment
+    pub fn prove_thing(x: u32) => () {
+        debug(x)
+
+        (
+            (if x > 0)
+            --------------------------------------- ("positive")
+            (prove_thing(x) => ())
+        )
+
+        (
+            (if x == 0)
+            --- ("zero")
+            (prove_thing(x) => ())
+        )
+    }
+}
+
+judgment_fn! {
+    fn only_one(x: u32) => () {
+        debug(x)
+
+        (
+            (if x == 1)
+            ----- ("one")
+            (only_one(x) => ())
+        )
+    }
+}
+"#;
+
+#[test]
+fn scrapes_judgments_and_rules() {
+    let got = scrape_text(FIXTURE, "fixture.rs");
+    assert_eq!(got.len(), 2);
+
+    assert_eq!(got[0].name, "prove_thing");
+    assert_eq!(got[0].file, "fixture.rs");
+    let rule_names: Vec<&str> = got[0].rules.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(rule_names, vec!["positive", "zero"]);
+
+    assert_eq!(got[1].name, "only_one");
+    let rule_names: Vec<&str> = got[1].rules.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(rule_names, vec!["one"]);
+}
+
+#[test]
+fn rule_line_numbers_are_absolute() {
+    let got = scrape_text(FIXTURE, "fixture.rs");
+    let positive = got[0].rules.iter().find(|r| r.name == "positive").unwrap();
+    let expected_line = FIXTURE
+        .lines()
+        .position(|l| l.contains(r#"("positive")"#))
+        .unwrap() as u32
+        + 1;
+    assert_eq!(positive.line, expected_line);
+}
+
+#[test]
+fn markdown_index_snapshot() {
+    let judgments = vec![
+        Judgment {
+            name: "prove_thing".into(),
+            file: "fixture.rs".into(),
+            line: 4,
+            rules: vec![
+                Rule {
+                    name: "positive".into(),
+                    line: 10,
+                },
+                Rule {
+                    name: "zero".into(),
+                    line: 16,
+                },
+            ],
+        },
+        Judgment {
+            name: "only_one".into(),
+            file: "fixture.rs".into(),
+            line: 22,
+            rules: vec![Rule {
+                name: "one".into(),
+                line: 28,
+            }],
+        },
+    ];
+
+    let mut covered = BTreeSet::new();
+    covered.insert(CoveredRule {
+        judgment: "prove_thing".into(),
+        rule: "positive".into(),
+    });
+
+    let md = report::render_index(&judgments, &covered);
+    expect![[r#"
+        # Coverage report
+
+        | Judgment/Rule | Positive coverage |
+        | --- | --- |
+        | **[prove_thing](./prove_thing.md)** | - |
+        | ↳ [positive](./prove_thing.md#positive) | :check: |
+        | ↳ [zero](./prove_thing.md#zero) | :x: |
+        | **[only_one](./only_one.md)** | - |
+        | ↳ [one](./only_one.md#one) | :x: |
+    "#]]
+    .assert_eq(&md);
+}
+
+#[test]
+fn markdown_subpage_snapshot() {
+    let j = Judgment {
+        name: "prove_thing".into(),
+        file: "fixture.rs".into(),
+        line: 4,
+        rules: vec![
+            Rule {
+                name: "positive".into(),
+                line: 10,
+            },
+            Rule {
+                name: "zero".into(),
+                line: 16,
+            },
+        ],
+    };
+    let mut covered = BTreeSet::new();
+    covered.insert(CoveredRule {
+        judgment: "prove_thing".into(),
+        rule: "positive".into(),
+    });
+
+    let md = report::render_subpage(&j, &covered);
+    expect![[r#"
+        # Judgment `prove_thing` at fixture.rs:4
+
+        | Rule | Line | Positive coverage |
+        | --- | --- | --- |
+        | <a id="positive"></a>`positive` | 10 | :check: |
+        | <a id="zero"></a>`zero` | 16 | :x: |
+    "#]]
+    .assert_eq(&md);
+}
+
+#[test]
+fn empty_rules_renders_no_rules_message() {
+    let j = Judgment {
+        name: "lonely".into(),
+        file: "fixture.rs".into(),
+        line: 1,
+        rules: vec![],
+    };
+    let covered = BTreeSet::new();
+    let md = report::render_subpage(&j, &covered);
+    expect![[r#"
+        # Judgment `lonely` at fixture.rs:1
+
+        _No rules discovered._
+    "#]]
+    .assert_eq(&md);
+}
+
+#[test]
+fn jsonl_reader_tolerates_malformed_lines() {
+    let tmp = std::env::temp_dir().join(format!(
+        "formality-coverage-malformed-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let path = tmp.join("test-coverage.jsonl");
+
+    // First line is well-formed; second line has two JSON objects glued together
+    // (the failure mode we saw in practice when parallel appends interleaved);
+    // third line is well-formed again.
+    let body = concat!(
+        r#"{"test_file":"a.rs","test_line":1,"test_column":1,"rules":[{"judgment":"j1","rule":"r1","file":"f","line":1}]}"#,
+        "\n",
+        r#"{"test_file":"b.rs","test_line":2,"test_column":1,"rules":[{"judgment":"j2","rule":"r2","file":"f","line":1}]}{"#,
+        "\n",
+        r#"{"test_file":"c.rs","test_line":3,"test_column":1,"rules":[{"judgment":"j3","rule":"r3","file":"f","line":1}]}"#,
+        "\n",
+    );
+    std::fs::write(&path, body).unwrap();
+
+    let got = jsonl::read_positive(&path).expect("malformed line should not fail the reader");
+    let names: Vec<(&str, &str)> = got
+        .iter()
+        .map(|r| (r.judgment.as_str(), r.rule.as_str()))
+        .collect();
+    assert_eq!(names, vec![("j1", "r1"), ("j3", "r3")]);
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}


### PR DESCRIPTION
## What does this PR do?
Adds a new `formality-coverage` crate that generates a markdown coverage report from positive-test data recorded by #361.
Follow-up from the Zulip thread ["Coverage tracking: first PR plan"](https://rust-lang.zulipchat.com/#narrow/channel/402470-t-types.2Fformality/topic/Coverage.20tracking.3A.20first.20PR.20plan).

- regex-scrapes the source tree for `judgment_fn!` blocks and `--- ("rule")` lines to enumerate every judgment/rule
- reads `target/test-coverage.jsonl` produced by positive tests
- emits `coverage.md` (top-level table) plus one subpage per judgment under `--out-dir`
- coverage marks are mdbook emoji shortcodes (`:check:` / `:x:`), matching the mockup on Zulip, so the mdbook preprocessor will render them
- ships a `formality-coverage` binary: `--src-root`, `--jsonl`, `--out-dir`

The new crate intentionally has no in-workspace dependencies (we don't reuse `RuleId` from `formality-core` as the JSONL reader only needs `(judgment, rule)` pairs and the scraper has its own types).

## How does it work, what questions do you have?

The scraper is intentionally hacky regex, as discussed on Zulip. It finds each `judgment_fn!` invocation, grabs the next `fn <name>(`, and treats everything up to the next `judgment_fn!` (or EOF) as that judgment's body so rule lines are matched with `^\s*-{3,}\s*\("([^"]+)"\)\s*$`. A rule-shaped line outside a macro invocation would be misattributed; the file-level comment notes this trade-off. The JSONL reader tolerates malformed lines (occasional interleaved parallel appends) with a warning rather than failing the report which is fine :)

## AI disclosure

<!-- Remove the items that do not apply -->

* I used an AI to author the main logic of the code
