### PR TITLE
Add feature flag for non lifetime bound

### DIFF
--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -143,7 +143,6 @@ fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
                     bail!("non lifetime binders require #![feature(non_lifetime_binders)]");
                 }
             }
-            // TODO: impl, fn, adt, ..
             _ => {}
         }
     }

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -5,7 +5,9 @@ use std::fmt::Debug;
 use crate::prove::prove::{is_definitely_not_proveable, Constraints, Env, Program};
 use crate::rust::Visit;
 use crate::{
-    grammar::{Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData, Wcs},
+    grammar::{
+        Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData, Wcs,
+    },
     prove::ToWcs,
 };
 use anyhow::{anyhow, bail};
@@ -129,10 +131,16 @@ fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
     for item in c.items.iter() {
         match item {
             CrateItem::Trait(t) => {
-                let has_non_lifetime_binder = t.binder.explicit_binder.peek().where_clauses.iter().any(|wc| wc.has_non_lifetime_binder());
+                let has_non_lifetime_binder = t
+                    .binder
+                    .explicit_binder
+                    .peek()
+                    .where_clauses
+                    .iter()
+                    .any(|wc| wc.has_non_lifetime_binder());
 
                 if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
-                    bail!("non-lifetime binders require #![feature(non_lifetime_binders)");
+                    bail!("non lifetime binders require #![feature(non_lifetime_binders)]");
                 }
             }
             // TODO: impl, fn, adt, ..

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use crate::prove::prove::{is_definitely_not_proveable, Constraints, Env, Program};
 use crate::rust::Visit;
 use crate::{
-    grammar::{Crate, CrateId, CrateItem, Crates, Fallible, Test, TestBoundData, Wcs},
+    grammar::{Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData, Wcs},
     prove::ToWcs,
 };
 use anyhow::{anyhow, bail};
@@ -66,6 +66,7 @@ judgment_fn! {
 
         (
             (check_for_duplicate_items(program) => ())
+            (check_for_non_lifetime_binders(c) => ())
             (for_all(item in &c.items)
                 (check_crate_item(program, item, &c.id) => ()))
             (check_coherence(program, c) => ())
@@ -118,6 +119,28 @@ fn check_for_duplicate_items(program: &Program) -> Fallible<ProofTree> {
     Ok(ProofTree::leaf(
         "check_for_duplicate_items: no duplicates found",
     ))
+}
+
+fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
+    let is_non_lifetime_binder_enabled = c.items.iter().any(|item|
+        matches!(item, CrateItem::FeatureGate(fg) if fg.name == FeatureGateName::NonLifetimeBinders)
+    );
+
+    for item in c.items.iter() {
+        match item {
+            CrateItem::Trait(t) => {
+                let has_non_lifetime_binder = t.binder.explicit_binder.peek().where_clauses.iter().any(|wc| wc.has_non_lifetime_binder());
+
+                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
+                    bail!("non-lifetime binders require #![feature(non_lifetime_binders)");
+                }
+            }
+            // TODO: impl, fn, adt, ..
+            _ => {}
+        }
+    }
+
+    Ok(ProofTree::leaf("check_for_non_lifetime_binders: ok"))
 }
 
 judgment_fn! {

--- a/crates/formality-rust/src/grammar/feature.rs
+++ b/crates/formality-rust/src/grammar/feature.rs
@@ -10,4 +10,6 @@ pub struct FeatureGate {
 pub enum FeatureGateName {
     #[grammar(polonius_alpha)]
     PoloniusAlpha,
+    #[grammar(non_lifetime_binders)]
+    NonLifetimeBinders
 }

--- a/crates/formality-rust/src/grammar/feature.rs
+++ b/crates/formality-rust/src/grammar/feature.rs
@@ -11,5 +11,5 @@ pub enum FeatureGateName {
     #[grammar(polonius_alpha)]
     PoloniusAlpha,
     #[grammar(non_lifetime_binders)]
-    NonLifetimeBinders
+    NonLifetimeBinders,
 }

--- a/crates/formality-rust/src/grammar/traits_and_impls.rs
+++ b/crates/formality-rust/src/grammar/traits_and_impls.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use crate::grammar::{AliasTy, AssociatedItemId, Binder, Const, Fallible, Lt, Parameter, ParameterKind, Predicate, TraitId, TraitRef, Ty, Wc, Wcs};
+use crate::grammar::{
+    AliasTy, AssociatedItemId, Binder, Const, Fallible, Lt, Parameter, ParameterKind, Predicate,
+    TraitId, TraitRef, Ty, Wc, Wcs,
+};
 use crate::grammar::{Fn, Relation};
 use crate::prove::prove::Safety;
 use crate::rust::Term;
@@ -191,10 +194,13 @@ impl WhereClause {
     pub fn has_non_lifetime_binder(&self) -> bool {
         match self {
             WhereClause::ForAll(binder) => {
-                binder.kinds().iter().any(|kind| !matches!(kind, ParameterKind::Lt))
+                binder
+                    .kinds()
+                    .iter()
+                    .any(|kind| !matches!(kind, ParameterKind::Lt))
                     || binder.peek().has_non_lifetime_binder()
             }
-            _ => false
+            _ => false,
         }
     }
 }

--- a/crates/formality-rust/src/grammar/traits_and_impls.rs
+++ b/crates/formality-rust/src/grammar/traits_and_impls.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use crate::grammar::{
-    AliasTy, AssociatedItemId, Binder, Const, Fallible, Lt, Parameter, Predicate, TraitId,
-    TraitRef, Ty, Wc, Wcs,
-};
+use crate::grammar::{AliasTy, AssociatedItemId, Binder, Const, Fallible, Lt, Parameter, ParameterKind, Predicate, TraitId, TraitRef, Ty, Wc, Wcs};
 use crate::grammar::{Fn, Relation};
 use crate::prove::prove::Safety;
 use crate::rust::Term;
@@ -188,6 +185,16 @@ impl WhereClause {
                     .into_iter()
                     .collect()
             }
+        }
+    }
+
+    pub fn has_non_lifetime_binder(&self) -> bool {
+        match self {
+            WhereClause::ForAll(binder) => {
+                binder.kinds().iter().any(|kind| !matches!(kind, ParameterKind::Lt))
+                    || binder.peek().has_non_lifetime_binder()
+            }
+            _ => false
         }
     }
 }

--- a/crates/formality-rust/src/to_rust/feature_gate.rs
+++ b/crates/formality-rust/src/to_rust/feature_gate.rs
@@ -5,7 +5,7 @@ use crate::to_rust::syntax;
 pub fn lower_feature_gate(gate: &FeatureGate) -> Fallible<syntax::Attr> {
     let name = match gate.name {
         FeatureGateName::PoloniusAlpha => "polonius_alpha",
-        FeatureGateName::NonLifetimeBinders => "non_lifetime_binders"
+        FeatureGateName::NonLifetimeBinders => "non_lifetime_binders",
     };
     Ok(syntax::Attr::Feature(name.to_owned()))
 }

--- a/crates/formality-rust/src/to_rust/feature_gate.rs
+++ b/crates/formality-rust/src/to_rust/feature_gate.rs
@@ -5,6 +5,7 @@ use crate::to_rust::syntax;
 pub fn lower_feature_gate(gate: &FeatureGate) -> Fallible<syntax::Attr> {
     let name = match gate.name {
         FeatureGateName::PoloniusAlpha => "polonius_alpha",
+        FeatureGateName::NonLifetimeBinders => "non_lifetime_binders"
     };
     Ok(syntax::Attr::Feature(name.to_owned()))
 }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -94,12 +94,13 @@ fn basic_where_clauses_fail() {
 #[test]
 fn basic_where_clauses_fail_without_lifetime_binders_feature_flag() {
     FormalityTest::new(crates![crate core {
-                trait A<T> where T: B { }
+        trait A<T> where T: B { }
 
-                trait B { }
+        trait B { }
 
-                trait WellFormed where for<T> u32: A<T> { }
-            }]).err(expect_test::expect![[r#"
+        trait WellFormed where for<T> u32: A<T> { }
+    }])
+    .err(expect_test::expect![[r#"
                 the rule "check crate" at (mod.rs) failed because
                   non-lifetime binders require #![feature(non_lifetime_binders)"#]])
 }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -61,6 +61,7 @@ fn hello_world() {
 #[test]
 fn basic_where_clauses_pass() {
     FormalityTest::new(crates![crate core {
+        #![feature(non_lifetime_binders)]
         trait A<T> where T: B { }
 
         trait B { }
@@ -75,6 +76,7 @@ fn basic_where_clauses_pass() {
 #[test]
 fn basic_where_clauses_fail() {
     FormalityTest::new(crates![crate core {
+                #![feature(non_lifetime_binders)]
                 trait A<T> where T: B { }
 
                 trait B { }
@@ -87,6 +89,19 @@ fn basic_where_clauses_fail() {
 
             the rule "trait implied bound" at (prove_wc.rs) failed because
               expression evaluated to an empty collection: `decls.trait_invariants()`"#]])
+}
+
+#[test]
+fn basic_where_clauses_fail_without_lifetime_binders_feature_flag() {
+    FormalityTest::new(crates![crate core {
+                trait A<T> where T: B { }
+
+                trait B { }
+
+                trait WellFormed where for<T> u32: A<T> { }
+            }]).err(expect_test::expect![[r#"
+                the rule "check crate" at (mod.rs) failed because
+                  non-lifetime binders require #![feature(non_lifetime_binders)"#]])
 }
 
 #[test]

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -101,8 +101,8 @@ fn basic_where_clauses_fail_without_lifetime_binders_feature_flag() {
         trait WellFormed where for<T> u32: A<T> { }
     }])
     .err(expect_test::expect![[r#"
-                the rule "check crate" at (mod.rs) failed because
-                  non-lifetime binders require #![feature(non_lifetime_binders)"#]])
+        the rule "check crate" at (mod.rs) failed because
+          non lifetime binders require #![feature(non_lifetime_binders)]"#]])
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/rust-lang/a-mir-formality/issues/379

## How does it work, what questions do you have?

<!-- In your own words (**no LLM usage here**), explain the main idea of why it's correct. It's ok if you're not sure! Please include any questions you have. If you wish to use an LLM for translation, include the original as well as the translated version. Thanks! -->

Think title and the issue is self-explanatory but this checks if the `non_lifetime_bound` feature gate is there whenever lifetime parameters are used and rejects if it's not

I do have a question if the below matters at all? I looked to the surrounding `check_for_duplicate_items` for alot of inspiration and guidance on this. 
```rust
fn check_for_non_lifetime_binders(p: &Program) -> Fallible<ProofTree> {
    let Crates { crates } = p.program();
    //.. 
```

## AI disclosure

<!-- Remove the items that do not apply -->
* I used an AI tool for research, autocomplete, or in other minimal ways
* Other: (explain)

I had Claude initially point me to the relevant files, then looked at the surrounding code and worked on it. Finally, at the end I asked if it had any suggestions after looking at the issue but for the most part it just agreed with the choices. 

I did ask how to run it using rustc and it said to use `FORMALITY_RUN_RUSTC` (which worked) then pointed to the comment [here](https://github.com/rust-lang/a-mir-formality/blob/1f66a4773cb3c365efec27d801b9c66d71a48ab4/src/test_util.rs#L63)  but I do think it might be helpful to add it to the book [here](https://rust-lang.github.io/a-mir-formality/intro.html?search=#running-tests) because at first I was a little confused on how to reproduce it
