### PR TITLE
Allow implicitly returning ()

### DIFF
--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -388,6 +388,8 @@ judgment_fn! {
             (let FnBoundData { input_args, output_ty, where_clauses, body: _ } =
                 binder.instantiate_with(parameters)?)
 
+            (let output_ty : crate::grammar::Ty = output_ty.into())
+
             // Check argument count matches
             (let input_tys: Vec<Ty> = input_args.iter().map(|a| a.ty.clone()).collect())
             (if input_tys.len() == args.len())

--- a/crates/formality-rust/src/check/fns.rs
+++ b/crates/formality-rust/src/check/fns.rs
@@ -47,6 +47,7 @@ judgment_fn! {
         (
             (let (env, bound_data) = env.instantiate_universally(&f.binder))
             (let FnBoundData { input_args, output_ty, where_clauses, body } = bound_data)
+            (let output_ty : crate::grammar::Ty = output_ty.into())
             (let assumptions: Wcs = (assumptions, where_clauses).to_wcs())
             (prove_where_clauses_well_formed(program, env, assumptions, where_clauses) => ())
             (for_all(input_arg in input_args)

--- a/crates/formality-rust/src/check/impls.rs
+++ b/crates/formality-rust/src/check/impls.rs
@@ -195,6 +195,9 @@ judgment_fn! {
             (let FnBoundData { input_args: ii_input_args, output_ty: ii_output_ty, where_clauses: ii_where_clauses, body: _ } = ii_bound)
             (let FnBoundData { input_args: ti_input_args, output_ty: ti_output_ty, where_clauses: ti_where_clauses, body: _ } = ti_bound)
 
+            (let ii_output_ty : crate::grammar::Ty = ii_output_ty.into())
+            (let ti_output_ty : crate::grammar::Ty = ti_output_ty.into())
+
             // Prove impl where-clauses follow from trait where-clauses
             (super::prove_goal(program, &env, (&impl_assumptions, &ti_where_clauses), &ii_where_clauses) => ())
 

--- a/crates/formality-rust/src/grammar/fns.rs
+++ b/crates/formality-rust/src/grammar/fns.rs
@@ -48,7 +48,7 @@ pub enum MaybeReturnType {
     Empty,
 
     #[grammar(-> $v0)]
-    Specified(Ty)
+    Specified(Ty),
 }
 
 impl From<MaybeReturnType> for Ty {

--- a/crates/formality-rust/src/grammar/fns.rs
+++ b/crates/formality-rust/src/grammar/fns.rs
@@ -10,10 +10,10 @@ pub struct Fn {
     pub binder: Binder<FnBoundData>,
 }
 
-#[term($(input_args) -> $output_ty $:where $,where_clauses $body)]
+#[term($(input_args) $output_ty $:where $,where_clauses $body)]
 pub struct FnBoundData {
     pub input_args: Vec<InputArg>,
-    pub output_ty: Ty,
+    pub output_ty: MaybeReturnType,
     pub where_clauses: Vec<WhereClause>,
     pub body: MaybeFnBody,
 }
@@ -40,4 +40,31 @@ pub enum FnBody {
 
     #[cast]
     Expr(Block),
+}
+
+#[term]
+pub enum MaybeReturnType {
+    #[grammar()]
+    Empty,
+
+    #[grammar(-> $v0)]
+    Specified(Ty)
+}
+
+impl From<MaybeReturnType> for Ty {
+    fn from(value: MaybeReturnType) -> Self {
+        match value {
+            MaybeReturnType::Specified(ty) => ty,
+            MaybeReturnType::Empty => Ty::unit(),
+        }
+    }
+}
+
+impl From<&MaybeReturnType> for Ty {
+    fn from(value: &MaybeReturnType) -> Self {
+        match value {
+            MaybeReturnType::Specified(ty) => ty.clone(),
+            MaybeReturnType::Empty => Ty::unit(),
+        }
+    }
 }

--- a/crates/formality-rust/src/to_rust/fns.rs
+++ b/crates/formality-rust/src/to_rust/fns.rs
@@ -19,7 +19,7 @@ pub fn lower_fn(
         .iter()
         .map(|arg| lower_fn_param(ctx, arg))
         .collect::<Result<Vec<_>, _>>()?;
-    let return_ty = tys::lower_ty(ctx, &term.output_ty)?;
+    let return_ty = tys::lower_ty(ctx, &term.output_ty.into())?;
     let body = lower_fn_body(ctx, &term.body)?;
 
     Ok(syntax::FunctionItem {

--- a/tests/no_return_type.rs
+++ b/tests/no_return_type.rs
@@ -1,0 +1,19 @@
+use a_mir_formality::{crates, FormalityTest};
+
+#[test]
+fn explicit_void() {
+    FormalityTest::new(crates![crate Foo {
+        fn foo() -> () {
+        }
+    }])
+    .ok()
+}
+
+#[test]
+fn implicit_void() {
+    FormalityTest::new(crates![crate Foo {
+        fn foo() {
+        }
+    }])
+    .ok()
+}

--- a/tests/output_type.rs
+++ b/tests/output_type.rs
@@ -1,7 +1,7 @@
 use a_mir_formality::{crates, FormalityTest};
 
 #[test]
-fn explicit_void() {
+fn explicit_return_type() {
     FormalityTest::new(crates![crate Foo {
         fn foo() -> () {
         }
@@ -10,7 +10,7 @@ fn explicit_void() {
 }
 
 #[test]
-fn implicit_void() {
+fn implicit_return_type() {
     FormalityTest::new(crates![crate Foo {
         fn foo() {
         }


### PR DESCRIPTION
## What does this PR do?

May close #393 

## How does it work, what questions do you have?

<!-- In your own words (**no LLM usage here**), explain the main idea of why it's correct. It's ok if you're not sure! Please include any questions you have. If you wish to use an LLM for translation, include the original as well as the translated version. Thanks! -->

The tests pass and look reasonable, but I'm not sure if there's a way to avoid having to manually convert to create the unit type. Names such as `output_ty` should possibly have been changed to something like `maybe_output_ty` before the conversion.

## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools
