### PR TITLE
Remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,6 @@ dependencies = [
  "formality-core",
  "formality-macros",
  "formality-rust",
- "pretty_assertions",
  "tracing",
 ]
 
@@ -233,35 +232,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "dissimilar"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "equivalent"
@@ -287,17 +261,6 @@ checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
 dependencies = [
  "dissimilar",
  "once_cell",
-]
-
-[[package]]
-name = "extension-trait"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd65f1b59dd22d680c7a626cc4a000c1e03d241c51c3e034d2bc9f1e90734f9b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -341,12 +304,9 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "contracts",
- "either",
- "env_logger",
  "expect-test",
  "final_fn",
  "formality-macros",
- "itertools 0.12.1",
  "lazy_static",
  "miette",
  "regex",
@@ -362,7 +322,6 @@ name = "formality-macros"
 version = "0.1.0"
 dependencies = [
  "convert_case",
- "expect-test",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -375,18 +334,14 @@ name = "formality-rust"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "contracts",
  "expect-test",
- "extension-trait",
  "fn-error-context",
  "formality-core",
  "formality-macros",
- "itertools 0.10.5",
  "lazy_static",
  "libspecr",
  "minirust-rs",
  "regex",
- "stacker",
  "tempfile",
  "tracing",
 ]
@@ -454,18 +409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,17 +441,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,24 +451,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -734,16 +648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
 ]
 
 [[package]]
@@ -1043,15 +947,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,15 +1178,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1548,12 +1434,6 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-pretty_assertions = "1.3.0"
 expect-test = "1.4.0"
 formality-macros = { version = "0.1.0", path = "crates/formality-macros" }
 formality-core = { version = "0.1.0", path = "crates/formality-core" }

--- a/crates/formality-core/Cargo.toml
+++ b/crates/formality-core/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 
 [dependencies]
 lazy_static = "1.4.0"
-env_logger = "0.10.0"
 stacker = "0.1.15"
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}
@@ -21,8 +20,6 @@ formality-macros = { version = "0.1.0", path = "../formality-macros" }
 anyhow = "1.0.75"
 contracts = "0.6.3"
 final_fn = "0.1.0"
-itertools = "0.12.0"
-either = "1.9.0"
 expect-test = "1.4.1"
 regex = "1.10.2"
 similar = "2"

--- a/crates/formality-macros/Cargo.toml
+++ b/crates/formality-macros/Cargo.toml
@@ -19,6 +19,3 @@ syn = { version = "2.0", features = ["full"] }
 synstructure = "0.13.0"
 tracing = "0.1"
 convert_case = "0.6.0"
-
-[dev-dependencies]
-expect-test = "1.4.0"

--- a/crates/formality-rust/Cargo.toml
+++ b/crates/formality-rust/Cargo.toml
@@ -10,15 +10,11 @@ formality-macros = { path = "../formality-macros" }
 formality-core = { path = "../formality-core" }
 anyhow = "1.0.66"
 lazy_static = "1.4.0"
-contracts = "0.6.3"
+regex = "1.12.3"
 tracing = "0.1"
 fn-error-context = "0.2.0"
-itertools = "0.10.5"
-stacker = "0.1.15"
-extension-trait = "1.0.1"
 minirust-rs = { path = "../minirust-rs" }
 libspecr = "=0.1.36"
-regex = "1.12.3"
 tempfile = "3.27.0"
 
 [dev-dependencies]


### PR DESCRIPTION
## What does this PR do?

We have a couple unused dependencies, which this PR removes. The major motivation was this thread: https://rust-lang.zulipchat.com/#narrow/channel/402470-t-types.2Fformality/topic/target.20directory.20size/with/599523951, but unfortunately this removal is not that detrimental like it only reduced target size by 100 MB

Before:

```sh
du -sh target/
3.1G    target/
```
After:

```sh
du -sh target/
3.0G    target/
```

## How does it work, what questions do you have?

An effort to reduce the target directory size, which brought it down by around 100 MB. I used `cargo machete` for this. I thought about adding it to CI, but for some reason we don’t currently have CI checks even for clippy/fmt, so I didn’t add it yet. Though I would like to.

## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools