### PR TITLE
feat: convert check_neg_trait_impl to a judgment_fn

### DIFF
--- a/crates/formality-rust/src/check/impls.rs
+++ b/crates/formality-rust/src/check/impls.rs
@@ -8,7 +8,6 @@ use crate::grammar::{
 };
 use crate::prove::prove::{Env, Program, Safety};
 use crate::rust::Term;
-use fn_error_context::context;
 use formality_core::{judgment::ProofTree, judgment_fn, Downcasted};
 
 judgment_fn! {
@@ -43,50 +42,29 @@ judgment_fn! {
     }
 }
 
-#[context("check_neg_trait_impl({trait_impl:?})")]
-pub(super) fn check_neg_trait_impl(
-    program: &Program,
-    trait_impl: &NegTraitImpl,
-) -> Fallible<ProofTree> {
-    let NegTraitImpl { binder, safety } = trait_impl;
+judgment_fn! {
+    pub(super) fn check_neg_trait_impl(
+        program: Program,
+        trait_impl: NegTraitImpl,
+    ) => () {
+        debug(program, trait_impl)
 
-    let (
-        env,
-        NegTraitImplBoundData {
-            trait_id,
-            self_ty,
-            trait_parameters,
-            where_clauses,
-        },
-    ) = Env::default().instantiate_universally(binder);
+        (
+            (fail "negative impls cannot be unsafe")
+            ---- ("check_neg_trait_impl")
+            (check_neg_trait_impl(program, NegTraitImpl { binder, safety: Safety::Unsafe }) => ())
+        )
 
-    let trait_ref = trait_id.with(self_ty, trait_parameters);
-
-    // Negative impls are always safe (rustc E0198) regardless of the trait's safety.
-    if *safety == Safety::Unsafe {
-        bail!("negative impls cannot be unsafe");
+        (
+            (let (env, bound_data) = Env::default().instantiate_universally(binder))
+            (let NegTraitImplBoundData { trait_id, self_ty, trait_parameters, where_clauses } = bound_data)
+            (let trait_ref = trait_id.with(self_ty, trait_parameters))
+            (super::where_clauses::prove_where_clauses_well_formed(program, &env, &where_clauses, &where_clauses) => ())
+            (super::prove_goal(program, &env, &where_clauses, Predicate::not_implemented(&trait_ref)) => ())
+            ---- ("check_neg_trait_impl")
+            (check_neg_trait_impl(program, NegTraitImpl { binder, safety: Safety::Safe }) => ())
+        )
     }
-
-    let mut proof_tree =
-        ProofTree::new(format!("check_neg_trait_impl({trait_ref:?})"), None, vec![]);
-
-    proof_tree
-        .children
-        .push(super::where_clauses::prove_where_clauses_well_formed(
-            program,
-            &env,
-            &where_clauses,
-            &where_clauses,
-        )?);
-
-    proof_tree.children.push(super::prove_goal(
-        program,
-        &env,
-        &where_clauses,
-        Predicate::not_implemented(&trait_ref),
-    )?);
-
-    Ok(proof_tree)
 }
 
 judgment_fn! {

--- a/tests/decl_safety.rs
+++ b/tests/decl_safety.rs
@@ -36,11 +36,8 @@ fn unsafe_trait_negative_impl_mismatch() {
         unsafe impl !Foo for u32 {}
     }])
     .err(expect_test::expect![[r#"
-            the rule "neg trait impl" at (mod.rs) failed because
-              check_neg_trait_impl(unsafe impl ! Foo for u32 {})
-
-              Caused by:
-                  negative impls cannot be unsafe"#]])
+        the rule "check_neg_trait_impl" at (impls.rs) failed because
+          negative impls cannot be unsafe"#]])
 }
 
 #[test]
@@ -50,11 +47,8 @@ fn safe_trait_negative_impl_mismatch() {
         unsafe impl !Foo for u32 {}
     }])
     .err(expect_test::expect![[r#"
-            the rule "neg trait impl" at (mod.rs) failed because
-              check_neg_trait_impl(unsafe impl ! Foo for u32 {})
-
-              Caused by:
-                  negative impls cannot be unsafe"#]])
+        the rule "check_neg_trait_impl" at (impls.rs) failed because
+          negative impls cannot be unsafe"#]])
 }
 
 #[test]


### PR DESCRIPTION
Converts `check_neg_trait_impl` from a regular Rust function to a
`judgment_fn!`. Uses two rules  one that explicitly fails with
`(fail "negative impls cannot be unsafe")` when safety is `Unsafe`,
and one that proves well-formedness and `not_implemented` when safe.
Updated expect tests to match new error format.