### PR TITLE
Give labelling perm to users

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,6 +1,12 @@
 # Gives us the commands 'ready', 'author', 'blocked'.
 [shortcut]
 
+# Allow any user to add labels.
+[relabel]
+allow-unauthenticated = [
+    "*",
+]
+
 # Allow any user to assign themselves to a Github issue.
 [assign]
 


### PR DESCRIPTION
## What does this PR do?

As title. In the meeting yesterday, @liolin told us he couldn't label issue. I think it is reasonable to let contributors assign labels. 

<!-- In your own words (**no LLM usage here**), explain the main idea of why it's correct. It's ok if you're not sure! Please include any questions you have. If you wish to use an LLM for translation, include the original as well as the translated version. Thanks! -->

## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools
