### PR TITLE
Share judgment_fn parser between formality-coverage and formality-mdbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ name = "formality-mdbook"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "formality-coverage",
  "mdbook-preprocessor",
  "regex",
  "serde_json",

--- a/crates/formality-coverage/src/scrape.rs
+++ b/crates/formality-coverage/src/scrape.rs
@@ -1,15 +1,10 @@
 //! Discover the full set of judgments and rules in the source tree by
-//! regex-scraping `judgment_fn!` macro invocations.
+//! parsing `judgment_fn!` macro invocations.
 //!
-//! This is intentionally lightweight: we do not parse Rust, we just find
-//! `judgment_fn!` blocks and the `--- ("rule-name")` lines inside them. If
-//! the macro syntax changes, the regexes here must follow.
-//!
-//! Block boundary caveat: each judgment's body is taken as the text from
-//! `judgment_fn!` up to the next `judgment_fn!` (or EOF). A rule-shaped line
-//! (`--- ("name")`) sitting outside a macro invocation would be misattributed.
-//! In practice this pattern only appears inside `judgment_fn!`, so we accept
-//! the trade-off and avoid Rust-aware brace balancing.
+//! Parsing is intentionally lightweight: we do not invoke a Rust parser, we
+//! only scan for `judgment_fn!` and walk the body with brace/paren matching
+//! that ignores strings and `//` line comments. If the macro syntax changes,
+//! the logic here must follow.
 
 use anyhow::Result;
 use regex::Regex;
@@ -17,16 +12,12 @@ use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 use walkdir::WalkDir;
 
-static INVOCATION_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"judgment_fn!\s*\{").unwrap());
-static FN_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\b(?:pub\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(").unwrap());
-static RULE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"^\s*-{3,}\s*\(\s*"([^"]+)"\s*\)\s*$"#).unwrap());
-
 /// A single judgment discovered by the scraper.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Judgment {
     pub name: String,
+    pub doc_comment: String,
+    pub signature: String,
     pub file: String,
     pub line: u32,
     pub rules: Vec<Rule>,
@@ -36,6 +27,7 @@ pub struct Judgment {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Rule {
     pub name: String,
+    pub raw_text: String,
     pub line: u32,
 }
 
@@ -57,7 +49,7 @@ pub fn scrape_dir(root: &Path) -> Result<Vec<Judgment>> {
         }
         let contents = std::fs::read_to_string(path)?;
         let rel = normalize_path(path, root);
-        out.extend(scrape_text(&contents, &rel));
+        out.extend(parse_judgment_fns(&contents, &rel));
     }
     out.sort_by(|a, b| (a.file.as_str(), a.line).cmp(&(b.file.as_str(), b.line)));
     Ok(out)
@@ -68,41 +60,268 @@ fn normalize_path(path: &Path, root: &Path) -> String {
     rel.to_string_lossy().replace('\\', "/")
 }
 
-/// Scrape one file's text. `file` is the path string to record in results.
+/// Scrape one file's text. `file` is the path string recorded in results.
+/// Kept as a thin alias for [`parse_judgment_fns`] so existing callers and
+/// tests can continue to use it.
 pub fn scrape_text(text: &str, file: &str) -> Vec<Judgment> {
-    let starts: Vec<usize> = INVOCATION_RE.find_iter(text).map(|m| m.start()).collect();
-    let mut out = Vec::new();
-    for (i, &start) in starts.iter().enumerate() {
-        let end = starts.get(i + 1).copied().unwrap_or(text.len());
-        let block = &text[start..end];
+    parse_judgment_fns(text, file)
+}
 
-        let Some(cap) = FN_RE.captures(block) else {
+/// Find every `judgment_fn! { ... }` invocation in `content` and parse it.
+pub fn parse_judgment_fns(content: &str, file: &str) -> Vec<Judgment> {
+    let mut judgments = Vec::new();
+    let mut pos = 0;
+
+    while let Some(start) = content[pos..].find("judgment_fn!") {
+        let abs_start = pos + start;
+        let jf_line = line_number(content, abs_start);
+
+        let Some(brace_rel) = content[abs_start..].find('{') else {
+            pos = abs_start + "judgment_fn!".len();
             continue;
         };
-        let name = cap.get(1).unwrap().as_str().to_string();
-        let fn_offset_in_block = cap.get(0).unwrap().start();
-        let fn_abs = start + fn_offset_in_block;
-        let header_line = line_number(text, fn_abs);
+        let brace_start = abs_start + brace_rel;
 
-        let mut rules = Vec::new();
-        for (rel_line_idx, line) in block.lines().enumerate() {
-            if let Some(c) = RULE_RE.captures(line) {
-                let line_no = line_number(text, start) + rel_line_idx as u32;
-                rules.push(Rule {
-                    name: c.get(1).unwrap().as_str().to_string(),
-                    line: line_no,
-                });
+        let Some(brace_end) = find_matching_brace(content, brace_start) else {
+            pos = brace_start + 1;
+            continue;
+        };
+
+        let block = &content[brace_start + 1..brace_end];
+        let block_start_line = line_number(content, brace_start + 1);
+
+        if let Some(judgment) = parse_single_judgment(
+            block,
+            &content[..abs_start],
+            file,
+            jf_line,
+            block_start_line,
+        ) {
+            judgments.push(judgment);
+        }
+
+        pos = brace_end + 1;
+    }
+
+    judgments
+}
+
+fn parse_single_judgment(
+    block: &str,
+    preceding: &str,
+    file: &str,
+    jf_line: u32,
+    block_start_line: u32,
+) -> Option<Judgment> {
+    static FN_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?s)(pub\s+)?fn\s+(\w+)\s*\((.*?)\)\s*=>\s*([^{]+)\{").unwrap()
+    });
+
+    let doc_comment = extract_doc_comment(preceding);
+    let captures = FN_RE.captures(block)?;
+
+    let name = captures.get(2)?.as_str().to_string();
+    let params = captures.get(3)?.as_str();
+    let return_ty = captures.get(4)?.as_str().trim();
+
+    let clean_params = clean_params(params);
+    let signature = format!("{name}({clean_params}) => {return_ty}");
+
+    let rules = extract_rules(block, block_start_line);
+
+    Some(Judgment {
+        name,
+        doc_comment,
+        signature,
+        file: file.to_string(),
+        line: jf_line,
+        rules,
+    })
+}
+
+fn extract_doc_comment(preceding: &str) -> String {
+    let mut doc_lines = Vec::new();
+    for line in preceding.lines().rev() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("///") {
+            doc_lines.push(rest.trim());
+        } else if trimmed.is_empty() {
+            continue;
+        } else {
+            break;
+        }
+    }
+    doc_lines.reverse();
+    doc_lines.join("\n")
+}
+
+fn clean_params(params: &str) -> String {
+    params
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .replace(" ,", ",")
+}
+
+fn extract_rules(block: &str, block_start_line: u32) -> Vec<Rule> {
+    static SEPARATOR_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"-{3,}\s*\("[^"]+"\)"#).unwrap());
+
+    let mut rules = Vec::new();
+
+    // Skip past an optional `debug(...)` directive at the top of the block.
+    let after_debug_offset = if let Some(debug_start) = block.find("debug(") {
+        let paren_close = find_matching_paren(block, debug_start + 5).unwrap_or(debug_start + 6);
+        paren_close + 1
+    } else {
+        0
+    };
+
+    let after_debug = &block[after_debug_offset..];
+    let after_debug_line_offset = block[..after_debug_offset].matches('\n').count() as u32;
+
+    let mut pos = 0;
+    while pos < after_debug.len() {
+        let Some(trimmed_offset) = after_debug[pos..].find(|c: char| !c.is_whitespace()) else {
+            break;
+        };
+        pos += trimmed_offset;
+
+        if !after_debug[pos..].starts_with('(') {
+            if let Some(nl) = after_debug[pos..].find('\n') {
+                pos += nl + 1;
+            } else {
+                break;
+            }
+            continue;
+        }
+
+        let Some(close) = find_matching_paren(after_debug, pos) else {
+            pos += 1;
+            continue;
+        };
+
+        let rule_text = &after_debug[pos + 1..close];
+
+        if let Some(rule_name) = extract_rule_name(rule_text) {
+            let separator_line_offset = if let Some(m) = SEPARATOR_RE.find(rule_text) {
+                rule_text[..m.start()].matches('\n').count() as u32
+            } else {
+                0
+            };
+
+            let rule_start_lines = after_debug[..pos + 1].matches('\n').count() as u32;
+            let abs_line = block_start_line
+                + after_debug_line_offset
+                + rule_start_lines
+                + separator_line_offset;
+
+            rules.push(Rule {
+                name: rule_name,
+                raw_text: clean_rule_text(rule_text),
+                line: abs_line,
+            });
+        }
+
+        pos = close + 1;
+    }
+
+    rules
+}
+
+fn extract_rule_name(rule_text: &str) -> Option<String> {
+    static NAME_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"-{3,}\s*\("([^"]+)"\)"#).unwrap());
+    let captures = NAME_RE.captures(rule_text)?;
+    Some(captures.get(1)?.as_str().to_string())
+}
+
+fn clean_rule_text(rule_text: &str) -> String {
+    let lines: Vec<&str> = rule_text.lines().collect();
+
+    let min_indent = lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    lines
+        .iter()
+        .map(|l| {
+            if l.trim().is_empty() {
+                ""
+            } else if l.len() >= min_indent {
+                &l[min_indent..]
+            } else {
+                l.trim()
+            }
+        })
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+fn find_matching_brace(content: &str, open_pos: usize) -> Option<usize> {
+    find_matching(content, open_pos, '{', '}')
+}
+
+fn find_matching_paren(content: &str, open_pos: usize) -> Option<usize> {
+    find_matching(content, open_pos, '(', ')')
+}
+
+fn find_matching(content: &str, open_pos: usize, open: char, close: char) -> Option<usize> {
+    let mut depth = 0;
+    let mut in_string = false;
+    let mut in_line_comment = false;
+    let mut prev_char = '\0';
+
+    for (i, ch) in content[open_pos..].char_indices() {
+        if in_line_comment {
+            if ch == '\n' {
+                in_line_comment = false;
+            }
+            prev_char = ch;
+            continue;
+        }
+
+        if in_string {
+            if ch == '"' && prev_char != '\\' {
+                in_string = false;
+            }
+            prev_char = ch;
+            continue;
+        }
+
+        if ch == '/' && prev_char == '/' {
+            in_line_comment = true;
+            prev_char = ch;
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            prev_char = ch;
+            continue;
+        }
+
+        if ch == open {
+            depth += 1;
+        } else if ch == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(open_pos + i);
             }
         }
 
-        out.push(Judgment {
-            name,
-            file: file.to_string(),
-            line: header_line,
-            rules,
-        });
+        prev_char = ch;
     }
-    out
+
+    None
 }
 
 fn line_number(text: &str, byte_offset: usize) -> u32 {

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -76,25 +76,32 @@ fn markdown_index_snapshot() {
     let judgments = vec![
         Judgment {
             name: "prove_thing".into(),
+            doc_comment: String::new(),
+            signature: String::new(),
             file: "fixture.rs".into(),
             line: 4,
             rules: vec![
                 Rule {
                     name: "positive".into(),
+                    raw_text: String::new(),
                     line: 10,
                 },
                 Rule {
                     name: "zero".into(),
+                    raw_text: String::new(),
                     line: 16,
                 },
             ],
         },
         Judgment {
             name: "only_one".into(),
+            doc_comment: String::new(),
+            signature: String::new(),
             file: "fixture.rs".into(),
             line: 22,
             rules: vec![Rule {
                 name: "one".into(),
+                raw_text: String::new(),
                 line: 28,
             }],
         },
@@ -125,15 +132,19 @@ fn markdown_index_snapshot() {
 fn markdown_subpage_snapshot() {
     let j = Judgment {
         name: "prove_thing".into(),
+        doc_comment: String::new(),
+        signature: String::new(),
         file: "fixture.rs".into(),
         line: 4,
         rules: vec![
             Rule {
                 name: "positive".into(),
+                raw_text: String::new(),
                 line: 10,
             },
             Rule {
                 name: "zero".into(),
+                raw_text: String::new(),
                 line: 16,
             },
         ],
@@ -160,6 +171,8 @@ fn markdown_subpage_snapshot() {
 fn empty_rules_renders_no_rules_message() {
     let j = Judgment {
         name: "lonely".into(),
+        doc_comment: String::new(),
+        signature: String::new(),
         file: "fixture.rs".into(),
         line: 1,
         rules: vec![],

--- a/crates/formality-mdbook/Cargo.toml
+++ b/crates/formality-mdbook/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+formality-coverage = { version = "0.1.0", path = "../formality-coverage" }
 mdbook-preprocessor = "0.5"
 regex = "1"
 serde_json = "1"

--- a/crates/formality-mdbook/src/lib.rs
+++ b/crates/formality-mdbook/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use formality_coverage::scrape::{Judgment, Rule, parse_judgment_fns};
 use mdbook_preprocessor::book::{Book, BookItem};
 use mdbook_preprocessor::{Preprocessor, PreprocessorContext};
 use regex::Regex;
@@ -72,23 +73,6 @@ pub struct Anchor {
     pub name: String,
     pub content: String,
     pub file_path: String,
-    pub line_number: usize,
-}
-
-#[derive(Debug)]
-pub struct Judgment {
-    pub name: String,
-    pub doc_comment: String,
-    pub signature: String,
-    pub file_path: String,
-    pub line_number: usize,
-    pub rules: Vec<Rule>,
-}
-
-#[derive(Debug)]
-pub struct Rule {
-    pub name: String,
-    pub raw_text: String,
     pub line_number: usize,
 }
 
@@ -187,304 +171,6 @@ fn dedent(text: &str) -> String {
         .join("\n")
 }
 
-// --- Judgment parsing ---
-
-pub fn parse_judgment_fns(content: &str, file_path: &str) -> Vec<Judgment> {
-    let mut judgments = Vec::new();
-    let mut pos = 0;
-
-    while let Some(start) = content[pos..].find("judgment_fn!") {
-        let abs_start = pos + start;
-        let jf_line = content[..abs_start].matches('\n').count() + 1;
-
-        let Some(brace_start) = content[abs_start..].find('{') else {
-            pos = abs_start + 12;
-            continue;
-        };
-        let brace_start = abs_start + brace_start;
-
-        let Some(brace_end) = find_matching_brace(content, brace_start) else {
-            pos = brace_start + 1;
-            continue;
-        };
-
-        let block = &content[brace_start + 1..brace_end];
-        let block_start_line = content[..brace_start + 1].matches('\n').count() + 1;
-
-        if let Some(judgment) = parse_single_judgment(
-            block,
-            &content[..abs_start],
-            file_path,
-            jf_line,
-            block_start_line,
-        ) {
-            judgments.push(judgment);
-        }
-
-        pos = brace_end + 1;
-    }
-
-    judgments
-}
-
-fn find_matching_brace(content: &str, open_pos: usize) -> Option<usize> {
-    let mut depth = 0;
-    let mut in_string = false;
-    let mut in_line_comment = false;
-    let mut prev_char = '\0';
-
-    for (i, ch) in content[open_pos..].char_indices() {
-        if in_line_comment {
-            if ch == '\n' {
-                in_line_comment = false;
-            }
-            prev_char = ch;
-            continue;
-        }
-
-        if in_string {
-            if ch == '"' && prev_char != '\\' {
-                in_string = false;
-            }
-            prev_char = ch;
-            continue;
-        }
-
-        if ch == '/' && prev_char == '/' {
-            in_line_comment = true;
-            prev_char = ch;
-            continue;
-        }
-
-        if ch == '"' {
-            in_string = true;
-            prev_char = ch;
-            continue;
-        }
-
-        if ch == '{' {
-            depth += 1;
-        } else if ch == '}' {
-            depth -= 1;
-            if depth == 0 {
-                return Some(open_pos + i);
-            }
-        }
-
-        prev_char = ch;
-    }
-
-    None
-}
-
-fn parse_single_judgment(
-    block: &str,
-    preceding: &str,
-    file_path: &str,
-    jf_line: usize,
-    block_start_line: usize,
-) -> Option<Judgment> {
-    let doc_comment = extract_doc_comment(preceding);
-
-    let fn_re = Regex::new(r"(?s)(pub\s+)?fn\s+(\w+)\s*\((.*?)\)\s*=>\s*([^{]+)\{").unwrap();
-    let captures = fn_re.captures(block)?;
-
-    let name = captures.get(2)?.as_str().to_string();
-    let params = captures.get(3)?.as_str();
-    let return_ty = captures.get(4)?.as_str().trim();
-
-    let clean_params = clean_params(params);
-    let signature = format!("{name}({clean_params}) => {return_ty}");
-
-    let rules = extract_rules(block, block_start_line);
-
-    Some(Judgment {
-        name,
-        doc_comment,
-        signature,
-        file_path: file_path.to_string(),
-        line_number: jf_line,
-        rules,
-    })
-}
-
-fn extract_doc_comment(preceding: &str) -> String {
-    let lines: Vec<&str> = preceding.lines().collect();
-    let mut doc_lines = Vec::new();
-
-    for line in lines.iter().rev() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("///") {
-            doc_lines.push(trimmed.trim_start_matches("///").trim());
-        } else if trimmed.is_empty() {
-            continue;
-        } else {
-            break;
-        }
-    }
-
-    doc_lines.reverse();
-    doc_lines.join("\n")
-}
-
-fn clean_params(params: &str) -> String {
-    params
-        .lines()
-        .map(|l| l.trim())
-        .filter(|l| !l.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ")
-        .replace(" ,", ",")
-}
-
-fn extract_rules(block: &str, block_start_line: usize) -> Vec<Rule> {
-    let mut rules = Vec::new();
-
-    let after_debug_offset = if let Some(debug_start) = block.find("debug(") {
-        let paren_close = find_matching_paren(block, debug_start + 5).unwrap_or(debug_start + 6);
-        paren_close + 1
-    } else {
-        0
-    };
-
-    let after_debug = &block[after_debug_offset..];
-    let after_debug_line_offset = block[..after_debug_offset].matches('\n').count();
-    let separator_re = Regex::new(r#"-{3,}\s*\("[^"]+"\)"#).unwrap();
-
-    let mut pos = 0;
-    while pos < after_debug.len() {
-        let trimmed_start = after_debug[pos..].find(|c: char| !c.is_whitespace());
-        let Some(trimmed_offset) = trimmed_start else {
-            break;
-        };
-        pos += trimmed_offset;
-
-        if !after_debug[pos..].starts_with('(') {
-            if let Some(nl) = after_debug[pos..].find('\n') {
-                pos += nl + 1;
-            } else {
-                break;
-            }
-            continue;
-        }
-
-        let Some(close) = find_matching_paren(after_debug, pos) else {
-            pos += 1;
-            continue;
-        };
-
-        let rule_text = &after_debug[pos + 1..close];
-
-        if let Some(rule_name) = extract_rule_name(rule_text) {
-            let separator_line_offset = if let Some(m) = separator_re.find(rule_text) {
-                rule_text[..m.start()].matches('\n').count()
-            } else {
-                0
-            };
-
-            let rule_start_lines = after_debug[..pos + 1].matches('\n').count();
-            let abs_line = block_start_line
-                + after_debug_line_offset
-                + rule_start_lines
-                + separator_line_offset;
-
-            rules.push(Rule {
-                name: rule_name,
-                raw_text: clean_rule_text(rule_text),
-                line_number: abs_line,
-            });
-        }
-
-        pos = close + 1;
-    }
-
-    rules
-}
-
-fn find_matching_paren(text: &str, open_pos: usize) -> Option<usize> {
-    let mut depth = 0;
-    let mut in_string = false;
-    let mut in_line_comment = false;
-    let mut prev_char = '\0';
-
-    for (i, ch) in text[open_pos..].char_indices() {
-        if in_line_comment {
-            if ch == '\n' {
-                in_line_comment = false;
-            }
-            prev_char = ch;
-            continue;
-        }
-
-        if in_string {
-            if ch == '"' && prev_char != '\\' {
-                in_string = false;
-            }
-            prev_char = ch;
-            continue;
-        }
-
-        if ch == '/' && prev_char == '/' {
-            in_line_comment = true;
-            prev_char = ch;
-            continue;
-        }
-
-        if ch == '"' {
-            in_string = true;
-            prev_char = ch;
-            continue;
-        }
-
-        if ch == '(' {
-            depth += 1;
-        } else if ch == ')' {
-            depth -= 1;
-            if depth == 0 {
-                return Some(open_pos + i);
-            }
-        }
-
-        prev_char = ch;
-    }
-
-    None
-}
-
-fn extract_rule_name(rule_text: &str) -> Option<String> {
-    let re = Regex::new(r#"-{3,}\s*\("([^"]+)"\)"#).unwrap();
-    let captures = re.captures(rule_text)?;
-    Some(captures.get(1)?.as_str().to_string())
-}
-
-fn clean_rule_text(rule_text: &str) -> String {
-    let lines: Vec<&str> = rule_text.lines().collect();
-
-    let min_indent = lines
-        .iter()
-        .filter(|l| !l.trim().is_empty())
-        .map(|l| l.len() - l.trim_start().len())
-        .min()
-        .unwrap_or(0);
-
-    lines
-        .iter()
-        .map(|l| {
-            if l.trim().is_empty() {
-                ""
-            } else if l.len() >= min_indent {
-                &l[min_indent..]
-            } else {
-                l.trim()
-            }
-        })
-        .filter(|l| !l.trim_start().starts_with("//"))
-        .collect::<Vec<_>>()
-        .join("\n")
-        .trim()
-        .to_string()
-}
-
 // --- Rendering ---
 
 fn render_figure(
@@ -523,14 +209,14 @@ fn render_figure(
     out
 }
 
-fn source_link(github_base: Option<&str>, file_path: &str, line: usize) -> Option<String> {
+fn source_link(github_base: Option<&str>, file_path: &str, line: u32) -> Option<String> {
     github_base.map(|base| format!("{base}/{file_path}#L{line}"))
 }
 
 fn render_rule(judgment: &Judgment, rule_name: &str, github_base: Option<&str>) -> String {
-    match judgment.rules.iter().find(|r| r.name == rule_name) {
+    match judgment.rules.iter().find(|r: &&Rule| r.name == rule_name) {
         Some(rule) => {
-            let link = source_link(github_base, &judgment.file_path, rule.line_number);
+            let link = source_link(github_base, &judgment.file, rule.line);
             let id = format!("judgment-{}--{}", judgment.name, rule_name);
             let label = format!("{}::{}", judgment.name, rule_name);
             render_figure(
@@ -556,7 +242,7 @@ fn render_rule(judgment: &Judgment, rule_name: &str, github_base: Option<&str>) 
 }
 
 fn render_judgment(judgment: &Judgment, github_base: Option<&str>) -> String {
-    let link = source_link(github_base, &judgment.file_path, judgment.line_number);
+    let link = source_link(github_base, &judgment.file, judgment.line);
     let id = format!("judgment-{}", judgment.name);
     let doc = if judgment.doc_comment.is_empty() {
         None
@@ -574,7 +260,7 @@ fn render_judgment(judgment: &Judgment, github_base: Option<&str>) -> String {
 }
 
 fn render_anchor(anchor: &Anchor, github_base: Option<&str>) -> String {
-    let link = source_link(github_base, &anchor.file_path, anchor.line_number);
+    let link = source_link(github_base, &anchor.file_path, anchor.line_number as u32);
     let id = format!("anchor-{}", anchor.name);
     render_figure(
         "anchor",
@@ -696,30 +382,6 @@ some postamble
             judgments: judgment_map,
             anchors: anchor_map,
         }
-    }
-
-    #[test]
-    fn test_parse_judgment() {
-        let judgments = parse_judgment_fns(SAMPLE, "src/type_system/expressions.rs");
-        assert_eq!(judgments.len(), 1);
-        let j = &judgments[0];
-        assert_eq!(j.name, "move_place");
-        assert_eq!(j.rules.len(), 2);
-        assert_eq!(j.rules[0].name, "copy");
-        assert_eq!(j.rules[1].name, "give");
-        assert_eq!(j.file_path, "src/type_system/expressions.rs");
-    }
-
-    #[test]
-    fn test_extract_rule_name() {
-        assert_eq!(
-            extract_rule_name(r#"  --- ("foo")  "#),
-            Some("foo".to_string())
-        );
-        assert_eq!(
-            extract_rule_name(r#"  ----------------------------------- ("share-share")  "#),
-            Some("share-share".to_string())
-        );
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

This is about the de-duplication per Zulip discussion with @nikomatsakis: the two crates had separate ways of detecting `judgment_fn!`. Lifting the more robust parser into `formality-coverage` gives a single source of truth, and matches the agreed dependency direction (`formality-mdbook` → `formality-coverage`, so coverage reports can be embedded later).

## How does it work, what questions do you have?

Both formality-coverage and formality-mdbook had different ways of finding judgment function invocations in the .rs files. The Mdbook's way was more correct so I kept that one. The dependency direction is formality-mdbook -> formality-coverage as discussed. Line numbers for rules are accurate even if a non judgment function elsewhere in the file happens to have a --- ("...")-shaped line 

## AI disclosure

* I used an AI tool for rote or minor changes (e.g., refactoring, autocomplete)

