### PR TITLE
Record negative coverage when judgments fail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/formality-core/src/judgment.rs
+++ b/crates/formality-core/src/judgment.rs
@@ -9,8 +9,8 @@ pub mod coverage;
 
 mod proven_set;
 pub use proven_set::{
-    insert_smallest_proof, member_of, CheckProven, EachProof, FailedJudgment, FailedRule,
-    FailureLocation, ProofTree, Proven, ProvenSet, RuleFailureCause,
+    insert_smallest_proof, member_of, BlamedRule, CheckProven, EachProof, FailedJudgment,
+    FailedRule, FailureLocation, LeafFailure, ProofTree, Proven, ProvenSet, RuleFailureCause,
 };
 
 mod test_explicit_fail;

--- a/crates/formality-core/src/judgment/coverage.rs
+++ b/crates/formality-core/src/judgment/coverage.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 use std::panic::Location;
 use std::path::PathBuf;
 
-use super::ProofTree;
+use super::{BlamedRule, FailedJudgment, ProofTree};
 
 /// A single (judgment, rule) pair as identified in the coverage output.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
@@ -76,6 +76,34 @@ pub fn record_coverage<'a>(trees: impl IntoIterator<Item = &'a ProofTree>) {
     }
 
     let line = format_jsonl(caller, &rules);
+    let _ = append_line(&path, &line);
+}
+
+/// Record negative coverage for the currently-running test from one or more
+/// failed judgments. For each failure, every named rule that was "blamed"
+/// (see [`FailedJudgment::collect_blamed_rules`]) is appended.
+///
+/// JSONL records produced here carry `"kind":"negative"` and a per-rule
+/// `"cause"` tag. Positive records (written by [`record_coverage`]) omit the
+/// `kind` field so existing data remains valid.
+#[track_caller]
+pub fn record_negative_coverage<'a>(failures: impl IntoIterator<Item = &'a FailedJudgment>) {
+    if !coverage_enabled() {
+        return;
+    }
+
+    let Some(path) = coverage_file_path() else {
+        return;
+    };
+
+    let caller = Location::caller();
+
+    let mut rules: BTreeSet<BlamedRule> = BTreeSet::new();
+    for failure in failures {
+        rules.extend(failure.collect_blamed_rules());
+    }
+
+    let line = format_negative_jsonl(caller, &rules);
     let _ = append_line(&path, &line);
 }
 
@@ -142,6 +170,35 @@ fn format_jsonl(caller: &Location<'_>, rules: &BTreeSet<RuleId>) -> String {
         push_json_str(&mut s, &r.file);
         s.push_str(",\"line\":");
         s.push_str(&r.line.to_string());
+        s.push('}');
+    }
+    s.push_str("]}");
+    s
+}
+
+fn format_negative_jsonl(caller: &Location<'_>, rules: &BTreeSet<BlamedRule>) -> String {
+    let mut s = String::new();
+    s.push('{');
+    s.push_str("\"test_file\":");
+    push_json_str(&mut s, &caller.file().replace('\\', "/"));
+    s.push_str(",\"test_line\":");
+    s.push_str(&caller.line().to_string());
+    s.push_str(",\"test_column\":");
+    s.push_str(&caller.column().to_string());
+    s.push_str(",\"kind\":\"negative\",\"rules\":[");
+    for (i, r) in rules.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push('{');
+        s.push_str("\"rule\":");
+        push_json_str(&mut s, &r.rule);
+        s.push_str(",\"file\":");
+        push_json_str(&mut s, &r.file);
+        s.push_str(",\"line\":");
+        s.push_str(&r.line.to_string());
+        s.push_str(",\"cause\":");
+        push_json_str(&mut s, r.cause);
         s.push('}');
     }
     s.push_str("]}");

--- a/crates/formality-core/src/judgment/proven_set.rs
+++ b/crates/formality-core/src/judgment/proven_set.rs
@@ -1,5 +1,6 @@
 use crate::{judgment::IfThen, set, Fallible, Map, Set};
 use std::{
+    collections::BTreeSet,
     fmt::Debug,
     hash::{Hash, Hasher},
     panic::Location,
@@ -203,6 +204,7 @@ impl<J: Ord + Debug + Clone> ProvenSet<J> {
     pub fn assert_err(&self, expect: expect_test::Expect) {
         match &self.data {
             ProvenSetData::Failure(e) => {
+                crate::judgment::coverage::record_negative_coverage(std::iter::once(e.as_ref()));
                 expect.assert_eq(&crate::test_util::normalize_paths(e.format_leaves()));
             }
             ProvenSetData::Success(_) => {
@@ -590,6 +592,44 @@ impl FailedJudgment {
                 .join("\n\n")
         }
     }
+
+    /// Collect every named rule that was "blamed" for this judgment failing,
+    /// walking through nested failed sub-judgments. Used by negative
+    /// coverage tracking: a rule shows up here exactly when it survived
+    /// cycle-stripping and `!`-clause filtering, matched the conclusion
+    /// patterns, and then had some premise fail. Rules without a name
+    /// (single-rule judgments) are skipped because there's nothing to
+    /// blame distinctly.
+    pub fn collect_blamed_rules(&self) -> BTreeSet<BlamedRule> {
+        let mut acc = BTreeSet::new();
+        for leaf in self.leaf_failures() {
+            if let LeafFailure::Rule(rule) = leaf {
+                let Some(rule_name) = rule.rule_name else {
+                    continue;
+                };
+                acc.insert(BlamedRule {
+                    rule: rule_name,
+                    file: rule.file.replace('\\', "/"),
+                    line: rule.line,
+                    cause: rule.cause.discriminant_tag(),
+                });
+            }
+        }
+        acc
+    }
+}
+
+/// A single named rule that was blamed for a judgment failure. Identified
+/// by `(file, line)` of the rule definition, paired with a coarse tag
+/// describing which clause of the rule failed.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct BlamedRule {
+    pub rule: String,
+    pub file: String,
+    pub line: u32,
+    /// Discriminant tag from [`RuleFailureCause`]; see
+    /// [`RuleFailureCause::discriminant_tag`].
+    pub cause: &'static str,
 }
 
 impl FailedRule {
@@ -688,6 +728,21 @@ pub enum RuleFailureCause {
 }
 
 impl RuleFailureCause {
+    /// Snake-case tag identifying the variant. Used by negative coverage
+    /// to record *why* a blamed rule failed without leaking the inner
+    /// payload (which could differ from one test run to another).
+    pub fn discriminant_tag(&self) -> &'static str {
+        match self {
+            RuleFailureCause::IfFalse(_) => "if_false",
+            RuleFailureCause::IfLetDidNotMatch { .. } => "if_let",
+            RuleFailureCause::EmptyCollection { .. } => "empty_collection",
+            RuleFailureCause::FailedJudgment(_) => "failed_judgment",
+            RuleFailureCause::Inapplicable { .. } => "inapplicable",
+            RuleFailureCause::Cycle { .. } => "cycle",
+            RuleFailureCause::ExplicitFailure { .. } => "explicit_failure",
+        }
+    }
+
     pub fn from_anyhow(e: anyhow::Error) -> Self {
         if let Some(failed) = e.downcast_ref::<Box<FailedJudgment>>() {
             RuleFailureCause::FailedJudgment(Box::new((**failed).clone()))

--- a/crates/formality-core/src/judgment/proven_set.rs
+++ b/crates/formality-core/src/judgment/proven_set.rs
@@ -594,28 +594,48 @@ impl FailedJudgment {
     }
 
     /// Collect every named rule that was "blamed" for this judgment failing,
-    /// walking through nested failed sub-judgments. Used by negative
-    /// coverage tracking: a rule shows up here exactly when it survived
-    /// cycle-stripping and `!`-clause filtering, matched the conclusion
-    /// patterns, and then had some premise fail. Rules without a name
-    /// (single-rule judgments) are skipped because there's nothing to
-    /// blame distinctly.
+    /// walking every level of the failure tree — not just the terminal
+    /// leaves. Used by negative coverage tracking.
+    ///
+    /// Two kinds of rule end up here:
+    ///
+    /// * *Intermediate* rules — rules whose conclusion patterns matched and
+    ///   whose `!`-clauses survived, but which then ran a premise that was
+    ///   itself a sub-judgment that failed. These get cause
+    ///   `"failed_judgment"`, telling us "this branch was reached and the
+    ///   sub-judgment is what broke".
+    /// * *Leaf* rules — rules whose own premise produced a terminal failure
+    ///   (`if_false`, `if_let`, `inapplicable`, …). These give us coverage
+    ///   over the individual ways a sub-judgment can fail to prove.
+    ///
+    /// Rules without a name (single-rule judgments) are skipped because
+    /// there's nothing to blame distinctly.
     pub fn collect_blamed_rules(&self) -> BTreeSet<BlamedRule> {
         let mut acc = BTreeSet::new();
-        for leaf in self.leaf_failures() {
-            if let LeafFailure::Rule(rule) = leaf {
-                let Some(rule_name) = rule.rule_name else {
-                    continue;
-                };
-                acc.insert(BlamedRule {
-                    rule: rule_name,
-                    file: rule.file.replace('\\', "/"),
-                    line: rule.line,
-                    cause: rule.cause.discriminant_tag(),
-                });
-            }
+        for rule in &self.failed_rules {
+            rule.collect_blamed_into(&mut acc);
         }
         acc
+    }
+}
+
+impl FailedRule {
+    /// Insert `self` into `acc` if named, then recurse into nested
+    /// `FailedJudgment` causes. See [`FailedJudgment::collect_blamed_rules`].
+    fn collect_blamed_into(&self, acc: &mut BTreeSet<BlamedRule>) {
+        if let Some(rule_name) = &self.rule_name {
+            acc.insert(BlamedRule {
+                rule: rule_name.clone(),
+                file: self.file.replace('\\', "/"),
+                line: self.line,
+                cause: self.cause.discriminant_tag(),
+            });
+        }
+        if let RuleFailureCause::FailedJudgment(inner) = &self.cause {
+            for r in &inner.failed_rules {
+                r.collect_blamed_into(acc);
+            }
+        }
     }
 }
 

--- a/crates/formality-core/src/test_util.rs
+++ b/crates/formality-core/src/test_util.rs
@@ -130,11 +130,21 @@ impl<T: Debug> AnyhowResultTestExt<T> for anyhow::Result<T> {
         match self {
             Ok(v) => panic!("expected `Err`, got `Ok`:\n{v:?}"),
             Err(e) => {
+                record_negative_coverage_from_anyhow(&e);
                 // Extract just the leaf failures for a concise view
                 let output = normalize_paths(format_error_leaves(&e));
 
                 expect.assert_eq(&output);
             }
         }
+    }
+}
+
+#[track_caller]
+fn record_negative_coverage_from_anyhow(e: &anyhow::Error) {
+    if let Some(failed) = e.downcast_ref::<Box<FailedJudgment>>() {
+        crate::judgment::coverage::record_negative_coverage(std::iter::once(failed.as_ref()));
+    } else if let Some(failed) = e.downcast_ref::<FailedJudgment>() {
+        crate::judgment::coverage::record_negative_coverage(std::iter::once(failed));
     }
 }

--- a/crates/formality-coverage/src/bin/formality-coverage.rs
+++ b/crates/formality-coverage/src/bin/formality-coverage.rs
@@ -34,13 +34,16 @@ fn main() -> Result<()> {
             args.jsonl.display(),
         );
     }
-    let covered = jsonl::read_positive(&args.jsonl)?;
+    let cov = jsonl::read(&args.jsonl)?;
 
-    report::write_all(&args.out_dir, &judgments, &covered)?;
+    let positive_count = cov.positive.len();
+    let negative_count = cov.negative.len();
+    report::write_all(&args.out_dir, &judgments, &cov)?;
     eprintln!(
-        "wrote {} judgments ({} rules covered) to {}",
+        "wrote {} judgments ({} positive, {} negative) to {}",
         judgments.len(),
-        covered.len(),
+        positive_count,
+        negative_count,
         args.out_dir.display(),
     );
     Ok(())

--- a/crates/formality-coverage/src/jsonl.rs
+++ b/crates/formality-coverage/src/jsonl.rs
@@ -1,25 +1,69 @@
-//! Read the `test-coverage.jsonl` file produced by positive tests and
-//! collapse it to the set of `(judgment, rule)` pairs that fired at least once.
+//! Read the `test-coverage.jsonl` file produced by tests and collapse it to
+//! the deduplicated set of rules that fired (positive) and rules that were
+//! blamed for a failure (negative).
 
 use anyhow::{Context, Result};
 use serde_json::Value;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-/// A `(judgment, rule)` pair as it appears in coverage data.
+/// A `(judgment, rule)` pair as it appears in positive coverage data.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct CoveredRule {
     pub judgment: String,
     pub rule: String,
 }
 
-/// Parse the JSONL file at `path`, returning the deduplicated set of rules
-/// that fired across all recorded tests. If the file does not exist, returns
-/// an empty set (positive coverage is opt-in via `cargo test`).
-pub fn read_positive(path: &Path) -> Result<BTreeSet<CoveredRule>> {
-    let mut out = BTreeSet::new();
+/// A rule blamed for a negative-test failure. The recorded `file` is the
+/// path the `file!()` macro produced (workspace-relative) and `line` is
+/// the failing-premise line, not the rule's `--- ("name")` line — that's
+/// where the macro respans the failure. Both fields are kept for
+/// diagnostics; matching against the scraper uses `rule` + file suffix.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BlamedRuleLoc {
+    pub rule: String,
+    pub file: String,
+    pub line: u32,
+}
+
+/// Aggregated coverage data from a JSONL file.
+#[derive(Default, Debug)]
+pub struct Coverage {
+    /// `(judgment, rule)` pairs that fired in at least one positive test.
+    pub positive: BTreeSet<CoveredRule>,
+    /// Each blamed rule location with the set of clause-cause tags observed.
+    pub negative: BTreeMap<BlamedRuleLoc, BTreeSet<String>>,
+}
+
+impl Coverage {
+    /// Look up causes for a scraped rule. Matches by rule name and file
+    /// suffix (either side being a suffix of the other), tolerating the
+    /// path-root difference between `file!()` and the scraper's
+    /// `--src-root`.
+    pub fn negative_causes_for(&self, judgment_file: &str, rule_name: &str) -> BTreeSet<String> {
+        let mut out = BTreeSet::new();
+        for (loc, causes) in &self.negative {
+            if loc.rule != rule_name {
+                continue;
+            }
+            if paths_overlap(&loc.file, judgment_file) {
+                out.extend(causes.iter().cloned());
+            }
+        }
+        out
+    }
+}
+
+fn paths_overlap(a: &str, b: &str) -> bool {
+    a.ends_with(b) || b.ends_with(a)
+}
+
+/// Parse the JSONL file at `path`. If the file does not exist, returns an
+/// empty `Coverage` (recording is opt-in via `cargo test`).
+pub fn read(path: &Path) -> Result<Coverage> {
+    let mut cov = Coverage::default();
     if !path.exists() {
-        return Ok(out);
+        return Ok(cov);
     }
     let text =
         std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
@@ -41,18 +85,55 @@ pub fn read_positive(path: &Path) -> Result<BTreeSet<CoveredRule>> {
         let Some(rules) = value.get("rules").and_then(|v| v.as_array()) else {
             continue;
         };
-        for rule in rules {
-            let (Some(j), Some(r)) = (
-                rule.get("judgment").and_then(|v| v.as_str()),
-                rule.get("rule").and_then(|v| v.as_str()),
-            ) else {
-                continue;
-            };
-            out.insert(CoveredRule {
-                judgment: j.to_string(),
-                rule: r.to_string(),
-            });
+        let kind = value
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("positive");
+        match kind {
+            "negative" => ingest_negative(rules, &mut cov.negative),
+            _ => ingest_positive(rules, &mut cov.positive),
         }
     }
-    Ok(out)
+    Ok(cov)
+}
+
+/// Back-compat wrapper for tools that only want the positive set.
+pub fn read_positive(path: &Path) -> Result<BTreeSet<CoveredRule>> {
+    Ok(read(path)?.positive)
+}
+
+fn ingest_positive(rules: &[Value], out: &mut BTreeSet<CoveredRule>) {
+    for rule in rules {
+        let (Some(j), Some(r)) = (
+            rule.get("judgment").and_then(|v| v.as_str()),
+            rule.get("rule").and_then(|v| v.as_str()),
+        ) else {
+            continue;
+        };
+        out.insert(CoveredRule {
+            judgment: j.to_string(),
+            rule: r.to_string(),
+        });
+    }
+}
+
+fn ingest_negative(rules: &[Value], out: &mut BTreeMap<BlamedRuleLoc, BTreeSet<String>>) {
+    for rule in rules {
+        let (Some(rname), Some(file), Some(line)) = (
+            rule.get("rule").and_then(|v| v.as_str()),
+            rule.get("file").and_then(|v| v.as_str()),
+            rule.get("line").and_then(|v| v.as_u64()),
+        ) else {
+            continue;
+        };
+        let loc = BlamedRuleLoc {
+            rule: rname.to_string(),
+            file: file.to_string(),
+            line: line as u32,
+        };
+        let causes = out.entry(loc).or_default();
+        if let Some(cause) = rule.get("cause").and_then(|v| v.as_str()) {
+            causes.insert(cause.to_string());
+        }
+    }
 }

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -1,32 +1,34 @@
-//! Render scraped judgments + positive-coverage data into markdown.
+//! Render scraped judgments + coverage data into markdown.
 
-use crate::jsonl::CoveredRule;
+use crate::jsonl::{Coverage, CoveredRule};
 use crate::scrape::Judgment;
 use anyhow::{Context, Result};
 use std::collections::{BTreeSet, HashSet};
 use std::path::Path;
 
 /// Render the top-level coverage table.
-pub fn render_index(judgments: &[Judgment], covered: &BTreeSet<CoveredRule>) -> String {
+pub fn render_index(judgments: &[Judgment], cov: &Coverage) -> String {
     let mut s = String::new();
     s.push_str("# Coverage report\n\n");
-    s.push_str("| Judgment/Rule | Positive coverage |\n");
-    s.push_str("| --- | --- |\n");
+    s.push_str("| Judgment/Rule | Positive coverage | Negative coverage |\n");
+    s.push_str("| --- | --- | --- |\n");
     for j in judgments {
         let slug = slug(&j.name);
         s.push_str(&format!(
-            "| **[{name}](./{slug}.md)** | - |\n",
+            "| **[{name}](./{slug}.md)** | - | - |\n",
             name = j.name,
             slug = slug,
         ));
         for r in &j.rules {
-            let mark = covered_mark(covered, &j.name, &r.name);
+            let pos = positive_mark(&cov.positive, &j.name, &r.name);
+            let neg = negative_mark(cov, &j.file, &r.name);
             s.push_str(&format!(
-                "| ↳ [{rname}](./{slug}.md#{anchor}) | {mark} |\n",
+                "| ↳ [{rname}](./{slug}.md#{anchor}) | {pos} | {neg} |\n",
                 rname = r.name,
                 slug = slug,
                 anchor = anchor(&r.name),
-                mark = mark,
+                pos = pos,
+                neg = neg,
             ));
         }
     }
@@ -34,7 +36,7 @@ pub fn render_index(judgments: &[Judgment], covered: &BTreeSet<CoveredRule>) -> 
 }
 
 /// Render one subpage per judgment.
-pub fn render_subpage(j: &Judgment, covered: &BTreeSet<CoveredRule>) -> String {
+pub fn render_subpage(j: &Judgment, cov: &Coverage) -> String {
     let mut s = String::new();
     s.push_str(&format!(
         "# Judgment `{}` at {}:{}\n\n",
@@ -44,22 +46,24 @@ pub fn render_subpage(j: &Judgment, covered: &BTreeSet<CoveredRule>) -> String {
         s.push_str("_No rules discovered._\n");
         return s;
     }
-    s.push_str("| Rule | Line | Positive coverage |\n");
-    s.push_str("| --- | --- | --- |\n");
+    s.push_str("| Rule | Line | Positive coverage | Negative coverage |\n");
+    s.push_str("| --- | --- | --- | --- |\n");
     for r in &j.rules {
-        let mark = covered_mark(covered, &j.name, &r.name);
+        let pos = positive_mark(&cov.positive, &j.name, &r.name);
+        let neg = negative_cell(cov, &j.file, &r.name);
         s.push_str(&format!(
-            "| <a id=\"{anchor}\"></a>`{rname}` | {line} | {mark} |\n",
+            "| <a id=\"{anchor}\"></a>`{rname}` | {line} | {pos} | {neg} |\n",
             anchor = anchor(&r.name),
             rname = r.name,
             line = r.line,
-            mark = mark,
+            pos = pos,
+            neg = neg,
         ));
     }
     s
 }
 
-fn covered_mark(covered: &BTreeSet<CoveredRule>, judgment: &str, rule: &str) -> &'static str {
+fn positive_mark(covered: &BTreeSet<CoveredRule>, judgment: &str, rule: &str) -> &'static str {
     let hit = covered.contains(&CoveredRule {
         judgment: judgment.to_string(),
         rule: rule.to_string(),
@@ -71,14 +75,30 @@ fn covered_mark(covered: &BTreeSet<CoveredRule>, judgment: &str, rule: &str) -> 
     }
 }
 
+fn negative_mark(cov: &Coverage, judgment_file: &str, rule_name: &str) -> &'static str {
+    if cov.negative_causes_for(judgment_file, rule_name).is_empty() {
+        "✗"
+    } else {
+        "✓"
+    }
+}
+
+/// Per-judgment-subpage cell: shows `✓` plus the observed clause-cause tags,
+/// e.g. `✓ (if_false, failed_judgment)`, or `✗` if the rule was never blamed.
+fn negative_cell(cov: &Coverage, judgment_file: &str, rule_name: &str) -> String {
+    let causes = cov.negative_causes_for(judgment_file, rule_name);
+    if causes.is_empty() {
+        "✗".to_string()
+    } else {
+        let joined = causes.into_iter().collect::<Vec<_>>().join(", ");
+        format!("✓ ({joined})")
+    }
+}
+
 /// Write the index and per-judgment subpages into `out_dir`.
-pub fn write_all(
-    out_dir: &Path,
-    judgments: &[Judgment],
-    covered: &BTreeSet<CoveredRule>,
-) -> Result<()> {
+pub fn write_all(out_dir: &Path, judgments: &[Judgment], cov: &Coverage) -> Result<()> {
     std::fs::create_dir_all(out_dir).with_context(|| format!("creating {}", out_dir.display()))?;
-    let index = render_index(judgments, covered);
+    let index = render_index(judgments, cov);
     std::fs::write(out_dir.join("coverage.md"), index)?;
 
     // Two judgments with the same name (or names that differ only by characters
@@ -93,7 +113,7 @@ pub fn write_all(
                 j.name, j.file, j.line,
             );
         }
-        let body = render_subpage(j, covered);
+        let body = render_subpage(j, cov);
         std::fs::write(out_dir.join(format!("{}.md", slug)), body)?;
     }
     Ok(())

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -2,12 +2,26 @@
 //! fixtures (a fake `judgment_fn!` source snippet) so the tests don't depend
 //! on the live `formality-rust` source layout.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use expect_test::expect;
-use formality_coverage::jsonl::{self, CoveredRule};
+use formality_coverage::jsonl::{self, BlamedRuleLoc, Coverage, CoveredRule};
 use formality_coverage::report;
 use formality_coverage::scrape::{scrape_text, Judgment, Rule};
+
+fn cov_with_positive(rules: &[(&str, &str)]) -> Coverage {
+    let mut positive = BTreeSet::new();
+    for (j, r) in rules {
+        positive.insert(CoveredRule {
+            judgment: (*j).into(),
+            rule: (*r).into(),
+        });
+    }
+    Coverage {
+        positive,
+        negative: BTreeMap::new(),
+    }
+}
 
 const FIXTURE: &str = r#"
 use formality_core::judgment_fn;
@@ -107,23 +121,19 @@ fn markdown_index_snapshot() {
         },
     ];
 
-    let mut covered = BTreeSet::new();
-    covered.insert(CoveredRule {
-        judgment: "prove_thing".into(),
-        rule: "positive".into(),
-    });
+    let cov = cov_with_positive(&[("prove_thing", "positive")]);
 
-    let md = report::render_index(&judgments, &covered);
+    let md = report::render_index(&judgments, &cov);
     expect![[r#"
         # Coverage report
 
-        | Judgment/Rule | Positive coverage |
-        | --- | --- |
-        | **[prove_thing](./prove_thing.md)** | - |
-        | ↳ [positive](./prove_thing.md#positive) | ✓ |
-        | ↳ [zero](./prove_thing.md#zero) | ✗ |
-        | **[only_one](./only_one.md)** | - |
-        | ↳ [one](./only_one.md#one) | ✗ |
+        | Judgment/Rule | Positive coverage | Negative coverage |
+        | --- | --- | --- |
+        | **[prove_thing](./prove_thing.md)** | - | - |
+        | ↳ [positive](./prove_thing.md#positive) | ✓ | ✗ |
+        | ↳ [zero](./prove_thing.md#zero) | ✗ | ✗ |
+        | **[only_one](./only_one.md)** | - | - |
+        | ↳ [one](./only_one.md#one) | ✗ | ✗ |
     "#]]
     .assert_eq(&md);
 }
@@ -149,20 +159,16 @@ fn markdown_subpage_snapshot() {
             },
         ],
     };
-    let mut covered = BTreeSet::new();
-    covered.insert(CoveredRule {
-        judgment: "prove_thing".into(),
-        rule: "positive".into(),
-    });
+    let cov = cov_with_positive(&[("prove_thing", "positive")]);
 
-    let md = report::render_subpage(&j, &covered);
+    let md = report::render_subpage(&j, &cov);
     expect![[r#"
         # Judgment `prove_thing` at fixture.rs:4
 
-        | Rule | Line | Positive coverage |
-        | --- | --- | --- |
-        | <a id="positive"></a>`positive` | 10 | ✓ |
-        | <a id="zero"></a>`zero` | 16 | ✗ |
+        | Rule | Line | Positive coverage | Negative coverage |
+        | --- | --- | --- | --- |
+        | <a id="positive"></a>`positive` | 10 | ✓ | ✗ |
+        | <a id="zero"></a>`zero` | 16 | ✗ | ✗ |
     "#]]
     .assert_eq(&md);
 }
@@ -177,8 +183,8 @@ fn empty_rules_renders_no_rules_message() {
         line: 1,
         rules: vec![],
     };
-    let covered = BTreeSet::new();
-    let md = report::render_subpage(&j, &covered);
+    let cov = Coverage::default();
+    let md = report::render_subpage(&j, &cov);
     expect![[r#"
         # Judgment `lonely` at fixture.rs:1
 
@@ -217,4 +223,98 @@ fn jsonl_reader_tolerates_malformed_lines() {
     assert_eq!(names, vec![("j1", "r1"), ("j3", "r3")]);
 
     let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn jsonl_reads_negative_records_with_causes() {
+    let tmp = std::env::temp_dir().join(format!("formality-coverage-neg-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let path = tmp.join("test-coverage.jsonl");
+
+    // Mix of a positive record (no `kind` — back-compat) and two negative
+    // records that blame the same rule but with different causes.
+    let body = concat!(
+        r#"{"test_file":"a.rs","test_line":1,"test_column":1,"rules":[{"judgment":"j1","rule":"r1","file":"f.rs","line":10}]}"#,
+        "\n",
+        r#"{"test_file":"b.rs","test_line":2,"test_column":1,"kind":"negative","rules":[{"rule":"r1","file":"f.rs","line":10,"cause":"if_false"}]}"#,
+        "\n",
+        r#"{"test_file":"c.rs","test_line":3,"test_column":1,"kind":"negative","rules":[{"rule":"r1","file":"f.rs","line":10,"cause":"if_let"}]}"#,
+        "\n",
+    );
+    std::fs::write(&path, body).unwrap();
+
+    let cov = jsonl::read(&path).unwrap();
+    assert_eq!(cov.positive.len(), 1);
+    let causes = cov
+        .negative
+        .get(&BlamedRuleLoc {
+            rule: "r1".into(),
+            file: "f.rs".into(),
+            line: 10,
+        })
+        .expect("negative record should be present");
+    let causes: Vec<&str> = causes.iter().map(String::as_str).collect();
+    assert_eq!(causes, vec!["if_false", "if_let"]);
+
+    // The lookup matches by rule name + file suffix.
+    let causes = cov.negative_causes_for("f.rs", "r1");
+    let causes: Vec<&str> = causes.iter().map(String::as_str).collect();
+    assert_eq!(causes, vec!["if_false", "if_let"]);
+    // Different file should not match.
+    assert!(cov.negative_causes_for("other.rs", "r1").is_empty());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn negative_coverage_renders_in_subpage_with_causes() {
+    let j = Judgment {
+        name: "prove_thing".into(),
+        doc_comment: String::new(),
+        signature: String::new(),
+        file: "fixture.rs".into(),
+        line: 4,
+        rules: vec![
+            Rule {
+                name: "positive".into(),
+                raw_text: String::new(),
+                line: 10,
+            },
+            Rule {
+                name: "zero".into(),
+                raw_text: String::new(),
+                line: 16,
+            },
+        ],
+    };
+    let mut negative = BTreeMap::new();
+    let mut causes = BTreeSet::new();
+    causes.insert("if_false".to_string());
+    causes.insert("failed_judgment".to_string());
+    // `file` here is whatever the macro recorded — a path including the
+    // file basename. The matcher resolves it against the scraped
+    // judgment file via suffix overlap.
+    negative.insert(
+        BlamedRuleLoc {
+            rule: "positive".into(),
+            file: "crates/sub/fixture.rs".into(),
+            line: 11,
+        },
+        causes,
+    );
+    let cov = Coverage {
+        positive: BTreeSet::new(),
+        negative,
+    };
+
+    let md = report::render_subpage(&j, &cov);
+    expect![[r#"
+        # Judgment `prove_thing` at fixture.rs:4
+
+        | Rule | Line | Positive coverage | Negative coverage |
+        | --- | --- | --- | --- |
+        | <a id="positive"></a>`positive` | 10 | ✗ | ✓ (failed_judgment, if_false) |
+        | <a id="zero"></a>`zero` | 16 | ✗ | ✗ |
+    "#]]
+    .assert_eq(&md);
 }


### PR DESCRIPTION
## What does this PR do?

Follow-up to #366 and #374. Adds *negative* coverage tracking: whenever a test asserts a judgment fails (`assert_err` / `assert_err_leaves` / `FormalityTest::err`), we now walk the resulting `FailedJudgment`, collect every named rule that was "blamed" (survived cycle stripping and `!`-clause filtering, conclusion patterns matched, premise failed), and append a `"kind":"negative"` JSONL record next to the existing positive records.

## How does it work, what questions do you have?

The `formality-coverage` report grows a third **Negative coverage** column. Per-judgment subpages also show which `RuleFailureCause` discriminants were observed (e.g. `✓ (if_false, inapplicable)`), so you can see *which clause* of a rule failed.

## AI disclosure

* I used an AI to author the main logic of the code

