### PR TITLE
Remove pointless `quote_spanned` invocations

### DIFF
--- a/crates/formality-macros/src/cast.rs
+++ b/crates/formality-macros/src/cast.rs
@@ -1,6 +1,6 @@
 use convert_case::{Case, Casing};
 use proc_macro2::{Ident, TokenStream};
-use quote::{quote, quote_spanned};
+use quote::quote;
 use syn::Type;
 use synstructure::VariantInfo;
 
@@ -35,7 +35,7 @@ fn arc_cast(s: &synstructure::Structure) -> TokenStream {
     let type_name = &s.ast().ident;
     let (impl_generics, type_generics, where_clauses) = s.ast().generics.split_for_impl();
 
-    quote_spanned! { type_name.span() =>
+    quote! {
         const _: () = {
             use formality_core::Upcast;
             use formality_core::UpcastFrom;
@@ -154,7 +154,7 @@ fn downcast_to_variant(s: &synstructure::Structure, v: &VariantInfo) -> TokenStr
             }
         });
 
-        let as_impl = quote_spanned! { v.ast().ident.span() =>
+        let as_impl = quote! {
             #[allow(dead_code)]
             impl #impl_generics #type_name #type_generics
             where #where_clauses

--- a/crates/formality-macros/src/constructors.rs
+++ b/crates/formality-macros/src/constructors.rs
@@ -1,6 +1,6 @@
 use convert_case::{Case, Casing};
 use proc_macro2::{Ident, TokenStream};
-use quote::quote_spanned;
+use quote::{quote, quote_spanned};
 use synstructure::VariantInfo;
 
 const RUST_KEYWORDS: &[&str] = &[
@@ -66,7 +66,7 @@ fn derive_new_for_variant(
         )
     });
 
-    quote_spanned! { v.ast().ident.span() =>
+    quote! {
         #[allow(dead_code)]
         impl #impl_generics #type_name #type_generics
         where #where_clauses

--- a/crates/formality-macros/src/debug.rs
+++ b/crates/formality-macros/src/debug.rs
@@ -48,29 +48,33 @@ pub(crate) fn derive_debug_with_spec(
 
 fn default_debug_variant(s: &synstructure::Structure) -> TokenStream {
     let arms = s.each_variant(|v| {
-        let fields: TokenStream = v.bindings().iter().map(|bi| {
-            if let Some(name) = &bi.ast().ident {
-                let name = as_literal(name);
-                quote_spanned!(name.span() => .field(#name, #bi))
-            } else {
-                quote_spanned!(bi.span() => .field(#bi))
-            }
-        }).collect();
+        let fields: TokenStream = v
+            .bindings()
+            .iter()
+            .map(|bi| {
+                if let Some(name) = &bi.ast().ident {
+                    let name = as_literal(name);
+                    quote_spanned!(name.span() => .field(#name, #bi))
+                } else {
+                    quote_spanned!(bi.span() => .field(#bi))
+                }
+            })
+            .collect();
         let variant_name = as_literal(v.ast().ident);
         match v.ast().fields {
             syn::Fields::Named(_) => {
-                quote_spanned!(variant_name.span() => fmt.debug_struct(#variant_name) #fields .finish())
+                quote!(fmt.debug_struct(#variant_name) #fields .finish())
             }
             syn::Fields::Unnamed(_) => {
-                quote_spanned!(variant_name.span() => fmt.debug_tuple(#variant_name) #fields .finish())
+                quote!(fmt.debug_tuple(#variant_name) #fields .finish())
             }
             syn::Fields::Unit => {
-                quote_spanned!(variant_name.span() => fmt.debug_tuple(#variant_name) .finish())
+                quote!(fmt.debug_tuple(#variant_name) .finish())
             }
         }
     });
 
-    quote_spanned! { s.ast().span() =>
+    quote! {
         match self {
             #arms
         }

--- a/crates/formality-macros/src/parse.rs
+++ b/crates/formality-macros/src/parse.rs
@@ -86,8 +86,7 @@ pub(crate) fn derive_parse_with_spec(
         let precedence = precedence(variant.ast().attrs)?.expr();
         let is_variable = has_variable_attr(variant.ast().attrs);
         has_variable_variant |= is_variable;
-        let variant_code = quote_spanned!(
-            variant.ast().ident.span() =>
+        let variant_code = quote!(
             __parser.parse_variant(#variant_name, #precedence, |__p| { #v });
         );
         parse_variants.extend(variant_code);
@@ -172,8 +171,7 @@ fn parse_variant(
         // No bindings (e.g., `Foo`) -- just parse a keyword `foo`
         let literal = Literal::string(&to_parse_ident(ast.ident));
         let construct = variant.construct(|_, _| quote! {});
-        stream.extend(quote_spanned! {
-            ast.ident.span() =>
+        stream.extend(quote! {
             __p.expect_keyword(#literal)?;
             __p.ok(#construct)
         });
@@ -189,8 +187,7 @@ fn parse_variant(
         let v0_binding = &variant.bindings()[0];
         let v0 = field_ident(v0_binding.ast(), 0);
         let construct = variant.construct(field_ident);
-        stream.extend(quote_spanned! {
-            ast.ident.span() =>
+        stream.extend(quote! {
             let #v0 = __p.variable_of_kind(#kind)?;
             __p.ok(#construct)
         });
@@ -198,13 +195,11 @@ fn parse_variant(
         // Has the `#[cast]` attribute -- just parse the bindings (comma separated, if needed)
         let construct = variant.construct(field_ident_cloned);
         let ok_expr = wrap_with_reject(quote!(#construct), variant, rejects)?;
-        let tail = quote_spanned! {
-            ast.ident.span() =>
+        let tail = quote! {
             #ok_expr
         };
         let body = wrap_bindings(variant.bindings(), tail, 0);
-        stream.extend(quote_spanned! {
-            ast.ident.span() =>
+        stream.extend(quote! {
             #body
         });
     } else {
@@ -212,15 +207,13 @@ fn parse_variant(
         let literal = Literal::string(&to_parse_ident(ast.ident));
         let construct = variant.construct(field_ident_cloned);
         let ok_expr = wrap_with_reject(quote!(#construct), variant, rejects)?;
-        let tail = quote_spanned! {
-            ast.ident.span() =>
+        let tail = quote! {
             __p.skip_trailing_comma();
             __p.expect_char(')')?;
             #ok_expr
         };
         let body = wrap_bindings(variant.bindings(), tail, 0);
-        stream.extend(quote_spanned! {
-            ast.ident.span() =>
+        stream.extend(quote! {
             __p.expect_keyword(#literal)?;
             __p.expect_char('(')?;
             #body


### PR DESCRIPTION

## What does this PR do?

Improves UX for IDEs (notably rust-analyzer)

## How does it work, what questions do you have?

All of these re-spans just point diagnostics to the item's identifier instead of the callsite, this doesn't really improve the diagnostics while actively hurting rust-analyzer UX.

## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools