### PR TITLE
Lower `forall` and `outlives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +369,7 @@ dependencies = [
  "fn-error-context",
  "formality-core",
  "formality-macros",
+ "itertools",
  "lazy_static",
  "libspecr",
  "minirust-rs",
@@ -477,6 +484,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"

--- a/crates/formality-rust/Cargo.toml
+++ b/crates/formality-rust/Cargo.toml
@@ -17,6 +17,4 @@ fn-error-context = "0.2.0"
 minirust-rs = { path = "../minirust-rs" }
 libspecr = "=0.1.40"
 tempfile = "3.27.0"
-
-[dev-dependencies]
 expect-test = "1.4.0"

--- a/crates/formality-rust/Cargo.toml
+++ b/crates/formality-rust/Cargo.toml
@@ -10,6 +10,7 @@ formality-macros = { path = "../formality-macros" }
 formality-core = { path = "../formality-core" }
 anyhow = "1.0.66"
 lazy_static = "1.4.0"
+itertools = "0.14.0"
 regex = "1.12.3"
 tracing = "0.1"
 fn-error-context = "0.2.0"

--- a/crates/formality-rust/src/to_rust/context.rs
+++ b/crates/formality-rust/src/to_rust/context.rs
@@ -69,7 +69,7 @@ impl Context {
 
     /// Opens the binder `b` and instatiates ith with a fresh set of
     /// existential variables and returns the term.
-    pub fn open_exists<T: Term>(&mut self, b: Binder<T>) -> T {
+    pub fn open_exists<T: Term>(&mut self, b: Binder<T>) -> Wrapped<'_, T> {
         let subst = self.existential_substitution(&b);
         let term = b.instantiate_with(&subst).expect("suitable substitution");
         // TODO: How can I prevent the collect()?
@@ -82,8 +82,10 @@ impl Context {
                 )
             })
             .collect();
+        self.bounded
+            .insert(0, names.iter().cloned().map(|(_, name)| name).collect());
         self.free.extend(names.into_iter());
-        term
+        Wrapped::new(self, term.clone())
     }
 
     /// Allocates a new set of fresh names and returns a wrapped `T`.

--- a/crates/formality-rust/src/to_rust/context.rs
+++ b/crates/formality-rust/src/to_rust/context.rs
@@ -70,6 +70,7 @@ impl Context {
     /// Opens the binder `b` and instatiates ith with a fresh set of
     /// existential variables and returns the term.
     pub fn open_exists<T: Term>(&mut self, b: Binder<T>) -> Wrapped<'_, T> {
+        // TODO: Replace Existential Lifetimes with an Erased after codegen (#369) is merged
         let subst = self.existential_substitution(&b);
         let term = b.instantiate_with(&subst).expect("suitable substitution");
         // TODO: How can I prevent the collect()?

--- a/crates/formality-rust/src/to_rust/context.rs
+++ b/crates/formality-rust/src/to_rust/context.rs
@@ -13,6 +13,7 @@ pub struct Context {
     counter: VarIndex,
     bounded: Vec<Vec<String>>,
     free: HashMap<VarIndex, String>,
+    nesting_level: usize,
 }
 
 impl Context {
@@ -27,6 +28,7 @@ impl Default for Context {
             counter: VarIndex { index: 0 },
             bounded: Vec::new(),
             free: HashMap::new(),
+            nesting_level: 0,
         }
     }
 }
@@ -42,17 +44,23 @@ impl Context {
     /// For each binder parameter, a fresh name is generated and pushed onto the
     /// context. The returned [`Wrapped`] value provides access to the term while
     /// these names are in scope. When the `Wrapped` value is dropped, the names
-    /// are removed from the contex
+    /// are removed from the contex.
     pub fn open_bounded<T: Term>(&mut self, b: Binder<T>) -> Wrapped<'_, T> {
         let term = b.peek();
         let names = b
             .kinds()
             .into_iter()
             .enumerate()
-            .map(|(index, kind)| format!("{}{}", self.kind_to_string(kind), index))
+            .map(|(index, kind)| {
+                format!(
+                    "{}{}{}",
+                    self.kind_to_string(kind),
+                    self.nesting_level,
+                    index
+                )
+            })
             .collect::<Vec<_>>();
-        self.bounded.insert(0, names);
-        Wrapped::new(self, term.clone())
+        Wrapped::bound(self, term.clone(), names)
     }
 
     /// Introduces a fresh set of bound variable names for the binder `b` and
@@ -60,7 +68,7 @@ impl Context {
     ///
     /// Fresh names are generated as in [`open_bounded`], but the first bound
     /// variable is always renamed to `Self` to reflect Rust’s implicit `Self`
-    /// parameter in trait declarations
+    /// parameter in trait declarations.
     pub fn open_trait<T: Term>(&mut self, b: TraitBinder<T>) -> Wrapped<'_, T> {
         let wrapped = self.open_bounded(b.explicit_binder);
         wrapped.ctx.bounded[0][0] = "Self".to_string();
@@ -73,7 +81,6 @@ impl Context {
         // TODO: Replace Existential Lifetimes with an Erased after codegen (#369) is merged
         let subst = self.existential_substitution(&b);
         let term = b.instantiate_with(&subst).expect("suitable substitution");
-        // TODO: How can I prevent the collect()?
         let names: Vec<_> = subst
             .into_iter()
             .map(|var| {
@@ -83,10 +90,7 @@ impl Context {
                 )
             })
             .collect();
-        self.bounded
-            .insert(0, names.iter().cloned().map(|(_, name)| name).collect());
-        self.free.extend(names.into_iter());
-        Wrapped::new(self, term.clone())
+        Wrapped::free(self, term.clone(), names)
     }
 
     /// Allocates a new set of fresh names and returns a wrapped `T`.
@@ -216,13 +220,27 @@ pub struct Wrapped<'ctx, T> {
 }
 
 impl<'ctx, T> Wrapped<'ctx, T> {
-    pub fn new(ctx: &'ctx mut Context, term: T) -> Wrapped<'ctx, T> {
+    /// Adds `names` as bounded variables in `ctx` and returns [Wrapped].
+    pub fn bound(ctx: &'ctx mut Context, term: T, names: Vec<String>) -> Wrapped<'ctx, T> {
+        ctx.nesting_level += 1;
+        ctx.bounded.insert(0, names);
         Wrapped { ctx, term }
+    }
+
+    /// Adds `names` as free variables in `ctx` and returns [Wrapped].
+    pub fn free(
+        ctx: &'ctx mut Context,
+        term: T,
+        names: Vec<(VarIndex, String)>,
+    ) -> Wrapped<'ctx, T> {
+        ctx.free.extend(names.clone().into_iter());
+        Wrapped::bound(ctx, term, names.into_iter().map(|(_, name)| name).collect())
     }
 }
 
 impl<'ctx, T> Drop for Wrapped<'ctx, T> {
     fn drop(&mut self) {
+        self.ctx.nesting_level -= 1;
         self.ctx.bounded.remove(0);
     }
 }
@@ -270,6 +288,7 @@ mod tests {
                 counter: VarIndex { index: 0 },
                 bounded,
                 free: HashMap::new(),
+                nesting_level: 0,
             }
         }
     }
@@ -317,5 +336,24 @@ mod tests {
         let b = Context::with(vec![vec!["N0".into()]]);
         let const1 = create_const(0);
         assert_eq!("N0", b.core_variable_to_string(&const1).unwrap());
+    }
+
+    #[test]
+    fn nesting_causes_no_shadowing() {
+        crate::assert_rust!(
+            [
+                crate Blub {
+                    trait Foo<T> {
+                        fn blub<K, V>(k: K, v:V) -> T;
+                        fn bar<K, V>(k: K, v:V) -> T;
+                    }
+                }
+            ],
+            expect_test::expect![[r#"
+                pub trait Foo<T01> {
+                    fn blub<T10, T11>(mut k: T10, mut v: T11) -> T01;
+                    fn bar<T10, T11>(mut k: T10, mut v: T11) -> T01;
+                }"#]]
+        );
     }
 }

--- a/crates/formality-rust/src/to_rust/context.rs
+++ b/crates/formality-rust/src/to_rust/context.rs
@@ -1,13 +1,18 @@
+use std::collections::HashMap;
+
 use crate::{
     grammar::{
-        Binder, BoundVar, ExistentialVar, Fallible, ParameterKind, UniversalVar, VarIndex, Variable,
+        Binder, DebruijnIndex, ExistentialVar, Fallible, ParameterKind, TraitBinder, UniversalVar,
+        VarIndex, Variable,
     },
-    rust::Fold,
+    rust::{Fold, Term},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Context {
     counter: VarIndex,
+    bounded: Vec<Vec<String>>,
+    free: HashMap<VarIndex, String>,
 }
 
 impl Context {
@@ -20,61 +25,96 @@ impl Default for Context {
     fn default() -> Self {
         Self {
             counter: VarIndex { index: 0 },
+            bounded: Vec::new(),
+            free: HashMap::new(),
         }
     }
 }
 
 impl Context {
-    /// Opens the binder `b` and instatiates ith with a fresh set of
-    /// bounded variables and returns the term and the names
-    pub fn open_bounded<T: Fold>(&mut self, b: &Binder<T>) -> (T, Vec<String>) {
-        let subst = self.bounded_substitution(b);
-        let term = b.instantiate_with(&subst).expect("suitable substitution");
-        let names = subst
+    pub fn first(&self) -> Option<&Vec<String>> {
+        self.bounded.first()
+    }
+
+    pub fn open_bounded<T: Term>(&mut self, b: Binder<T>) -> Wrapped<'_, T> {
+        let term = b.peek();
+        let names = b
+            .kinds()
             .into_iter()
-            .map(|var| format!("{}{}", self.kind_to_string(&var.kind), var.var_index.index))
+            .enumerate()
+            .map(|(index, kind)| format!("{}{}", self.kind_to_string(kind), index))
             .collect::<Vec<_>>();
-        (term, names)
+        self.bounded.insert(0, names);
+        Wrapped::new(self, term.clone())
+    }
+
+    pub fn open_trait<T: Term>(&mut self, b: TraitBinder<T>) -> Wrapped<'_, T> {
+        let wrapped = self.open_bounded(b.explicit_binder);
+        wrapped.ctx.bounded[0][0] = "Self".to_string();
+        wrapped
     }
 
     /// Opens the binder `b` and instatiates ith with a fresh set of
-    /// existential variables and returns the term and the names
-    pub fn open_exists<T: Fold>(&mut self, b: &Binder<T>) -> (T, Vec<String>) {
-        let subst = self.existential_substitution(b);
+    /// existential variables and returns the term
+    pub fn open_exists<T: Term>(&mut self, b: Binder<T>) -> T {
+        let subst = self.existential_substitution(&b);
         let term = b.instantiate_with(&subst).expect("suitable substitution");
-        let names = subst
+        // TODO: How can I prevent the collect()?
+        let names: Vec<_> = subst
             .into_iter()
-            .map(|var| format!("{}{}", self.kind_to_string(&var.kind), var.var_index.index))
-            .collect::<Vec<_>>();
-        (term, names)
+            .map(|var| {
+                (
+                    var.var_index,
+                    format!("{}E{}", self.kind_to_string(&var.kind), var.var_index.index),
+                )
+            })
+            .collect();
+        self.free.extend(names.into_iter());
+        term
     }
 
     /// Opens the binder `b` and instatiates ith with a fresh set of
-    /// universal variables and returns the term and the names
-    pub fn open_universal<T: Fold>(&mut self, b: &Binder<T>) -> (T, Vec<String>) {
-        let subst = self.universal_substitution(b);
-        let term = b.instantiate_with(&subst).expect("suitable substitution");
-        let names = subst
-            .into_iter()
-            .map(|var| format!("{}{}", self.kind_to_string(&var.kind), var.var_index.index))
-            .collect::<Vec<_>>();
-        (term, names)
+    /// universal variables and returns the term
+    pub fn open_universal<T: Term>(&mut self, b: Binder<T>) -> Wrapped<'_, T> {
+        self.open_bounded(b)
     }
 
     pub fn core_variable_to_string(&self, variable: &Variable) -> Fallible<String> {
-        let index = match variable {
-            Variable::UniversalVar(universal_var) => universal_var.var_index,
-            Variable::ExistentialVar(existential_var) => existential_var.var_index,
+        let kind = self.kind_to_string(&variable.kind());
+        match variable {
             Variable::BoundVar(bound_var) => {
-                if bound_var.debruijn.is_some() {
-                    anyhow::bail!("binder is not open")
+                if let Some(index) = bound_var.debruijn {
+                    self.lookup_bounded_var(&index, &bound_var.var_index)
+                } else {
+                    anyhow::bail!("binder was opened")
                 }
-                bound_var.var_index
+            }
+            Variable::UniversalVar(universal_var) => {
+                Ok(format!("{kind}{}", universal_var.var_index.index))
+            }
+            Variable::ExistentialVar(existential_var) => {
+                Ok(format!("{kind}{}", existential_var.var_index.index))
             }
         }
-        .index;
-        let kind = self.kind_to_string(&variable.kind());
-        Ok(format!("{kind}{index}"))
+    }
+
+    fn lookup_bounded_var(
+        &self,
+        debruijn: &DebruijnIndex,
+        var_index: &VarIndex,
+    ) -> Fallible<String> {
+        Ok(self
+            .bounded
+            .get(debruijn.index)
+            .and_then(|v| v.get(var_index.index))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "variable with {}.{} is not bound",
+                    debruijn.index,
+                    var_index.index
+                )
+            })?
+            .clone())
     }
 
     fn kind_to_string(&self, kind: &ParameterKind) -> &'static str {
@@ -83,23 +123,6 @@ impl Context {
             ParameterKind::Lt => "'a",
             ParameterKind::Const => "N",
         }
-    }
-
-    /// Creates a substitution that replaces the variables introduced by the
-    /// binder `b` with fresh bound variables.
-    ///
-    /// Each binder parameter is mapped to a new [`BoundVar`] with a fresh
-    /// variable index. The resulting substitution can be used to instantiate
-    /// the binder without capturing existing variables.
-    pub fn bounded_substitution<T>(&mut self, b: &Binder<T>) -> Vec<BoundVar>
-    where
-        T: Fold,
-    {
-        self.substitution(b, |kind, var_index| BoundVar {
-            debruijn: None,
-            kind,
-            var_index,
-        })
     }
 
     /// Creates a substitution that replaces the variables introduced by the
@@ -166,29 +189,113 @@ impl Context {
     }
 }
 
+#[derive(Debug)]
+pub struct Wrapped<'ctx, T> {
+    pub ctx: &'ctx mut Context,
+    pub term: T,
+}
+
+impl<'ctx, T> Wrapped<'ctx, T> {
+    pub fn new(ctx: &'ctx mut Context, term: T) -> Wrapped<'ctx, T> {
+        Wrapped { ctx, term }
+    }
+}
+
+impl<'ctx, T> Drop for Wrapped<'ctx, T> {
+    fn drop(&mut self) {
+        self.ctx.bounded.remove(0);
+    }
+}
+
 #[macro_export]
 macro_rules! open_bounded {
     ($ctx:expr, $binder:expr) => {{
-        let (term, names) = $ctx.open_bounded($binder);
+        let mut wrapper = $ctx.open_bounded($binder);
+        let ctx = &mut wrapper.ctx;
+        let term = &wrapper.term;
         let generics = $crate::to_rust::lower_generics_for_binder(
-            $ctx,
+            ctx,
             $binder.kinds(),
             &term.where_clauses,
-            &names,
             false,
         )?;
-        (term, generics)
+        (wrapper, generics)
     }};
-    ($ctx:expr, $binder:expr, $is_trait:literal) => {{
-        let (term, names) = $ctx.open_bounded($binder);
+}
+#[macro_export]
+macro_rules! open_trait {
+    ($ctx:expr, $binder:expr) => {{
+        let mut wrapper = $ctx.open_trait($binder);
+        let ctx = &mut wrapper.ctx;
+        let term = &wrapper.term;
         let generics = $crate::to_rust::lower_generics_for_binder(
-            $ctx,
-            $binder.kinds(),
+            ctx,
+            $binder.explicit_binder.kinds(),
             &term.where_clauses,
-            &names,
-            $is_trait,
+            true,
         )?;
-        (term, generics)
+        (wrapper, generics)
     }};
 }
 pub(crate) use open_bounded;
+pub(crate) use open_trait;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grammar::{BoundVar, DebruijnIndex, VarIndex, Variable};
+    impl Context {
+        pub fn with(bounded: Vec<Vec<String>>) -> Context {
+            Context {
+                counter: VarIndex { index: 0 },
+                bounded,
+                free: HashMap::new(),
+            }
+        }
+    }
+
+    fn create_ty(index: usize) -> Variable {
+        Variable::BoundVar(BoundVar {
+            debruijn: Some(DebruijnIndex { index: 0 }),
+            var_index: VarIndex { index },
+            kind: crate::grammar::ParameterKind::Ty,
+        })
+    }
+
+    fn create_lt(index: usize) -> Variable {
+        Variable::BoundVar(BoundVar {
+            debruijn: Some(DebruijnIndex { index: 0 }),
+            var_index: VarIndex { index },
+            kind: crate::grammar::ParameterKind::Lt,
+        })
+    }
+
+    fn create_const(index: usize) -> Variable {
+        Variable::BoundVar(BoundVar {
+            debruijn: Some(DebruijnIndex { index: 0 }),
+            var_index: VarIndex { index },
+            kind: crate::grammar::ParameterKind::Const,
+        })
+    }
+
+    #[test]
+    fn pretty_print_type_variables() {
+        let b = Context::with(vec![vec!["T0".into()]]);
+        let ty1 = create_ty(0);
+        assert_eq!("T0", b.core_variable_to_string(&ty1).unwrap());
+    }
+
+    #[test]
+    fn pretty_print_life_time_variables() {
+        let b = Context::with(vec![vec!["'a0".into()]]);
+        let lt1 = create_lt(0);
+        assert_eq!("'a0", b.core_variable_to_string(&lt1).unwrap());
+    }
+
+    #[test]
+    fn pretty_print_const_variables() {
+        let b = Context::with(vec![vec!["N0".into()]]);
+        let const1 = create_const(0);
+        assert_eq!("N0", b.core_variable_to_string(&const1).unwrap());
+    }
+}

--- a/crates/formality-rust/src/to_rust/context.rs
+++ b/crates/formality-rust/src/to_rust/context.rs
@@ -36,6 +36,13 @@ impl Context {
         self.bounded.first()
     }
 
+    /// Introduces a fresh set of bound variable names for the binder `b` and
+    /// returns the contained term wrapped in a [`Wrapped`] guard.
+    ///
+    /// For each binder parameter, a fresh name is generated and pushed onto the
+    /// context. The returned [`Wrapped`] value provides access to the term while
+    /// these names are in scope. When the `Wrapped` value is dropped, the names
+    /// are removed from the contex
     pub fn open_bounded<T: Term>(&mut self, b: Binder<T>) -> Wrapped<'_, T> {
         let term = b.peek();
         let names = b
@@ -48,6 +55,12 @@ impl Context {
         Wrapped::new(self, term.clone())
     }
 
+    /// Introduces a fresh set of bound variable names for the binder `b` and
+    /// returns the contained term wrapped in a [`Wrapped`] guard.
+    ///
+    /// Fresh names are generated as in [`open_bounded`], but the first bound
+    /// variable is always renamed to `Self` to reflect Rust’s implicit `Self`
+    /// parameter in trait declarations
     pub fn open_trait<T: Term>(&mut self, b: TraitBinder<T>) -> Wrapped<'_, T> {
         let wrapped = self.open_bounded(b.explicit_binder);
         wrapped.ctx.bounded[0][0] = "Self".to_string();
@@ -55,7 +68,7 @@ impl Context {
     }
 
     /// Opens the binder `b` and instatiates ith with a fresh set of
-    /// existential variables and returns the term
+    /// existential variables and returns the term.
     pub fn open_exists<T: Term>(&mut self, b: Binder<T>) -> T {
         let subst = self.existential_substitution(&b);
         let term = b.instantiate_with(&subst).expect("suitable substitution");
@@ -73,8 +86,7 @@ impl Context {
         term
     }
 
-    /// Opens the binder `b` and instatiates ith with a fresh set of
-    /// universal variables and returns the term
+    /// Allocates a new set of fresh names and returns a wrapped `T`.
     pub fn open_universal<T: Term>(&mut self, b: Binder<T>) -> Wrapped<'_, T> {
         self.open_bounded(b)
     }
@@ -189,6 +201,11 @@ impl Context {
     }
 }
 
+/// A RAII guard that provides access to a term `T` while a set of bound
+/// variable names is active in the associated [`Context`].
+///
+/// When this guard is dropped, the bound variable names introduced for the
+/// scope are removed from the context.
 #[derive(Debug)]
 pub struct Wrapped<'ctx, T> {
     pub ctx: &'ctx mut Context,

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -72,7 +72,7 @@ pub fn lower_let(
 
 pub fn lower_exists_stmt(ctx: &mut Context, binder: &Binder<Block>) -> Fallible<syntax::Stmt> {
     // TODO: Check again, after codegen is merged, if "erased" lifetimes could work here.
-    let (term, _) = ctx.open_exists(binder);
+    let term = ctx.open_exists(binder.clone());
     let result = syntax::Stmt::Block(lower_block(ctx, &term)?);
     Ok(result)
 }

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -1,8 +1,11 @@
 use std::ops::Deref;
 
-use crate::grammar::{
-    expr::{Block, Expr, FieldExpr, Init, Label, PlaceExpr, Stmt},
-    Binder, Fallible, FieldName, RefKind, Ty, ValueId,
+use crate::{
+    grammar::{
+        expr::{Block, Expr, FieldExpr, Init, Label, PlaceExpr, Stmt},
+        Binder, Fallible, FieldName, RefKind, Ty, ValueId,
+    },
+    to_rust::context::Wrapped,
 };
 
 use crate::to_rust::{context::Context, syntax, tys};
@@ -72,7 +75,10 @@ pub fn lower_let(
 
 pub fn lower_exists_stmt(ctx: &mut Context, binder: &Binder<Block>) -> Fallible<syntax::Stmt> {
     // TODO: Check again, after codegen is merged, if "erased" lifetimes could work here.
-    let term = ctx.open_exists(binder.clone());
+    let Wrapped {
+        ref mut ctx,
+        ref term,
+    } = ctx.open_exists(binder.clone());
     let result = syntax::Stmt::Block(lower_block(ctx, &term)?);
     Ok(result)
 }

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use crate::{
     grammar::{
         expr::{Block, Expr, FieldExpr, Init, Label, PlaceExpr, Stmt},
-        Binder, Fallible, FieldName, RefKind, Ty, ValueId,
+        Binder, Fallible, FieldName, Lt, Parameter, RefKind, Ty, ValueId, Variable,
     },
     to_rust::context::Wrapped,
 };
@@ -111,6 +111,12 @@ pub fn lower_expr(ctx: &mut Context, expr: &Expr) -> Fallible<syntax::Expr> {
             name: id.deref().clone(),
             args: args
                 .iter()
+                .filter(|arg| match arg {
+                    Parameter::Ty(_) | Parameter::Const(_) => true,
+                    Parameter::Lt(lt) => {
+                        matches!(**lt, Lt::Static | Lt::Variable(Variable::BoundVar(_)))
+                    }
+                })
                 .map(|arg| tys::lower_generic_arg(ctx, arg))
                 .collect::<Result<Vec<_>, _>>()?,
         }),

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -260,7 +260,7 @@ pub fn foo() -> () {
                 pub fn foo() -> u32 {
                     {
                         let mut v1: u32 = 0_u32;
-                        let mut v2: &mut u32 = &mut v1;
+                        let mut v2: &'_ mut u32 = &mut v1;
                         return *v2;
                     }
                 }"#]]

--- a/crates/formality-rust/src/to_rust/expr.rs
+++ b/crates/formality-rust/src/to_rust/expr.rs
@@ -199,11 +199,12 @@ mod test {
                     }
                 }
             ],
-            r#"
+            expect_test::expect![[r#"
 pub fn foo() -> u32 {
     let mut x: u32;
     return x;
 }"#
+                                  ]]
         );
     }
 
@@ -219,12 +220,13 @@ pub fn foo() -> u32 {
                     }
                 }
             ],
-            r#"
+            expect_test::expect![[r#"
 pub fn foo() -> () {
     'a: {
         break 'a;
     }
 }"#
+                                   ]]
         );
     }
 
@@ -242,15 +244,14 @@ pub fn foo() -> () {
                     }
                 }
             ],
-            r#"
-pub fn foo() -> u32 {
-    {
-        let mut v1: u32 = 0_u32;
-        let mut v2: &mut u32 = &mut v1;
-        return *v2;
-    }
-}
-"#
+            expect_test::expect![[r#"
+                pub fn foo() -> u32 {
+                    {
+                        let mut v1: u32 = 0_u32;
+                        let mut v2: &mut u32 = &mut v1;
+                        return *v2;
+                    }
+                }"#]]
         );
     }
 }

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -71,11 +71,10 @@ mod test {
                     fn run() -> i32 {trusted}
                 }
             ],
-            r#"
-pub fn run() -> i32 {
-    panic!("Trusted Fn Body")
-}
-"#
+            expect_test::expect![[r#"
+                pub fn run() -> i32 {
+                    panic!("Trusted Fn Body")
+                }"#]]
         );
     }
 
@@ -87,11 +86,10 @@ pub fn run() -> i32 {
                     fn run(p1: i32, p2: i32) -> i32 {trusted}
                 }
             ],
-            r#"
-pub fn run(mut p1: i32, mut p2: i32) -> i32 {
-    panic!("Trusted Fn Body")
-}
-"#
+            expect_test::expect![[r#"
+                pub fn run(mut p1: i32, mut p2: i32) -> i32 {
+                    panic!("Trusted Fn Body")
+                }"#]]
         );
     }
 
@@ -103,11 +101,10 @@ pub fn run(mut p1: i32, mut p2: i32) -> i32 {
                     fn run<T>(p1: T) -> T {trusted}
                 }
             ],
-            r#"
-pub fn run<T0>(mut p1: T0) -> T0 {
-    panic!("Trusted Fn Body")
-}
-"#
+            expect_test::expect![[r#"
+                pub fn run<T0>(mut p1: T0) -> T0 {
+                    panic!("Trusted Fn Body")
+                }"#]]
         );
     }
 
@@ -120,13 +117,12 @@ pub fn run<T0>(mut p1: T0) -> T0 {
                     fn run<T>(p1: T) -> T where T: Bar {trusted}
                 }
             ],
-            r#"
-pub trait Bar { }
+            expect_test::expect![[r#"
+                pub trait Bar { }
 
-pub fn run<T1>(mut p1: T1) -> T1 where T1: Bar {
-    panic!("Trusted Fn Body")
-}
-"#
+                pub fn run<T0>(mut p1: T0) -> T0 where T0: Bar {
+                    panic!("Trusted Fn Body")
+                }"#]]
         );
     }
 
@@ -139,11 +135,10 @@ pub fn run<T1>(mut p1: T1) -> T1 where T1: Bar {
 
                 }
             ],
-            r#"
-pub fn run<const N0: i32>() -> i32 {
-    panic!("Trusted Fn Body")
-}
-"#
+            expect_test::expect![[r#"
+                pub fn run<const N0: i32>() -> i32 {
+                    panic!("Trusted Fn Body")
+                }"#]]
         );
     }
 }

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -4,7 +4,7 @@ use crate::grammar::{Fallible, Fn, FnBody, InputArg, MaybeFnBody};
 use crate::prove::prove::Safety;
 
 use crate::to_rust::{
-    context::{open_bounded, Context},
+    context::{open_bounded, Context, Wrapped},
     syntax, tys,
 };
 
@@ -13,7 +13,13 @@ pub fn lower_fn(
     function: &Fn,
     visibility: syntax::Visibility,
 ) -> Fallible<syntax::FunctionItem> {
-    let (term, generics) = open_bounded!(ctx, &function.binder);
+    let (
+        Wrapped {
+            ref mut ctx,
+            ref term,
+        },
+        generics,
+    ) = open_bounded!(ctx, function.binder.clone());
     let params = term
         .input_args
         .iter()

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -102,7 +102,7 @@ mod test {
                 }
             ],
             expect_test::expect![[r#"
-                pub fn run<T0>(mut p1: T0) -> T0 {
+                pub fn run<T00>(mut p1: T00) -> T00 {
                     panic!("Trusted Fn Body")
                 }"#]]
         );
@@ -120,7 +120,7 @@ mod test {
             expect_test::expect![[r#"
                 pub trait Bar { }
 
-                pub fn run<T0>(mut p1: T0) -> T0 where T0: Bar {
+                pub fn run<T00>(mut p1: T00) -> T00 where T00: Bar {
                     panic!("Trusted Fn Body")
                 }"#]]
         );
@@ -136,7 +136,7 @@ mod test {
                 }
             ],
             expect_test::expect![[r#"
-                pub fn run<const N0: i32>() -> i32 {
+                pub fn run<const N00: i32>() -> i32 {
                     panic!("Trusted Fn Body")
                 }"#]]
         );

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -1,4 +1,6 @@
-use crate::grammar::{Crates, Fallible, ParameterKind, Ty, WhereClause, WhereClauseData};
+use crate::grammar::{
+    Crates, Fallible, Parameter, ParameterKind, Ty, WhereClause, WhereClauseData,
+};
 use std::cell::LazyCell;
 use std::ops::Deref;
 
@@ -156,10 +158,10 @@ pub fn lower_generics_for_binder(
                 }
             }
             WhereClauseData::AliasEq(_, _) => {
-                todo!("lowering `AliasEq` where-clauses is not implemented yet")
+                continue;
             }
             WhereClauseData::Outlives(_, _) => {
-                todo!("lowering `Outlives` where-clauses is not implemented yet")
+                continue;
             }
             WhereClauseData::ForAll(_) => {
                 todo!("lowering `ForAll` where-clauses is not implemented yet")
@@ -197,8 +199,17 @@ pub fn lower_where_clauses(
             WhereClauseData::AliasEq(_, _) => {
                 anyhow::bail!("lowering `AliasEq` where-clauses is not implemented yet")
             }
-            WhereClauseData::Outlives(_, _) => {
-                anyhow::bail!("lowering `Outlives` where-clauses is not implemented yet")
+            WhereClauseData::Outlives(parameter, lifetime) => {
+                let lifetime = tys::lower_lt(ctx, lifetime)?;
+                let parameter = match parameter {
+                    Parameter::Ty(ty) => syntax::Parameter::Type(tys::lower_ty(ctx, ty)?),
+                    Parameter::Lt(lt) => syntax::Parameter::Lifetime(tys::lower_lt(ctx, lt)?),
+                    Parameter::Const(_) => anyhow::bail!("constant in an outlives constraint"),
+                };
+                preds.push(syntax::WhereClause::Lifetime {
+                    parameter,
+                    lifetime,
+                });
             }
             WhereClauseData::ForAll(_) => {
                 anyhow::bail!("lowering `ForAll` where-clauses is not implemented yet")
@@ -264,5 +275,50 @@ mod test {
             ],
             "#![feature(polonius_alpha)]"
         );
+    }
+
+    #[test]
+    fn outlives_type() {
+        crate::assert_rust!(
+            [
+                crate core {
+                    trait Trait {}
+                    struct A<X> where X: Trait {}
+                    fn valid<'a, X>(x: &'a A<X>) -> ()
+                    where
+                        X: 'a,
+                        X: Trait,
+                    {}
+                }
+            ],
+            r#"
+pub trait Trait { }
+
+pub struct A<T1> where T1: Trait {}
+
+pub fn valid<'a2, T3>(mut x: &'a2 A<T3>) -> () where T3: 'a2, T3: Trait {}
+"#
+        )
+    }
+
+    #[test]
+    fn outlives_lifetime() {
+        crate::assert_rust!(
+            [
+                crate core {
+                    fn foo<'a, 'b>(a: &'a u32) -> &'b u32
+                    where 'a: 'b {
+                        let r: &'b u32 = identity::<&'b u32>(a);
+                        return r;
+                    }
+                }
+            ],
+            r#"
+pub fn foo<'a0, 'a1>(mut a: &'a0 u32) -> &'a1 u32 where 'a0: 'a1 {
+    let mut r: &'a1 u32 = identity::<&'a1 u32>(a);
+    return r;
+}
+"#
+        )
     }
 }

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -1,7 +1,6 @@
-use crate::grammar::{
-    Crates, Fallible, Parameter, ParameterKind, Ty, WhereClause, WhereClauseData,
-};
+use crate::grammar::{Crates, Fallible, Parameter, ParameterKind, WhereClause, WhereClauseData};
 use std::cell::LazyCell;
+use std::collections::HashMap;
 use std::ops::Deref;
 
 pub mod context;
@@ -115,25 +114,16 @@ pub fn lower_generics_for_binder(
     }
 
     let start = usize::from(skip_first);
-    let mut params: Vec<syntax::GenericParam> = names
+    let mut params: HashMap<String, syntax::GenericParam> = names
         .iter()
         .skip(start)
         .cloned()
         .zip(binder_kinds.iter().copied().skip(start))
-        .map(|(name, kind)| generic_param_from_kind(name, kind))
+        .map(|(name, kind)| (name.clone(), generic_param_from_kind(name, kind)))
         .collect();
 
     for wc in where_clauses {
         match wc {
-            WhereClauseData::IsImplemented(ty, _, _) => {
-                if let Ty::Variable(var) = ty {
-                    let name = ctx.core_variable_to_string(&var)?;
-                    // If the `where` clause referes to a type
-                    // variable from an outer binder, that
-                    // variable is not yet included in `params`.
-                    push_type_param_if_missing(&mut params, name);
-                }
-            }
             WhereClauseData::TypeOfConst(konst, ty) => {
                 let name = match tys::lower_const(ctx, konst)? {
                     syntax::ConstExpr::Ident(id) => id,
@@ -143,19 +133,20 @@ pub fn lower_generics_for_binder(
                 };
                 let ty = tys::lower_ty(ctx, ty)?;
 
-                if let Some(existing_ty) = params.iter_mut().find_map(|param| match param {
-                    syntax::GenericParam::Const { name: existing, ty } if existing == &name => {
-                        Some(ty)
+                let param = params.get_mut(&name).unwrap();
+                match param {
+                    syntax::GenericParam::Type(_) => todo!(),
+                    syntax::GenericParam::Lifetime(_) => todo!(),
+                    syntax::GenericParam::Const {
+                        name: _name,
+                        ty: existing_ty,
+                    } => {
+                        *existing_ty = ty;
                     }
-                    _ => None,
-                }) {
-                    *existing_ty = ty;
-                } else {
-                    // If the `where` clause referes to a type
-                    // variable from an outer binder, that
-                    // variable is not yet included in `params`.
-                    params.push(syntax::GenericParam::Const { name, ty });
                 }
+            }
+            WhereClauseData::IsImplemented(_, _, _) => {
+                continue;
             }
             WhereClauseData::AliasEq(_, _) => {
                 continue;
@@ -164,7 +155,7 @@ pub fn lower_generics_for_binder(
                 continue;
             }
             WhereClauseData::ForAll(_) => {
-                todo!("lowering `ForAll` where-clauses is not implemented yet")
+                continue;
             }
         }
     }
@@ -184,52 +175,52 @@ pub fn lower_where_clauses(
     let mut preds = Vec::new();
 
     for wc in where_clauses {
-        match wc {
-            WhereClauseData::IsImplemented(ty, trait_id, params) => {
-                preds.push(syntax::WhereClause::Trait {
-                    ty: tys::lower_ty(ctx, ty)?,
-                    trait_name: trait_id.deref().clone(),
-                    args: params
-                        .iter()
-                        .map(|param| tys::lower_generic_arg(ctx, param))
-                        .collect::<Result<Vec<_>, _>>()?,
-                });
-            }
-            WhereClauseData::TypeOfConst(_, _) => {}
-            WhereClauseData::AliasEq(_, _) => {
-                anyhow::bail!("lowering `AliasEq` where-clauses is not implemented yet")
-            }
-            WhereClauseData::Outlives(parameter, lifetime) => {
-                let lifetime = tys::lower_lt(ctx, lifetime)?;
-                let parameter = match parameter {
-                    Parameter::Ty(ty) => syntax::Parameter::Type(tys::lower_ty(ctx, ty)?),
-                    Parameter::Lt(lt) => syntax::Parameter::Lifetime(tys::lower_lt(ctx, lt)?),
-                    Parameter::Const(_) => anyhow::bail!("constant in an outlives constraint"),
-                };
-                preds.push(syntax::WhereClause::Lifetime {
-                    parameter,
-                    lifetime,
-                });
-            }
-            WhereClauseData::ForAll(_) => {
-                anyhow::bail!("lowering `ForAll` where-clauses is not implemented yet")
-            }
+        let wc = lower_where_clause(ctx, wc)?;
+        if let Some(wc) = wc {
+            preds.push(wc);
         }
     }
 
     Ok(preds)
 }
 
-fn push_type_param_if_missing(params: &mut Vec<syntax::GenericParam>, name: String) {
-    if name == "Self" {
-        return;
-    }
-
-    if !params
-        .iter()
-        .any(|param| matches!(param, syntax::GenericParam::Type(existing) if existing == &name))
-    {
-        params.push(syntax::GenericParam::Type(name));
+fn lower_where_clause(
+    ctx: &mut context::Context,
+    where_clause: &WhereClause,
+) -> Fallible<Option<syntax::WhereClause>> {
+    match where_clause {
+        WhereClauseData::IsImplemented(ty, trait_id, params) => {
+            Ok(Some(syntax::WhereClause::Trait {
+                ty: tys::lower_ty(ctx, ty)?,
+                trait_name: trait_id.deref().clone(),
+                args: params
+                    .iter()
+                    .map(|param| tys::lower_generic_arg(ctx, param))
+                    .collect::<Result<Vec<_>, _>>()?,
+            }))
+        }
+        WhereClauseData::TypeOfConst(_, _) => Ok(None),
+        WhereClauseData::AliasEq(_, _) => {
+            anyhow::bail!("lowering `AliasEq` where-clauses is not implemented yet")
+        }
+        WhereClauseData::Outlives(parameter, lifetime) => {
+            let lifetime = tys::lower_lt(ctx, lifetime)?;
+            let parameter = match parameter {
+                Parameter::Ty(ty) => syntax::Parameter::Type(tys::lower_ty(ctx, ty)?),
+                Parameter::Lt(lt) => syntax::Parameter::Lifetime(tys::lower_lt(ctx, lt)?),
+                Parameter::Const(_) => anyhow::bail!("constant in an outlives constraint"),
+            };
+            Ok(Some(syntax::WhereClause::Lifetime {
+                parameter,
+                lifetime,
+            }))
+        }
+        WhereClauseData::ForAll(binder) => {
+            let (term, names) = ctx.open_universal(binder);
+            Ok(Some(syntax::WhereClause::ForAll(
+                lower_generics_for_binder(ctx, binder.kinds(), &[term], &names, false)?,
+            )))
+        }
     }
 }
 
@@ -246,7 +237,7 @@ fn generic_param_from_kind(name: String, kind: ParameterKind) -> syntax::Generic
         ParameterKind::Const => syntax::GenericParam::Const {
             name,
             ty: syntax::Type::Path {
-                name: "usize".to_owned(),
+                name: "###not a type###".to_owned(),
                 args: Vec::new(),
             },
         },
@@ -319,6 +310,24 @@ pub fn foo<'a0, 'a1>(mut a: &'a0 u32) -> &'a1 u32 where 'a0: 'a1 {
     return r;
 }
 "#
+        )
+    }
+
+    #[test]
+    fn forall() {
+        crate::assert_rust!(
+            [
+                crate core {
+                    trait A { }
+
+                    trait B where for<'a> &'a u32: A { }
+                }
+            ],
+            r#"
+pub trait A { }
+
+pub trait B where for<'a2> &'a2 u32: A { }
+        "#
         )
     }
 }

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -136,7 +136,9 @@ pub fn lower_generics_for_binder(
                 };
                 let ty = tys::lower_ty(ctx, ty)?;
 
-                let param = params.get_mut(&name).unwrap();
+                let param = params
+                    .get_mut(&name)
+                    .ok_or_else(|| anyhow::anyhow!("no generic parameter named '{name}'"))?;
                 match param {
                     syntax::GenericParam::Type(_) => todo!(),
                     syntax::GenericParam::Lifetime(_) => todo!(),

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -293,9 +293,9 @@ mod test {
             expect_test::expect![[r#"
                 pub trait Trait { }
 
-                pub struct A<T0> where T0: Trait {}
+                pub struct A<T00> where T00: Trait {}
 
-                pub fn valid<'a0, T1>(mut x: &'a0 A<T1>) -> () where T1: 'a0, T1: Trait {}"#]]
+                pub fn valid<'a00, T01>(mut x: &'a00 A<T01>) -> () where T01: 'a00, T01: Trait {}"#]]
         )
     }
 
@@ -312,10 +312,10 @@ mod test {
                 }
             ],
             expect_test::expect![[r#"
-pub fn foo<'a0, 'a1>(mut a: &'a0 u32) -> &'a1 u32 where 'a0: 'a1 {
-    let mut r: &'a1 u32 = identity::<&'a1 u32>(a);
-    return r;
-}"#]]
+                pub fn foo<'a00, 'a01>(mut a: &'a00 u32) -> &'a01 u32 where 'a00: 'a01 {
+                    let mut r: &'a01 u32 = identity::<&'a01 u32>(a);
+                    return r;
+                }"#]]
         )
     }
 
@@ -332,7 +332,7 @@ pub fn foo<'a0, 'a1>(mut a: &'a0 u32) -> &'a1 u32 where 'a0: 'a1 {
             expect_test::expect![[r#"
                 pub trait A { }
 
-                pub trait B where for<'a0> &'a0 u32: A { }"#]]
+                pub trait B where for<'a10> &'a10 u32: A { }"#]]
         )
     }
 }

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -1,4 +1,5 @@
 use crate::grammar::{Crates, Fallible, Parameter, ParameterKind, WhereClause, WhereClauseData};
+use crate::to_rust::context::Wrapped;
 use std::cell::LazyCell;
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -102,9 +103,11 @@ pub fn lower_generics_for_binder(
     ctx: &mut context::Context,
     binder_kinds: &[ParameterKind],
     where_clauses: &[WhereClause],
-    names: &[String],
     skip_first: bool,
 ) -> Fallible<syntax::Generics> {
+    let names = ctx
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("context has no data"))?;
     if names.len() != binder_kinds.len() {
         anyhow::bail!(
             "binder metadata mismatch: {} names but {} kinds",
@@ -216,9 +219,12 @@ fn lower_where_clause(
             }))
         }
         WhereClauseData::ForAll(binder) => {
-            let (term, names) = ctx.open_universal(binder);
+            let Wrapped {
+                ref mut ctx,
+                ref term,
+            } = ctx.open_universal(binder.as_ref().clone());
             Ok(Some(syntax::WhereClause::ForAll(
-                lower_generics_for_binder(ctx, binder.kinds(), &[term], &names, false)?,
+                lower_generics_for_binder(ctx, binder.kinds(), &[term.clone()], false)?,
             )))
         }
     }

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -258,7 +258,7 @@ mod test {
             [
                 crate Foo {}
             ],
-            ""
+            expect_test::expect![[""]]
         );
     }
 
@@ -270,7 +270,7 @@ mod test {
                     #![feature(polonius_alpha)]
                 }
             ],
-            "#![feature(polonius_alpha)]"
+            expect_test::expect![["#![feature(polonius_alpha)]"]]
         );
     }
 
@@ -288,13 +288,12 @@ mod test {
                     {}
                 }
             ],
-            r#"
-pub trait Trait { }
+            expect_test::expect![[r#"
+                pub trait Trait { }
 
-pub struct A<T1> where T1: Trait {}
+                pub struct A<T0> where T0: Trait {}
 
-pub fn valid<'a2, T3>(mut x: &'a2 A<T3>) -> () where T3: 'a2, T3: Trait {}
-"#
+                pub fn valid<'a0, T1>(mut x: &'a0 A<T1>) -> () where T1: 'a0, T1: Trait {}"#]]
         )
     }
 
@@ -310,12 +309,11 @@ pub fn valid<'a2, T3>(mut x: &'a2 A<T3>) -> () where T3: 'a2, T3: Trait {}
                     }
                 }
             ],
-            r#"
+            expect_test::expect![[r#"
 pub fn foo<'a0, 'a1>(mut a: &'a0 u32) -> &'a1 u32 where 'a0: 'a1 {
     let mut r: &'a1 u32 = identity::<&'a1 u32>(a);
     return r;
-}
-"#
+}"#]]
         )
     }
 
@@ -329,11 +327,10 @@ pub fn foo<'a0, 'a1>(mut a: &'a0 u32) -> &'a1 u32 where 'a0: 'a1 {
                     trait B where for<'a> &'a u32: A { }
                 }
             ],
-            r#"
-pub trait A { }
+            expect_test::expect![[r#"
+                pub trait A { }
 
-pub trait B where for<'a2> &'a2 u32: A { }
-        "#
+                pub trait B where for<'a0> &'a0 u32: A { }"#]]
         )
     }
 }

--- a/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
+++ b/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
@@ -108,12 +108,11 @@ mod test {
                     }
                 }
             ],
-            r#"
+            expect_test::expect![[r#"
 pub struct Bar {
     pub a: i32,
     pub b: i32,
-}
-"#
+}"#]]
         );
     }
 
@@ -124,20 +123,19 @@ pub struct Bar {
                 crate Foo {
                     trait Baz { }
                     struct Bar<T>
-                        where
+                    where
                         T: Baz
                     {
                         a: T,
                     }
                 }
             ],
-            r#"
+            expect_test::expect![[r#"
 pub trait Baz { }
 
-pub struct Bar<T1> where T1: Baz {
-    pub a: T1,
-}
-"#
+pub struct Bar<T0> where T0: Baz {
+    pub a: T0,
+}"#]]
         );
     }
 
@@ -152,12 +150,12 @@ pub struct Bar<T1> where T1: Baz {
                     }
                 }
             ],
-            r#"
+            expect_test::expect![[r#"
 pub enum Bar {
     A,
     B,
-}
-"#
+}"#]]
+
         );
     }
 
@@ -168,7 +166,7 @@ pub enum Bar {
                 crate Foo {
                     trait Baz { }
                     enum Bar<T>
-                        where
+                    where
                         T : Baz
                     {
                         A { t: T },
@@ -176,14 +174,13 @@ pub enum Bar {
                     }
                 }
             ],
-            r#"
-pub trait Baz { }
+            expect_test::expect![[r#"
+                pub trait Baz { }
 
-pub enum Bar<T1> where T1: Baz {
-    A { t: T1 },
-    B(T1),
-}
-"#
+                pub enum Bar<T0> where T0: Baz {
+                    A { t: T0 },
+                    B(T0),
+                }"#]]
         );
     }
 }

--- a/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
+++ b/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
@@ -131,11 +131,11 @@ pub struct Bar {
                 }
             ],
             expect_test::expect![[r#"
-pub trait Baz { }
+                pub trait Baz { }
 
-pub struct Bar<T0> where T0: Baz {
-    pub a: T0,
-}"#]]
+                pub struct Bar<T00> where T00: Baz {
+                    pub a: T00,
+                }"#]]
         );
     }
 
@@ -177,9 +177,9 @@ pub enum Bar {
             expect_test::expect![[r#"
                 pub trait Baz { }
 
-                pub enum Bar<T0> where T0: Baz {
-                    A { t: T0 },
-                    B(T0),
+                pub enum Bar<T00> where T00: Baz {
+                    A { t: T00 },
+                    B(T00),
                 }"#]]
         );
     }

--- a/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
+++ b/crates/formality-rust/src/to_rust/structs_enums_and_adts.rs
@@ -2,13 +2,20 @@ use std::ops::Deref;
 
 use crate::grammar::{Enum, Fallible, Field, FieldName, Struct, Variant};
 
+use crate::to_rust::context::Wrapped;
 use crate::to_rust::{
     context::{open_bounded, Context},
     syntax, tys,
 };
 
 pub fn lower_struct(ctx: &mut Context, strukt: &Struct) -> Fallible<syntax::StructItem> {
-    let (term, generics) = open_bounded!(ctx, &strukt.binder);
+    let (
+        Wrapped {
+            ref mut ctx,
+            ref term,
+        },
+        generics,
+    ) = open_bounded!(ctx, strukt.binder.clone());
     let fields = term
         .fields
         .iter()
@@ -24,7 +31,13 @@ pub fn lower_struct(ctx: &mut Context, strukt: &Struct) -> Fallible<syntax::Stru
 }
 
 pub fn lower_enum(ctx: &mut Context, e: &Enum) -> Fallible<syntax::EnumItem> {
-    let (term, generics) = open_bounded!(ctx, &e.binder);
+    let (
+        Wrapped {
+            ref mut ctx,
+            ref term,
+        },
+        generics,
+    ) = open_bounded!(ctx, e.binder.clone());
     let variants = term
         .variants
         .iter()

--- a/crates/formality-rust/src/to_rust/syntax.rs
+++ b/crates/formality-rust/src/to_rust/syntax.rs
@@ -285,11 +285,30 @@ impl Display for Type {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Parameter {
+    Type(Type),
+    Lifetime(String),
+}
+
+impl Display for Parameter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Parameter::Type(ty) => ty.fmt(f),
+            Parameter::Lifetime(lt) => f.write_str(lt),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WhereClause {
     Trait {
         ty: Type,
         trait_name: String,
         args: Vec<GenericArg>,
+    },
+    Lifetime {
+        parameter: Parameter,
+        lifetime: String,
     },
 }
 
@@ -303,6 +322,12 @@ impl Display for WhereClause {
             } => {
                 write!(f, "{ty}: {trait_name}")?;
                 fmt_generic_args(f, args, false)
+            }
+            WhereClause::Lifetime {
+                parameter,
+                lifetime,
+            } => {
+                write!(f, "{parameter}: {lifetime}")
             }
         }
     }

--- a/crates/formality-rust/src/to_rust/syntax.rs
+++ b/crates/formality-rust/src/to_rust/syntax.rs
@@ -5,7 +5,10 @@
 //! analysis. They exist soley to translate formality code into Rust
 //! code, which can then be compiled and analyzed using `rustc`.
 
+use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter, Write};
+
+use itertools::Itertools;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RustCrate {
@@ -91,7 +94,7 @@ pub struct Generics {
     ///     bar: T
     /// }
     /// ```
-    pub params: Vec<GenericParam>,
+    pub params: HashMap<String, GenericParam>,
     pub where_clauses: Vec<WhereClause>,
 }
 
@@ -102,7 +105,7 @@ impl Generics {
         }
 
         f.write_char('<')?;
-        for (index, param) in self.params.iter().enumerate() {
+        for (index, (_, param)) in self.params.iter().sorted().enumerate() {
             if index > 0 {
                 f.write_str(", ")?;
             }
@@ -121,7 +124,17 @@ impl Generics {
             if index > 0 {
                 f.write_str(", ")?;
             }
-            write!(f, "{wc}")?;
+            wc.fmt(f)?;
+        }
+        Ok(())
+    }
+
+    fn fmt_without_where(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for (index, wc) in self.where_clauses.iter().enumerate() {
+            if index > 0 {
+                f.write_str(", ")?;
+            }
+            wc.fmt(f)?;
         }
         Ok(())
     }
@@ -140,6 +153,37 @@ pub enum GenericParam {
     Type(String),
     Lifetime(String),
     Const { name: String, ty: Type },
+}
+
+impl PartialOrd for GenericParam {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use std::cmp::Ordering;
+        match (self, other) {
+            (GenericParam::Type(lhs), GenericParam::Type(rhs)) => lhs.partial_cmp(rhs),
+            (GenericParam::Type(_), _) => Some(Ordering::Less),
+            (GenericParam::Lifetime(_), GenericParam::Type(_)) => Some(Ordering::Greater),
+            (GenericParam::Lifetime(lhs), GenericParam::Lifetime(rhs)) => lhs.partial_cmp(rhs),
+            (GenericParam::Lifetime(_), GenericParam::Const { name: _, ty: _ }) => {
+                Some(std::cmp::Ordering::Less)
+            }
+            (GenericParam::Const { name: _, ty: _ }, GenericParam::Type(_)) => {
+                Some(Ordering::Greater)
+            }
+            (GenericParam::Const { name: _, ty: _ }, GenericParam::Lifetime(_)) => {
+                Some(Ordering::Greater)
+            }
+            (
+                GenericParam::Const { name: lhs, ty: _ },
+                GenericParam::Const { name: rhs, ty: _ },
+            ) => lhs.partial_cmp(rhs),
+        }
+    }
+}
+
+impl Ord for GenericParam {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
 }
 
 impl Display for GenericParam {
@@ -310,6 +354,7 @@ pub enum WhereClause {
         parameter: Parameter,
         lifetime: String,
     },
+    ForAll(Generics),
 }
 
 impl Display for WhereClause {
@@ -328,6 +373,12 @@ impl Display for WhereClause {
                 lifetime,
             } => {
                 write!(f, "{parameter}: {lifetime}")
+            }
+            WhereClause::ForAll(generics) => {
+                write!(f, "for")?;
+                generics.fmt_params(f)?;
+                write!(f, " ")?;
+                generics.fmt_without_where(f)
             }
         }
     }

--- a/crates/formality-rust/src/to_rust/test_util.rs
+++ b/crates/formality-rust/src/to_rust/test_util.rs
@@ -10,13 +10,13 @@ use crate::{
 /// Rust code. Only a single crate is supported.
 #[macro_export]
 macro_rules! assert_rust {
-    ($input:tt, $expected:literal) => {{
+    ($input:tt, $expected:expr) => {{
         $crate::to_rust::test_util::assert_rust(stringify!($input), $expected);
     }};
 }
 
 #[track_caller]
-pub fn assert_rust(input: &str, expected: &str) {
+pub fn assert_rust(input: &str, expected: expect_test::Expect) {
     let program = term(input);
     let mut ctx = Context::default();
     let rust = build_crates(&mut ctx, &program)
@@ -25,8 +25,7 @@ pub fn assert_rust(input: &str, expected: &str) {
         .next()
         .unwrap()
         .1;
-    let expected = expected.trim();
-    assert_eq!(rust, expected);
+    expected.assert_eq(&rust);
 }
 
 /// Runs rustc on the given Formality program and returns the captured

--- a/crates/formality-rust/src/to_rust/traits_and_impls.rs
+++ b/crates/formality-rust/src/to_rust/traits_and_impls.rs
@@ -226,7 +226,7 @@ pub trait Write {
             ],
             expect_test::expect![[r#"
                 pub trait Write {
-                    type Error<T0, T1>: Sized + Bar where T0: Read, T1: Write;
+                    type Error<T10, T11>: Sized + Bar where T10: Read, T11: Write;
                     fn test() -> i32;
                 }"#]]
 
@@ -245,7 +245,7 @@ pub trait Write {
             expect_test::expect![[r#"
                 pub trait Baz { }
 
-                pub trait Bar<T1> where T1: Baz { }"#]]
+                pub trait Bar<T01> where T01: Baz { }"#]]
 
         );
     }
@@ -260,9 +260,9 @@ pub trait Write {
                 }
             ],
             expect_test::expect![[r#"
-                pub trait Baz<T1, T2> { }
+                pub trait Baz<T01, T02> { }
 
-                pub trait Bar<T1> where T1: Baz<i32, u8> { }"#]]
+                pub trait Bar<T01> where T01: Baz<i32, u8> { }"#]]
 
         );
     }
@@ -282,9 +282,9 @@ pub trait Write {
             expect_test::expect![[r#"
                 pub trait Baz { }
 
-                pub trait Bar<T1> where T1: Baz {
+                pub trait Bar<T01> where T01: Baz {
                     type Error;
-                    fn test() -> T1;
+                    fn test() -> T01;
                 }"#]]
 
         );
@@ -298,7 +298,7 @@ pub trait Write {
                     trait Bar<const C> where type_of_const C is bool {}
                 }
             ],
-            expect_test::expect![[r#"pub trait Bar<const N1: bool> { }"#]]
+            expect_test::expect!["pub trait Bar<const N01: bool> { }"]
         );
     }
 
@@ -318,16 +318,16 @@ pub trait Write {
                 }
             ],
             expect_test::expect![[r#"
-                pub trait Bar<T1> {
-                    fn run() -> T1;
+                pub trait Bar<T01> {
+                    fn run() -> T01;
                 }
 
                 pub trait Bur { }
 
                 pub struct Baz {}
 
-                impl<T0> Bar<T0> for Baz where T0: Bur {
-                    fn run() -> T0 {
+                impl<T00> Bar<T00> for Baz where T00: Bur {
+                    fn run() -> T00 {
                         panic!("Trusted Fn Body")
                     }
                 }"#]]
@@ -390,8 +390,7 @@ impl !Bar for Baz {}"#]]
                     trait Foo<T> where T: Bar<Self> {}
                 }
             ],
-            expect_test::expect![[r#"
-        pub trait Foo<T1> where T1: Bar<Self> { }"#]]
+            expect_test::expect!["pub trait Foo<T01> where T01: Bar<Self> { }"]
 
         );
     }

--- a/crates/formality-rust/src/to_rust/traits_and_impls.rs
+++ b/crates/formality-rust/src/to_rust/traits_and_impls.rs
@@ -350,4 +350,18 @@ impl !Bar for Baz {}
 "#
         );
     }
+
+    #[test]
+    fn self_type_is_emityed_self() {
+        crate::assert_rust!(
+            [
+                crate Foo {
+                    trait Foo<T> where T: Bar<Self> {}
+                }
+            ],
+            r#"
+pub trait Foo<T1> where T1: Bar<Self> { }
+"#
+        );
+    }
 }

--- a/crates/formality-rust/src/to_rust/traits_and_impls.rs
+++ b/crates/formality-rust/src/to_rust/traits_and_impls.rs
@@ -6,14 +6,21 @@ use crate::grammar::{
 };
 use crate::prove::prove::Safety;
 
+use crate::to_rust::context::Wrapped;
 use crate::to_rust::{
     self,
-    context::{open_bounded, Context},
+    context::{open_bounded, open_trait, Context},
     fns, syntax, tys,
 };
 
 pub fn lower_trait(ctx: &mut Context, t: &Trait) -> Fallible<syntax::TraitItem> {
-    let (term, generics) = open_bounded!(ctx, &t.binder.explicit_binder, true);
+    let (
+        Wrapped {
+            ref mut ctx,
+            ref term,
+        },
+        generics,
+    ) = open_trait!(ctx, t.binder.clone());
     let mut items = Vec::new();
     for item in &term.trait_items {
         match item {
@@ -38,7 +45,13 @@ pub fn lower_trait(ctx: &mut Context, t: &Trait) -> Fallible<syntax::TraitItem> 
 }
 
 pub fn lower_trait_impl(ctx: &mut Context, trait_impl: &TraitImpl) -> Fallible<syntax::ImplItem> {
-    let (term, generics) = open_bounded!(ctx, &trait_impl.binder);
+    let (
+        Wrapped {
+            ref mut ctx,
+            ref term,
+        },
+        generics,
+    ) = open_bounded!(ctx, trait_impl.binder.clone());
     let mut items = Vec::new();
     for item in &term.impl_items {
         match item {
@@ -76,7 +89,13 @@ pub fn lower_neg_trait_impl(
     ctx: &mut Context,
     neg_trait_impl: &NegTraitImpl,
 ) -> Fallible<syntax::NegImplItem> {
-    let (term, generics) = open_bounded!(ctx, &neg_trait_impl.binder);
+    let (
+        Wrapped {
+            ref mut ctx,
+            ref term,
+        },
+        generics,
+    ) = open_bounded!(ctx, neg_trait_impl.binder.clone());
     let trait_args = term
         .trait_parameters
         .iter()
@@ -99,7 +118,13 @@ pub fn lower_assoc_ty(
     ctx: &mut Context,
     assoc_ty: &AssociatedTy,
 ) -> Fallible<syntax::AssociatedTypeItem> {
-    let (term, generics) = open_bounded!(ctx, &assoc_ty.binder);
+    let (
+        Wrapped {
+            ref mut ctx,
+            ref term,
+        },
+        generics,
+    ) = open_bounded!(ctx, assoc_ty.binder.clone());
     let mut bounds = Vec::new();
     for ensure in &term.ensures {
         match ensure {
@@ -132,7 +157,13 @@ pub fn lower_assoc_ty_value(
     ctx: &mut Context,
     assoc_ty: &AssociatedTyValue,
 ) -> Fallible<syntax::AssociatedTypeValueItem> {
-    let (term, generics) = open_bounded!(ctx, &assoc_ty.binder);
+    let (
+        Wrapped {
+            ref mut ctx,
+            ref term,
+        },
+        generics,
+    ) = open_bounded!(ctx, assoc_ty.binder.clone());
     let ty = tys::lower_ty(ctx, &term.ty)?;
     Ok(syntax::AssociatedTypeValueItem {
         name: assoc_ty.id.deref().clone(),

--- a/crates/formality-rust/src/to_rust/traits_and_impls.rs
+++ b/crates/formality-rust/src/to_rust/traits_and_impls.rs
@@ -185,11 +185,11 @@ mod test {
                     }
                 }
             ],
-            r#"
+            expect_test::expect![[r#"
 pub trait Write {
     fn test() -> i32;
-}
-"#
+}"#]]
+
         );
     }
 
@@ -204,12 +204,12 @@ pub trait Write {
                     }
                 }
             ],
-            r#"
+            expect_test::expect![[r#"
 pub trait Write {
     type Error;
     fn test() -> i32;
-}
-"#
+}"#]]
+
         );
     }
 
@@ -224,12 +224,12 @@ pub trait Write {
                     }
                 }
             ],
-            r#"
-pub trait Write {
-    type Error<T1, T2>: Sized + Bar where T1: Read, T2: Write;
-    fn test() -> i32;
-}
-"#
+            expect_test::expect![[r#"
+                pub trait Write {
+                    type Error<T0, T1>: Sized + Bar where T0: Read, T1: Write;
+                    fn test() -> i32;
+                }"#]]
+
         );
     }
 
@@ -242,11 +242,11 @@ pub trait Write {
                     trait Bar<T> where T: Baz {}
                 }
             ],
-            "
-pub trait Baz { }
+            expect_test::expect![[r#"
+                pub trait Baz { }
 
-pub trait Bar<T2> where T2: Baz { }
-"
+                pub trait Bar<T1> where T1: Baz { }"#]]
+
         );
     }
 
@@ -259,11 +259,11 @@ pub trait Bar<T2> where T2: Baz { }
                     trait Bar<V> where V: Baz<i32, u8> {}
                 }
             ],
-            "
-pub trait Baz<T1, T2> { }
+            expect_test::expect![[r#"
+                pub trait Baz<T1, T2> { }
 
-pub trait Bar<T4> where T4: Baz<i32, u8> { }
-"
+                pub trait Bar<T1> where T1: Baz<i32, u8> { }"#]]
+
         );
     }
 
@@ -279,14 +279,14 @@ pub trait Bar<T4> where T4: Baz<i32, u8> { }
                     }
                 }
             ],
-            r#"
-pub trait Baz { }
+            expect_test::expect![[r#"
+                pub trait Baz { }
 
-pub trait Bar<T2> where T2: Baz {
-    type Error;
-    fn test() -> T2;
-}
-"#
+                pub trait Bar<T1> where T1: Baz {
+                    type Error;
+                    fn test() -> T1;
+                }"#]]
+
         );
     }
 
@@ -298,7 +298,7 @@ pub trait Bar<T2> where T2: Baz {
                     trait Bar<const C> where type_of_const C is bool {}
                 }
             ],
-            "pub trait Bar<const N1: bool> { }"
+            expect_test::expect![[r#"pub trait Bar<const N1: bool> { }"#]]
         );
     }
 
@@ -317,20 +317,20 @@ pub trait Bar<T2> where T2: Baz {
                     }
                 }
             ],
-            r#"
-pub trait Bar<T1> {
-    fn run() -> T1;
-}
+            expect_test::expect![[r#"
+                pub trait Bar<T1> {
+                    fn run() -> T1;
+                }
 
-pub trait Bur { }
+                pub trait Bur { }
 
-pub struct Baz {}
+                pub struct Baz {}
 
-impl<T3> Bar<T3> for Baz where T3: Bur {
-    fn run() -> T3 {
-        panic!("Trusted Fn Body")
-    }
-}"#
+                impl<T0> Bar<T0> for Baz where T0: Bur {
+                    fn run() -> T0 {
+                        panic!("Trusted Fn Body")
+                    }
+                }"#]]
         );
     }
 
@@ -346,7 +346,7 @@ impl<T3> Bar<T3> for Baz where T3: Bur {
                     }
                 }
             ],
-            r#"
+            expect_test::expect![[r#"
 pub trait Bar {
     fn run() -> i32;
 }
@@ -357,8 +357,8 @@ impl Bar for Baz {
     fn run() -> i32 {
         panic!("Trusted Fn Body")
     }
-}
-"#
+}"#]]
+
         );
     }
 
@@ -372,13 +372,13 @@ impl Bar for Baz {
                     impl !Bar for Baz { }
                 }
             ],
-            r#"
+            expect_test::expect![[r#"
 pub trait Bar { }
 
 pub struct Baz {}
 
-impl !Bar for Baz {}
-"#
+impl !Bar for Baz {}"#]]
+
         );
     }
 
@@ -390,9 +390,9 @@ impl !Bar for Baz {}
                     trait Foo<T> where T: Bar<Self> {}
                 }
             ],
-            r#"
-pub trait Foo<T1> where T1: Bar<Self> { }
-"#
+            expect_test::expect![[r#"
+        pub trait Foo<T1> where T1: Bar<Self> { }"#]]
+
         );
     }
 }

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -489,9 +489,9 @@ mod test {
                     type Assoc;
                 }
 
-                pub trait Bar<T1> { }
+                pub trait Bar<T01> { }
 
-                impl<T0, T1> Bar<T1> for T0 where <T0 as Foo>::Assoc: Bar<T1> {}"#]]
+                impl<T00, T01> Bar<T01> for T00 where <T00 as Foo>::Assoc: Bar<T01> {}"#]]
         );
     }
 }

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -152,8 +152,9 @@ pub fn lower_ref(
         })
         .ok_or_else(|| anyhow::anyhow!("reference type is missing pointee type argument"))?;
 
+    // TODO: Match on Lt::Erased after codegen (#369) is merged
     let lifetime = match &lifetime {
-        Lt::Variable(Variable::ExistentialVar(_)) => None,
+        Lt::Variable(Variable::ExistentialVar(_)) => Some("'_".to_string()),
         _ => Some(lower_lt(ctx, &lifetime)?),
     };
     let pointee = lower_ty(ctx, pointee)?;
@@ -375,7 +376,7 @@ mod test {
             ],
         });
         let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
-        assert_eq!("&mut u8", t);
+        assert_eq!("&'_ mut u8", t);
     }
 
     #[test]

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -251,54 +251,8 @@ pub fn lower_fn_ptr(
 
 #[cfg(test)]
 mod test {
-    use crate::grammar::{AdtId, BoundVar, ExistentialVar, VarIndex, Variable};
-
     use super::*;
-
-    fn create_ty(index: usize) -> Variable {
-        Variable::BoundVar(BoundVar {
-            debruijn: None,
-            var_index: VarIndex { index },
-            kind: crate::grammar::ParameterKind::Ty,
-        })
-    }
-
-    fn create_lt(index: usize) -> Variable {
-        Variable::BoundVar(BoundVar {
-            debruijn: None,
-            var_index: VarIndex { index },
-            kind: crate::grammar::ParameterKind::Lt,
-        })
-    }
-
-    fn create_const(index: usize) -> Variable {
-        Variable::BoundVar(BoundVar {
-            debruijn: None,
-            var_index: VarIndex { index },
-            kind: crate::grammar::ParameterKind::Const,
-        })
-    }
-
-    #[test]
-    fn pretty_print_type_variables() {
-        let b = Context::default();
-        let ty1 = create_ty(1);
-        assert_eq!("T1", b.core_variable_to_string(&ty1).unwrap());
-    }
-
-    #[test]
-    fn pretty_print_life_time_variables() {
-        let b = Context::default();
-        let lt1 = create_lt(1);
-        assert_eq!("'a1", b.core_variable_to_string(&lt1).unwrap());
-    }
-
-    #[test]
-    fn pretty_print_const_variables() {
-        let b = Context::default();
-        let const1 = create_const(1);
-        assert_eq!("N1", b.core_variable_to_string(&const1).unwrap());
-    }
+    use crate::grammar::{AdtId, BoundVar, DebruijnIndex, ExistentialVar, VarIndex, Variable};
 
     #[test]
     fn pretty_print_adt() {
@@ -326,11 +280,18 @@ mod test {
 
     #[test]
     fn pretty_print_shared_ref() {
-        let mut ctx = Context::default();
+        let mut ctx = Context::with(vec![vec!["'a0".into()]]);
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Ref(RefKind::Shared),
             parameters: vec![
-                Parameter::Lt(Lt::Variable(create_lt(1)).into()),
+                Parameter::Lt(
+                    Lt::Variable(Variable::BoundVar(BoundVar {
+                        debruijn: Some(DebruijnIndex { index: 0 }),
+                        var_index: VarIndex { index: 0 },
+                        kind: crate::grammar::ParameterKind::Lt,
+                    }))
+                    .into(),
+                ),
                 Parameter::Ty(
                     Ty::RigidTy(RigidTy {
                         name: RigidName::ScalarId(ScalarId::U8),
@@ -341,16 +302,23 @@ mod test {
             ],
         });
         let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
-        assert_eq!("&'a1 u8", t);
+        assert_eq!("&'a0 u8", t);
     }
 
     #[test]
     fn pretty_print_mutable_ref() {
-        let mut ctx = Context::default();
+        let mut ctx = Context::with(vec![vec!["'a0".into()]]);
         let ty = Ty::RigidTy(RigidTy {
             name: RigidName::Ref(RefKind::Mut),
             parameters: vec![
-                Parameter::Lt(Lt::Variable(create_lt(1)).into()),
+                Parameter::Lt(
+                    Lt::Variable(Variable::BoundVar(BoundVar {
+                        debruijn: Some(DebruijnIndex { index: 0 }),
+                        var_index: VarIndex { index: 0 },
+                        kind: crate::grammar::ParameterKind::Lt,
+                    }))
+                    .into(),
+                ),
                 Parameter::Ty(
                     Ty::RigidTy(RigidTy {
                         name: RigidName::ScalarId(ScalarId::U8),
@@ -361,7 +329,7 @@ mod test {
             ],
         });
         let t = lower_ty(&mut ctx, &ty).unwrap().to_string();
-        assert_eq!("&'a1 mut u8", t);
+        assert_eq!("&'a0 mut u8", t);
     }
 
     #[test]

--- a/crates/formality-rust/src/to_rust/tys.rs
+++ b/crates/formality-rust/src/to_rust/tys.rs
@@ -483,15 +483,14 @@ mod test {
                         <T as Foo>::Assoc: Bar<U> {}
                 }
             ],
-            r#"
-pub trait Foo {
-    type Assoc;
-}
+            expect_test::expect![[r#"
+                pub trait Foo {
+                    type Assoc;
+                }
 
-pub trait Bar<T2> { }
+                pub trait Bar<T1> { }
 
-impl<T3, T4> Bar<T4> for T3 where <T3 as Foo>::Assoc: Bar<T4> {}
-"#
+                impl<T0, T1> Bar<T1> for T0 where <T0 as Foo>::Assoc: Bar<T1> {}"#]]
         );
     }
 }


### PR DESCRIPTION
## What does this PR do?

Lowers `forall` and `outlives` bounds. The implicit `Self` type in a trait definition is emitted correctly.
Modified tests to use `expect-test`.

## How does it work, what questions do you have?

Introduced a new `Wrapped` type that works as a RAII guard. By calling `Context::open_bounded` / `Context::open_bounded`, a fresh set of variable names is pushed to the context and the guard is returned. When `Wrapped` goes out of scope, the corresponding variable names are removed from the scope.

## AI disclosure

* Used AI for improving my doc comments.
