### PR TITLE
Add feature gate for non lifetime bound

### DIFF
--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -149,7 +149,6 @@ fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
                     bail!("non lifetime binders require #![feature(non_lifetime_binders)]");
                 }
             }
-            // TODO: impl, fn, adt, ..
             _ => {}
         }
     }

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -6,8 +6,7 @@ use crate::prove::prove::{is_definitely_not_proveable, Constraints, Env, Program
 use crate::rust::Visit;
 use crate::{
     grammar::{
-        Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData,
-        Wcs,
+        Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData, Wcs,
     },
     prove::ToWcs,
 };
@@ -136,7 +135,7 @@ fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
     );
 
     if is_non_lifetime_binder_enabled {
-        return Ok(ProofTree::leaf("check_for_non_lifetime_binders: ok"));
+        return Ok(ProofTree::leaf("check_for_non_lifetime_binders: feature enabled"));
     }
 
     if c.items.iter().any(item_has_non_lifetime_bind) {
@@ -149,15 +148,7 @@ fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
 fn item_has_non_lifetime_bind(item: &CrateItem) -> bool {
     let where_clauses = match item {
         CrateItem::Trait(t) => &t.binder.explicit_binder.peek().where_clauses,
-        CrateItem::AdtItem(adt) => {
-            return adt
-                .to_adt()
-                .binder
-                .peek()
-                .where_clauses
-                .iter()
-                .any(|wc| wc.has_non_lifetime_binder());
-        }
+        CrateItem::AdtItem(adt) => &adt.where_clauses(),
         CrateItem::TraitImpl(t) => &t.binder.peek().where_clauses,
         CrateItem::NegTraitImpl(nt) => &nt.binder.peek().where_clauses,
         CrateItem::Fn(f) => &f.binder.peek().where_clauses,

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -138,14 +138,14 @@ fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
         return Ok(ProofTree::leaf("check_for_non_lifetime_binders: feature enabled"));
     }
 
-    if c.items.iter().any(item_has_non_lifetime_bind) {
+    if c.items.iter().any(item_has_non_lifetime_binder) {
         bail!("non lifetime binders require #![feature(non_lifetime_binders)]");
     }
 
     Ok(ProofTree::leaf("check_for_non_lifetime_binders: ok"))
 }
 
-fn item_has_non_lifetime_bind(item: &CrateItem) -> bool {
+fn item_has_non_lifetime_binder(item: &CrateItem) -> bool {
     let where_clauses = match item {
         CrateItem::Trait(t) => &t.binder.explicit_binder.peek().where_clauses,
         CrateItem::AdtItem(adt) => &adt.where_clauses(),

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -5,7 +5,9 @@ use std::fmt::Debug;
 use crate::prove::prove::{is_definitely_not_proveable, Constraints, Env, Program};
 use crate::rust::Visit;
 use crate::{
-    grammar::{Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData, Wcs},
+    grammar::{
+        Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData, Wcs,
+    },
     prove::ToWcs,
 };
 use anyhow::{anyhow, bail};
@@ -135,10 +137,16 @@ fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
     for item in c.items.iter() {
         match item {
             CrateItem::Trait(t) => {
-                let has_non_lifetime_binder = t.binder.explicit_binder.peek().where_clauses.iter().any(|wc| wc.has_non_lifetime_binder());
+                let has_non_lifetime_binder = t
+                    .binder
+                    .explicit_binder
+                    .peek()
+                    .where_clauses
+                    .iter()
+                    .any(|wc| wc.has_non_lifetime_binder());
 
                 if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
-                    bail!("non-lifetime binders require #![feature(non_lifetime_binders)");
+                    bail!("non lifetime binders require #![feature(non_lifetime_binders)]");
                 }
             }
             // TODO: impl, fn, adt, ..

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -6,7 +6,7 @@ use crate::prove::prove::{is_definitely_not_proveable, Constraints, Env, Program
 use crate::rust::Visit;
 use crate::{
     grammar::{
-        Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData, Wcs,
+        AdtItem, Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData, Wcs,
     },
     prove::ToWcs,
 };
@@ -149,7 +149,57 @@ fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
                     bail!("non lifetime binders require #![feature(non_lifetime_binders)]");
                 }
             }
-            _ => {}
+            CrateItem::AdtItem(adt) => {
+                let has_non_lifetime_binder = adt
+                    .to_adt()
+                    .binder
+                    .peek()
+                    .where_clauses
+                    .iter()
+                    .any(|wc| wc.has_non_lifetime_binder());
+
+                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
+                    bail!("non lifetime binders require #![feature(non_lifetime_binder)]");
+                }
+            }
+            CrateItem::FeatureGate(_) => {}
+            CrateItem::TraitImpl(t) => {
+                let has_non_lifetime_binder = t
+                    .binder
+                    .peek()
+                    .where_clauses
+                    .iter()
+                    .any(|wc| wc.has_non_lifetime_binder());
+
+                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
+                    bail!("non lifetime binders require #![feature(non_lifetime_binder)]");
+                }
+            }
+            CrateItem::NegTraitImpl(nt) => {
+                let has_non_lifetime_binder = nt
+                    .binder
+                    .peek()
+                    .where_clauses
+                    .iter()
+                    .any(|wc| wc.has_non_lifetime_binder());
+
+                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
+                    bail!("non lifetime binders require #![feature(non_lifetime_binder)]");
+                }
+            }
+            CrateItem::Fn(f) => {
+                let has_non_lifetime_binder = f
+                    .binder
+                    .peek()
+                    .where_clauses
+                    .iter()
+                    .any(|wc| wc.has_non_lifetime_binder());
+
+                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
+                    bail!("non lifetime binders require #![feature(non_lifetime_binders)]");
+                }
+            }
+            CrateItem::Test(_) => {}
         }
     }
 

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -135,7 +135,9 @@ fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
     );
 
     if is_non_lifetime_binder_enabled {
-        return Ok(ProofTree::leaf("check_for_non_lifetime_binders: feature enabled"));
+        return Ok(ProofTree::leaf(
+            "check_for_non_lifetime_binders: feature enabled",
+        ));
     }
 
     if c.items.iter().any(item_has_non_lifetime_binder) {

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use crate::prove::prove::{is_definitely_not_proveable, Constraints, Env, Program};
 use crate::rust::Visit;
 use crate::{
-    grammar::{Crate, CrateId, CrateItem, Crates, Fallible, Test, TestBoundData, Wcs},
+    grammar::{Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData, Wcs},
     prove::ToWcs,
 };
 use anyhow::{anyhow, bail};
@@ -66,6 +66,7 @@ judgment_fn! {
 
         (
             (check_for_duplicate_items(program) => ())
+            (check_for_non_lifetime_binders(c) => ())
             (for_all(item in &c.items)
                 (check_crate_item(program, item, &c.id) => ()))
             (check_coherence(program, c) => ())
@@ -124,6 +125,28 @@ fn check_for_duplicate_items(program: &Program) -> Fallible<ProofTree> {
     Ok(ProofTree::leaf(
         "check_for_duplicate_items: no duplicates found",
     ))
+}
+
+fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
+    let is_non_lifetime_binder_enabled = c.items.iter().any(|item|
+        matches!(item, CrateItem::FeatureGate(fg) if fg.name == FeatureGateName::NonLifetimeBinders)
+    );
+
+    for item in c.items.iter() {
+        match item {
+            CrateItem::Trait(t) => {
+                let has_non_lifetime_binder = t.binder.explicit_binder.peek().where_clauses.iter().any(|wc| wc.has_non_lifetime_binder());
+
+                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
+                    bail!("non-lifetime binders require #![feature(non_lifetime_binders)");
+                }
+            }
+            // TODO: impl, fn, adt, ..
+            _ => {}
+        }
+    }
+
+    Ok(ProofTree::leaf("check_for_non_lifetime_binders: ok"))
 }
 
 judgment_fn! {

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -6,7 +6,8 @@ use crate::prove::prove::{is_definitely_not_proveable, Constraints, Env, Program
 use crate::rust::Visit;
 use crate::{
     grammar::{
-        AdtItem, Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData, Wcs,
+        Crate, CrateId, CrateItem, Crates, Fallible, FeatureGateName, Test, TestBoundData,
+        Wcs,
     },
     prove::ToWcs,
 };
@@ -134,76 +135,36 @@ fn check_for_non_lifetime_binders(c: &Crate) -> Fallible<ProofTree> {
         matches!(item, CrateItem::FeatureGate(fg) if fg.name == FeatureGateName::NonLifetimeBinders)
     );
 
-    for item in c.items.iter() {
-        match item {
-            CrateItem::Trait(t) => {
-                let has_non_lifetime_binder = t
-                    .binder
-                    .explicit_binder
-                    .peek()
-                    .where_clauses
-                    .iter()
-                    .any(|wc| wc.has_non_lifetime_binder());
+    if is_non_lifetime_binder_enabled {
+        return Ok(ProofTree::leaf("check_for_non_lifetime_binders: ok"));
+    }
 
-                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
-                    bail!("non lifetime binders require #![feature(non_lifetime_binders)]");
-                }
-            }
-            CrateItem::AdtItem(adt) => {
-                let has_non_lifetime_binder = adt
-                    .to_adt()
-                    .binder
-                    .peek()
-                    .where_clauses
-                    .iter()
-                    .any(|wc| wc.has_non_lifetime_binder());
-
-                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
-                    bail!("non lifetime binders require #![feature(non_lifetime_binder)]");
-                }
-            }
-            CrateItem::FeatureGate(_) => {}
-            CrateItem::TraitImpl(t) => {
-                let has_non_lifetime_binder = t
-                    .binder
-                    .peek()
-                    .where_clauses
-                    .iter()
-                    .any(|wc| wc.has_non_lifetime_binder());
-
-                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
-                    bail!("non lifetime binders require #![feature(non_lifetime_binder)]");
-                }
-            }
-            CrateItem::NegTraitImpl(nt) => {
-                let has_non_lifetime_binder = nt
-                    .binder
-                    .peek()
-                    .where_clauses
-                    .iter()
-                    .any(|wc| wc.has_non_lifetime_binder());
-
-                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
-                    bail!("non lifetime binders require #![feature(non_lifetime_binder)]");
-                }
-            }
-            CrateItem::Fn(f) => {
-                let has_non_lifetime_binder = f
-                    .binder
-                    .peek()
-                    .where_clauses
-                    .iter()
-                    .any(|wc| wc.has_non_lifetime_binder());
-
-                if !is_non_lifetime_binder_enabled && has_non_lifetime_binder {
-                    bail!("non lifetime binders require #![feature(non_lifetime_binders)]");
-                }
-            }
-            CrateItem::Test(_) => {}
-        }
+    if c.items.iter().any(item_has_non_lifetime_bind) {
+        bail!("non lifetime binders require #![feature(non_lifetime_binders)]");
     }
 
     Ok(ProofTree::leaf("check_for_non_lifetime_binders: ok"))
+}
+
+fn item_has_non_lifetime_bind(item: &CrateItem) -> bool {
+    let where_clauses = match item {
+        CrateItem::Trait(t) => &t.binder.explicit_binder.peek().where_clauses,
+        CrateItem::AdtItem(adt) => {
+            return adt
+                .to_adt()
+                .binder
+                .peek()
+                .where_clauses
+                .iter()
+                .any(|wc| wc.has_non_lifetime_binder());
+        }
+        CrateItem::TraitImpl(t) => &t.binder.peek().where_clauses,
+        CrateItem::NegTraitImpl(nt) => &nt.binder.peek().where_clauses,
+        CrateItem::Fn(f) => &f.binder.peek().where_clauses,
+        CrateItem::FeatureGate(_) | CrateItem::Test(_) => return false,
+    };
+
+    where_clauses.iter().any(|wc| wc.has_non_lifetime_binder())
 }
 
 judgment_fn! {

--- a/crates/formality-rust/src/grammar/crates.rs
+++ b/crates/formality-rust/src/grammar/crates.rs
@@ -53,6 +53,13 @@ impl AdtItem {
             AdtItem::Enum(e) => e.to_adt(),
         }
     }
+
+    pub fn where_clauses(&self) -> &Vec<WhereClause> {
+        match self {
+            AdtItem::Struct(s) => &s.binder.peek().where_clauses,
+            AdtItem::Enum(e) => &e.binder.peek().where_clauses,
+        }
+    }
 }
 
 #[term(test $binder)]

--- a/crates/formality-rust/src/grammar/feature.rs
+++ b/crates/formality-rust/src/grammar/feature.rs
@@ -10,4 +10,6 @@ pub struct FeatureGate {
 pub enum FeatureGateName {
     #[grammar(polonius_alpha)]
     PoloniusAlpha,
+    #[grammar(non_lifetime_binders)]
+    NonLifetimeBinders
 }

--- a/crates/formality-rust/src/grammar/feature.rs
+++ b/crates/formality-rust/src/grammar/feature.rs
@@ -11,5 +11,5 @@ pub enum FeatureGateName {
     #[grammar(polonius_alpha)]
     PoloniusAlpha,
     #[grammar(non_lifetime_binders)]
-    NonLifetimeBinders
+    NonLifetimeBinders,
 }

--- a/crates/formality-rust/src/grammar/traits_and_impls.rs
+++ b/crates/formality-rust/src/grammar/traits_and_impls.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use crate::grammar::{AliasTy, AssociatedItemId, Binder, Const, Fallible, Lt, Parameter, ParameterKind, Predicate, TraitId, TraitRef, Ty, Wc, Wcs};
+use crate::grammar::{
+    AliasTy, AssociatedItemId, Binder, Const, Fallible, Lt, Parameter, ParameterKind, Predicate,
+    TraitId, TraitRef, Ty, Wc, Wcs,
+};
 use crate::grammar::{Fn, Relation};
 use crate::prove::prove::Safety;
 use crate::rust::Term;
@@ -191,10 +194,13 @@ impl WhereClause {
     pub fn has_non_lifetime_binder(&self) -> bool {
         match self {
             WhereClause::ForAll(binder) => {
-                binder.kinds().iter().any(|kind| !matches!(kind, ParameterKind::Lt))
+                binder
+                    .kinds()
+                    .iter()
+                    .any(|kind| !matches!(kind, ParameterKind::Lt))
                     || binder.peek().has_non_lifetime_binder()
             }
-            _ => false
+            _ => false,
         }
     }
 }

--- a/crates/formality-rust/src/grammar/traits_and_impls.rs
+++ b/crates/formality-rust/src/grammar/traits_and_impls.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
-use crate::grammar::{
-    AliasTy, AssociatedItemId, Binder, Const, Fallible, Lt, Parameter, Predicate, TraitId,
-    TraitRef, Ty, Wc, Wcs,
-};
+use crate::grammar::{AliasTy, AssociatedItemId, Binder, Const, Fallible, Lt, Parameter, ParameterKind, Predicate, TraitId, TraitRef, Ty, Wc, Wcs};
 use crate::grammar::{Fn, Relation};
 use crate::prove::prove::Safety;
 use crate::rust::Term;
@@ -188,6 +185,16 @@ impl WhereClause {
                     .into_iter()
                     .collect()
             }
+        }
+    }
+
+    pub fn has_non_lifetime_binder(&self) -> bool {
+        match self {
+            WhereClause::ForAll(binder) => {
+                binder.kinds().iter().any(|kind| !matches!(kind, ParameterKind::Lt))
+                    || binder.peek().has_non_lifetime_binder()
+            }
+            _ => false
         }
     }
 }

--- a/crates/formality-rust/src/to_rust/feature_gate.rs
+++ b/crates/formality-rust/src/to_rust/feature_gate.rs
@@ -5,7 +5,7 @@ use crate::to_rust::syntax;
 pub fn lower_feature_gate(gate: &FeatureGate) -> Fallible<syntax::Attr> {
     let name = match gate.name {
         FeatureGateName::PoloniusAlpha => "polonius_alpha",
-        FeatureGateName::NonLifetimeBinders => "non_lifetime_binders"
+        FeatureGateName::NonLifetimeBinders => "non_lifetime_binders",
     };
     Ok(syntax::Attr::Feature(name.to_owned()))
 }

--- a/crates/formality-rust/src/to_rust/feature_gate.rs
+++ b/crates/formality-rust/src/to_rust/feature_gate.rs
@@ -5,6 +5,7 @@ use crate::to_rust::syntax;
 pub fn lower_feature_gate(gate: &FeatureGate) -> Fallible<syntax::Attr> {
     let name = match gate.name {
         FeatureGateName::PoloniusAlpha => "polonius_alpha",
+        FeatureGateName::NonLifetimeBinders => "non_lifetime_binders"
     };
     Ok(syntax::Attr::Feature(name.to_owned()))
 }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -94,12 +94,13 @@ fn basic_where_clauses_fail() {
 #[test]
 fn basic_where_clauses_fail_without_lifetime_binders_feature_flag() {
     FormalityTest::new(crates![crate core {
-                trait A<T> where T: B { }
+        trait A<T> where T: B { }
 
-                trait B { }
+        trait B { }
 
-                trait WellFormed where for<T> u32: A<T> { }
-            }]).err(expect_test::expect![[r#"
+        trait WellFormed where for<T> u32: A<T> { }
+    }])
+    .err(expect_test::expect![[r#"
                 the rule "check crate" at (mod.rs) failed because
                   non-lifetime binders require #![feature(non_lifetime_binders)"#]])
 }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -61,6 +61,7 @@ fn hello_world() {
 #[test]
 fn basic_where_clauses_pass() {
     FormalityTest::new(crates![crate core {
+        #![feature(non_lifetime_binders)]
         trait A<T> where T: B { }
 
         trait B { }
@@ -75,6 +76,7 @@ fn basic_where_clauses_pass() {
 #[test]
 fn basic_where_clauses_fail() {
     FormalityTest::new(crates![crate core {
+                #![feature(non_lifetime_binders)]
                 trait A<T> where T: B { }
 
                 trait B { }
@@ -87,6 +89,19 @@ fn basic_where_clauses_fail() {
 
             the rule "trait implied bound" at (prove_wc.rs) failed because
               expression evaluated to an empty collection: `decls.trait_invariants()`"#]])
+}
+
+#[test]
+fn basic_where_clauses_fail_without_lifetime_binders_feature_flag() {
+    FormalityTest::new(crates![crate core {
+                trait A<T> where T: B { }
+
+                trait B { }
+
+                trait WellFormed where for<T> u32: A<T> { }
+            }]).err(expect_test::expect![[r#"
+                the rule "check crate" at (mod.rs) failed because
+                  non-lifetime binders require #![feature(non_lifetime_binders)"#]])
 }
 
 #[test]

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -101,8 +101,8 @@ fn basic_where_clauses_fail_without_lifetime_binders_feature_flag() {
         trait WellFormed where for<T> u32: A<T> { }
     }])
     .err(expect_test::expect![[r#"
-                the rule "check crate" at (mod.rs) failed because
-                  non-lifetime binders require #![feature(non_lifetime_binders)"#]])
+        the rule "check crate" at (mod.rs) failed because
+          non lifetime binders require #![feature(non_lifetime_binders)]"#]])
 }
 
 #[test]

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -145,8 +145,8 @@ fn non_lifetime_binder_in_trait_impl_where_clause_pass() {
 
         impl<T> B for T where for<U> u32: A<U> { }
     }])
-        .skip_execute()
-        .ok()
+    .skip_execute()
+    .ok()
 }
 
 #[test]
@@ -158,9 +158,9 @@ fn non_lifetime_binder_in_trait_impl_where_clause_fail() {
 
         impl<T> B for T where for<U> u32: A<U> { }
     }])
-        .err(expect_test::expect![[r#"
-            the rule "check crate" at (mod.rs) failed because
-              non lifetime binders require #![feature(non_lifetime_binder)]"#]])
+    .err(expect_test::expect![[r#"
+        the rule "check crate" at (mod.rs) failed because
+          non lifetime binders require #![feature(non_lifetime_binders)]"#]])
 }
 
 #[test]
@@ -175,8 +175,8 @@ fn non_lifetime_binder_in_neg_trait_impl_where_clause_pass() {
 
         impl <T> B for T {}
     }])
-        .skip_execute()
-        .ok()
+    .skip_execute()
+    .ok()
 }
 
 #[test]
@@ -188,9 +188,9 @@ fn non_lifetime_binder_in_neg_trait_impl_where_clause_fail() {
 
         impl<T> !A<T> for u32 where for<U> u32: A<U> { }
     }])
-        .err(expect_test::expect![[r#"
-            the rule "check crate" at (mod.rs) failed because
-              non lifetime binders require #![feature(non_lifetime_binder)]"#]])
+    .err(expect_test::expect![[r#"
+        the rule "check crate" at (mod.rs) failed because
+          non lifetime binders require #![feature(non_lifetime_binders)]"#]])
 }
 
 #[test]
@@ -205,8 +205,8 @@ fn non_lifetime_binder_in_enum_where_clause_pass() {
 
         impl <T> B for T {}
     }])
-        .skip_execute()
-        .ok()
+    .skip_execute()
+    .ok()
 }
 
 #[test]
@@ -218,9 +218,9 @@ fn non_lifetime_binder_in_enum_where_clause_fail() {
 
         enum E where for<U> u32: A<U> { }
     }])
-        .err(expect_test::expect![[r#"
-            the rule "check crate" at (mod.rs) failed because
-              non lifetime binders require #![feature(non_lifetime_binder)]"#]])
+    .err(expect_test::expect![[r#"
+        the rule "check crate" at (mod.rs) failed because
+          non lifetime binders require #![feature(non_lifetime_binders)]"#]])
 }
 
 #[test]
@@ -235,8 +235,8 @@ fn non_lifetime_binder_in_struct_where_clause_pass() {
 
         impl <T> B for T {}
     }])
-        .skip_execute()
-        .ok()
+    .skip_execute()
+    .ok()
 }
 
 #[test]
@@ -248,9 +248,9 @@ fn non_lifetime_binder_in_struct_where_clause_fail() {
 
         struct S<T> where for<U> u32: A<U> { }
     }])
-        .err(expect_test::expect![[r#"
-            the rule "check crate" at (mod.rs) failed because
-              non lifetime binders require #![feature(non_lifetime_binder)]"#]])
+    .err(expect_test::expect![[r#"
+        the rule "check crate" at (mod.rs) failed because
+          non lifetime binders require #![feature(non_lifetime_binders)]"#]])
 }
 
 #[test]

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -254,6 +254,19 @@ fn non_lifetime_binder_in_struct_where_clause_fail() {
 }
 
 #[test]
+fn lifetime_binder_in_where_clause_without_feature_pass() {
+    FormalityTest::new(crates![crate core {
+        trait A<'b> { }
+
+        impl<'b> A<'b> for u32 { }
+
+        trait WellFormed where for<'b> u32: A<'b> { }
+    }])
+    .skip_execute()
+    .ok()
+}
+
+#[test]
 fn basic_adt_variant_dup() {
     FormalityTest::new(crates![crate Foo {
         enum Bar {

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -92,7 +92,7 @@ fn basic_where_clauses_fail() {
 }
 
 #[test]
-fn basic_where_clauses_fail_without_lifetime_binders_feature_flag() {
+fn basic_where_clauses_without_lifetime_binders_feature_flag_fail() {
     FormalityTest::new(crates![crate core {
         trait A<T> where T: B { }
 
@@ -103,6 +103,154 @@ fn basic_where_clauses_fail_without_lifetime_binders_feature_flag() {
     .err(expect_test::expect![[r#"
         the rule "check crate" at (mod.rs) failed because
           non lifetime binders require #![feature(non_lifetime_binders)]"#]])
+}
+
+#[test]
+fn non_lifetime_binder_in_fn_where_clause_pass() {
+    FormalityTest::new(crates![crate core {
+        #![feature(non_lifetime_binders)]
+        trait A<T> where T: B { }
+
+        trait B { }
+
+        fn foo() -> () where for<T> u32: A<T> { trusted }
+
+        impl <T> B for T {}
+    }])
+    .skip_execute()
+    .ok()
+}
+
+#[test]
+fn non_lifetime_binder_in_fn_where_clause_fail() {
+    FormalityTest::new(crates![crate core {
+        trait A<T> where T: B { }
+
+        trait B { }
+
+        fn foo() -> () where for<T> u32: A<T> { trusted }
+    }])
+    .err(expect_test::expect![[r#"
+        the rule "check crate" at (mod.rs) failed because
+          non lifetime binders require #![feature(non_lifetime_binders)]"#]])
+}
+
+#[test]
+fn non_lifetime_binder_in_trait_impl_where_clause_pass() {
+    FormalityTest::new(crates![crate core {
+        #![feature(non_lifetime_binders)]
+        trait A<T> where T: B { }
+
+        trait B { }
+
+        impl<T> B for T where for<U> u32: A<U> { }
+    }])
+        .skip_execute()
+        .ok()
+}
+
+#[test]
+fn non_lifetime_binder_in_trait_impl_where_clause_fail() {
+    FormalityTest::new(crates![crate core {
+        trait A<T> where T: B { }
+
+        trait B { }
+
+        impl<T> B for T where for<U> u32: A<U> { }
+    }])
+        .err(expect_test::expect![[r#"
+            the rule "check crate" at (mod.rs) failed because
+              non lifetime binders require #![feature(non_lifetime_binder)]"#]])
+}
+
+#[test]
+fn non_lifetime_binder_in_neg_trait_impl_where_clause_pass() {
+    FormalityTest::new(crates![crate core {
+        #![feature(non_lifetime_binders)]
+        trait A<T> where T: B { }
+
+        trait B { }
+
+        impl<T> !A<T> for u32 where for<U> u32: A<U> { }
+
+        impl <T> B for T {}
+    }])
+        .skip_execute()
+        .ok()
+}
+
+#[test]
+fn non_lifetime_binder_in_neg_trait_impl_where_clause_fail() {
+    FormalityTest::new(crates![crate core {
+        trait A<T> where T: B { }
+
+        trait B { }
+
+        impl<T> !A<T> for u32 where for<U> u32: A<U> { }
+    }])
+        .err(expect_test::expect![[r#"
+            the rule "check crate" at (mod.rs) failed because
+              non lifetime binders require #![feature(non_lifetime_binder)]"#]])
+}
+
+#[test]
+fn non_lifetime_binder_in_enum_where_clause_pass() {
+    FormalityTest::new(crates![crate core {
+        #![feature(non_lifetime_binders)]
+        trait A<T> where T: B { }
+
+        trait B { }
+
+        enum E where for<U> u32: A<U> { }
+
+        impl <T> B for T {}
+    }])
+        .skip_execute()
+        .ok()
+}
+
+#[test]
+fn non_lifetime_binder_in_enum_where_clause_fail() {
+    FormalityTest::new(crates![crate core {
+        trait A<T> where T: B { }
+
+        trait B { }
+
+        enum E where for<U> u32: A<U> { }
+    }])
+        .err(expect_test::expect![[r#"
+            the rule "check crate" at (mod.rs) failed because
+              non lifetime binders require #![feature(non_lifetime_binder)]"#]])
+}
+
+#[test]
+fn non_lifetime_binder_in_struct_where_clause_pass() {
+    FormalityTest::new(crates![crate core {
+        #![feature(non_lifetime_binders)]
+        trait A<T> where T: B { }
+
+        trait B { }
+
+        struct S<T> where for<U> u32: A<U> { }
+
+        impl <T> B for T {}
+    }])
+        .skip_execute()
+        .ok()
+}
+
+#[test]
+fn non_lifetime_binder_in_struct_where_clause_fail() {
+    FormalityTest::new(crates![crate core {
+        trait A<T> where T: B { }
+
+        trait B { }
+
+        struct S<T> where for<U> u32: A<U> { }
+    }])
+        .err(expect_test::expect![[r#"
+            the rule "check crate" at (mod.rs) failed because
+              non lifetime binders require #![feature(non_lifetime_binder)]"#]])
 }
 
 #[test]


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/rust-lang/a-mir-formality/issues/379. Closed https://github.com/rust-lang/a-mir-formality/pull/397 because I realized that's off my local main 🤦‍♂️ 

## How does it work, what questions do you have?

<!-- In your own words (**no LLM usage here**), explain the main idea of why it's correct. It's ok if you're not sure! Please include any questions you have. If you wish to use an LLM for translation, include the original as well as the translated version. Thanks! -->

Think title and the issue is self-explanatory but this checks if the `non_lifetime_bound` feature gate is there whenever lifetime parameters are used and rejects if it's not

I do have a question if the below matters at all? I looked to the surrounding `check_for_duplicate_items` for alot of inspiration and guidance on this. 
```rust
fn check_for_non_lifetime_binders(p: &Program) -> Fallible<ProofTree> {
    let Crates { crates } = p.program();
    //.. 
```

## AI disclosure

<!-- Remove the items that do not apply -->

* I used an AI tool for research, autocomplete, or in other minimal ways
* Other: (explain)

I had Claude initially point me to the relevant files, then looked at the surrounding code and worked on it. Finally, at the end I asked if it had any suggestions after looking at the issue but for the most part it just agreed with the choices but that might just be an LLM being an LLM.

I did ask how to run it using rustc and it said to use `FORMALITY_RUN_RUSTC` (which worked) then pointed to the comment [here](https://github.com/rust-lang/a-mir-formality/blob/1f66a4773cb3c365efec27d801b9c66d71a48ab4/src/test_util.rs#L63)  but I do think it might be helpful to add it to the book [here](https://rust-lang.github.io/a-mir-formality/intro.html?search=#running-tests) because at first I was a little confused on how to reproduce it
