### PR TITLE
Add clickable test links

### DIFF
--- a/crates/formality-coverage/src/bin/formality-coverage.rs
+++ b/crates/formality-coverage/src/bin/formality-coverage.rs
@@ -21,6 +21,12 @@ struct Args {
     /// Directory where the markdown report will be written.
     #[arg(long, default_value = "target/coverage-report")]
     out_dir: PathBuf,
+
+    /// Base URL for test links, e.g.
+    /// `https://github.com/rust-lang/a-mir-formality/blob/main`. When omitted,
+    /// ✓ marks render as plain text instead of links.
+    #[arg(long)]
+    github_base: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -38,7 +44,8 @@ fn main() -> Result<()> {
 
     let positive_count = cov.positive.len();
     let negative_premise_count = cov.negative_premises.len();
-    report::write_all(&args.out_dir, &judgments, &cov)?;
+    let github_base = args.github_base.as_deref().map(|s| s.trim_end_matches('/'));
+    report::write_all(&args.out_dir, &judgments, &cov, github_base)?;
     eprintln!(
         "wrote {} judgments ({} positive rules, {} negatively-tested premises) to {}",
         judgments.len(),

--- a/crates/formality-coverage/src/jsonl.rs
+++ b/crates/formality-coverage/src/jsonl.rs
@@ -18,6 +18,14 @@ pub struct CoveredRule {
     pub rule: String,
 }
 
+/// The source location of a `#[test]` that exercised some rule. Lets the report
+/// turn a ✓ into a link to the test on GitHub.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct TestLoc {
+    pub file: String,
+    pub line: u32,
+}
+
 /// The source location of a premise that failed in some negative test. The
 /// `file`/`line` come from the macro respanning the failure onto the failing
 /// premise, so they match the premise's position in the judgment source.
@@ -38,8 +46,9 @@ pub struct NoApplicableRuleLoc {
 /// Aggregated coverage data from a JSONL file.
 #[derive(Default, Debug)]
 pub struct Coverage {
-    /// `(judgment, rule)` pairs that fired in at least one positive test.
-    pub positive: BTreeSet<CoveredRule>,
+    /// `(judgment, rule)` pairs that fired in at least one positive test, each
+    /// mapped to the test locations that exercised them.
+    pub positive: BTreeMap<CoveredRule, BTreeSet<TestLoc>>,
     /// Each failing-premise location with the set of clause-cause tags observed.
     pub negative_premises: BTreeMap<PremiseLoc, BTreeSet<String>>,
     /// Judgments observed to fail with no applicable rule.
@@ -59,6 +68,14 @@ impl Coverage {
             }
         }
         out
+    }
+
+    /// Test locations that exercised rule `rule` of `judgment`, if any fired.
+    pub fn positive_tests(&self, judgment: &str, rule: &str) -> Option<&BTreeSet<TestLoc>> {
+        self.positive.get(&CoveredRule {
+            judgment: judgment.to_string(),
+            rule: rule.to_string(),
+        })
     }
 
     /// True if `judgment_name` (in a file overlapping `judgment_file`) was
@@ -103,19 +120,32 @@ pub fn read(path: &Path) -> Result<Coverage> {
     Ok(cov)
 }
 
-/// Back-compat wrapper for tools that only want the positive set.
+/// Back-compat wrapper for tools that only want the set of covered rules,
+/// without their test locations.
 pub fn read_positive(path: &Path) -> Result<BTreeSet<CoveredRule>> {
-    Ok(read(path)?.positive)
+    Ok(read(path)?.positive.into_keys().collect())
 }
 
 fn ingest(record: CoverageRecord, cov: &mut Coverage) {
     match record {
-        CoverageRecord::Positive { rules, .. } => {
+        CoverageRecord::Positive {
+            test_file,
+            test_line,
+            rules,
+            ..
+        } => {
+            let loc = TestLoc {
+                file: test_file,
+                line: test_line,
+            };
             for r in rules {
-                cov.positive.insert(CoveredRule {
-                    judgment: r.judgment,
-                    rule: r.rule,
-                });
+                cov.positive
+                    .entry(CoveredRule {
+                        judgment: r.judgment,
+                        rule: r.rule,
+                    })
+                    .or_default()
+                    .insert(loc.clone());
             }
         }
         CoverageRecord::Negative { reasons, .. } => {

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -4,14 +4,16 @@
 //! Negative coverage is premise-level: for each fallible premise we report
 //! whether some test failed trying to prove it.
 
-use crate::jsonl::{Coverage, CoveredRule};
+use crate::jsonl::{Coverage, TestLoc};
 use crate::scrape::{Judgment, Premise, Rule};
 use anyhow::{Context, Result};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 use std::path::Path;
 
-/// Render the top-level coverage table.
-pub fn render_index(judgments: &[Judgment], cov: &Coverage) -> String {
+/// Render the top-level coverage table. When `github_base` is set (e.g.
+/// `https://github.com/rust-lang/a-mir-formality/blob/main`), each ✓ links to
+/// a test that exercised the rule.
+pub fn render_index(judgments: &[Judgment], cov: &Coverage, github_base: Option<&str>) -> String {
     let mut s = String::new();
     s.push_str("# Coverage report\n\n");
     s.push_str("| Judgment/Rule | Positive coverage | Negative coverage |\n");
@@ -29,7 +31,7 @@ pub fn render_index(judgments: &[Judgment], cov: &Coverage) -> String {
             slug = slug,
         ));
         for r in &j.rules {
-            let pos = positive_mark(&cov.positive, &j.name, &r.name);
+            let pos = positive_cell(cov, &j.name, &r.name, github_base);
             let neg = negative_index_cell(cov, &j.file, r);
             s.push_str(&format!(
                 "| ↳ [{rname}](./{slug}.md#{anchor}) | {pos} | {neg} |\n",
@@ -45,7 +47,7 @@ pub fn render_index(judgments: &[Judgment], cov: &Coverage) -> String {
 }
 
 /// Render one subpage per judgment.
-pub fn render_subpage(j: &Judgment, cov: &Coverage) -> String {
+pub fn render_subpage(j: &Judgment, cov: &Coverage, github_base: Option<&str>) -> String {
     let mut s = String::new();
     s.push_str(&format!(
         "# Judgment `{}` at {}:{}\n\n",
@@ -64,7 +66,7 @@ pub fn render_subpage(j: &Judgment, cov: &Coverage) -> String {
     s.push_str("| Rule | Line | Positive coverage |\n");
     s.push_str("| --- | --- | --- |\n");
     for r in &j.rules {
-        let pos = positive_mark(&cov.positive, &j.name, &r.name);
+        let pos = positive_cell(cov, &j.name, &r.name, github_base);
         s.push_str(&format!(
             "| <a id=\"{anchor}\"></a>`{rname}` | {line} | {pos} |\n",
             anchor = anchor(&r.name),
@@ -100,15 +102,28 @@ pub fn render_subpage(j: &Judgment, cov: &Coverage) -> String {
     s
 }
 
-fn positive_mark(covered: &BTreeSet<CoveredRule>, judgment: &str, rule: &str) -> &'static str {
-    let hit = covered.contains(&CoveredRule {
-        judgment: judgment.to_string(),
-        rule: rule.to_string(),
-    });
-    if hit {
-        "✓"
-    } else {
-        "✗"
+/// Positive-coverage cell for a rule: `✗` if no test exercised it, otherwise a
+/// `✓` linking to one such test (the first, deterministically) when a
+/// `github_base` is configured, or a plain `✓` when it is not.
+fn positive_cell(cov: &Coverage, judgment: &str, rule: &str, github_base: Option<&str>) -> String {
+    match cov
+        .positive_tests(judgment, rule)
+        .and_then(|locs| locs.iter().next())
+    {
+        Some(loc) => test_link(github_base, loc),
+        None => "✗".to_string(),
+    }
+}
+
+/// A `✓` linking to `loc` on GitHub, or a plain `✓` when no base URL is set.
+fn test_link(github_base: Option<&str>, loc: &TestLoc) -> String {
+    match github_base {
+        Some(base) => format!(
+            "[✓]({base}/{file}#L{line})",
+            file = loc.file,
+            line = loc.line
+        ),
+        None => "✓".to_string(),
     }
 }
 
@@ -152,9 +167,14 @@ fn premise_label(raw: &str) -> String {
 }
 
 /// Write the index and per-judgment subpages into `out_dir`.
-pub fn write_all(out_dir: &Path, judgments: &[Judgment], cov: &Coverage) -> Result<()> {
+pub fn write_all(
+    out_dir: &Path,
+    judgments: &[Judgment],
+    cov: &Coverage,
+    github_base: Option<&str>,
+) -> Result<()> {
     std::fs::create_dir_all(out_dir).with_context(|| format!("creating {}", out_dir.display()))?;
-    let index = render_index(judgments, cov);
+    let index = render_index(judgments, cov, github_base);
     std::fs::write(out_dir.join("coverage.md"), index)?;
 
     // Two judgments with the same name (or names that differ only by characters
@@ -169,7 +189,7 @@ pub fn write_all(out_dir: &Path, judgments: &[Judgment], cov: &Coverage) -> Resu
                 j.name, j.file, j.line,
             );
         }
-        let body = render_subpage(j, cov);
+        let body = render_subpage(j, cov, github_base);
         std::fs::write(out_dir.join(format!("{}.md", slug)), body)?;
     }
     Ok(())

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -5,7 +5,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use expect_test::expect;
-use formality_coverage::jsonl::{self, Coverage, CoveredRule, NoApplicableRuleLoc, PremiseLoc};
+use formality_coverage::jsonl::{
+    self, Coverage, CoveredRule, NoApplicableRuleLoc, PremiseLoc, TestLoc,
+};
 use formality_coverage::report;
 use formality_coverage::scrape::{scrape_text, Judgment, Premise, PremiseKind, Rule};
 
@@ -198,27 +200,36 @@ fn prove_thing_coverage() -> Coverage {
         BTreeSet::from(["if_false".to_string()]),
     );
     Coverage {
-        positive: BTreeSet::from([CoveredRule {
-            judgment: "prove_thing".into(),
-            rule: "positive".into(),
-        }]),
+        positive: BTreeMap::from([(
+            CoveredRule {
+                judgment: "prove_thing".into(),
+                rule: "positive".into(),
+            },
+            BTreeSet::from([TestLoc {
+                file: "tests/prove_thing.rs".into(),
+                line: 42,
+            }]),
+        )]),
         negative_premises,
         no_applicable_rule: BTreeSet::new(),
     }
 }
 
+/// Base URL used in report snapshots to exercise the test-link rendering.
+const GITHUB_BASE: &str = "https://github.com/example/repo/blob/main";
+
 #[test]
 fn markdown_index_snapshot() {
     let judgments = vec![prove_thing_judgment()];
     let cov = prove_thing_coverage();
-    let md = report::render_index(&judgments, &cov);
+    let md = report::render_index(&judgments, &cov, Some(GITHUB_BASE));
     expect![[r#"
         # Coverage report
 
         | Judgment/Rule | Positive coverage | Negative coverage |
         | --- | --- | --- |
         | **[prove_thing](./prove_thing.md)** | - | - |
-        | ↳ [positive](./prove_thing.md#positive) | ✓ | 1/1 |
+        | ↳ [positive](./prove_thing.md#positive) | [✓](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L42) | 1/1 |
         | ↳ [zero](./prove_thing.md#zero) | ✗ | 0/1 |
     "#]]
     .assert_eq(&md);
@@ -228,7 +239,7 @@ fn markdown_index_snapshot() {
 fn markdown_subpage_snapshot() {
     let j = prove_thing_judgment();
     let cov = prove_thing_coverage();
-    let md = report::render_subpage(&j, &cov);
+    let md = report::render_subpage(&j, &cov, Some(GITHUB_BASE));
     expect![[r#"
         # Judgment `prove_thing` at fixture.rs:4
 
@@ -236,7 +247,7 @@ fn markdown_subpage_snapshot() {
 
         | Rule | Line | Positive coverage |
         | --- | --- | --- |
-        | <a id="positive"></a>`positive` | 10 | ✓ |
+        | <a id="positive"></a>`positive` | 10 | [✓](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L42) |
         | <a id="zero"></a>`zero` | 16 | ✗ |
 
         ## Premises (negative coverage)
@@ -266,7 +277,7 @@ fn infallible_premise_renders_as_na() {
     };
     let cov = Coverage::default();
 
-    let index = report::render_index(&[j.clone()], &cov);
+    let index = report::render_index(&[j.clone()], &cov, None);
     expect![[r#"
         # Coverage report
 
@@ -277,7 +288,7 @@ fn infallible_premise_renders_as_na() {
     "#]]
     .assert_eq(&index);
 
-    let subpage = report::render_subpage(&j, &cov);
+    let subpage = report::render_subpage(&j, &cov, None);
     expect![[r#"
         # Judgment `easy` at fixture.rs:1
 
@@ -306,7 +317,7 @@ fn no_applicable_rule_renders_in_index_and_subpage() {
         line: 4,
     });
 
-    let index = report::render_index(&[j.clone()], &cov);
+    let index = report::render_index(&[j.clone()], &cov, None);
     expect![[r#"
         # Coverage report
 
@@ -318,7 +329,7 @@ fn no_applicable_rule_renders_in_index_and_subpage() {
     "#]]
     .assert_eq(&index);
 
-    let subpage = report::render_subpage(&j, &cov);
+    let subpage = report::render_subpage(&j, &cov, None);
     assert!(subpage.contains("_No applicable rule observed:"));
 }
 
@@ -333,7 +344,7 @@ fn empty_rules_renders_no_rules_message() {
         rules: vec![],
     };
     let cov = Coverage::default();
-    let md = report::render_subpage(&j, &cov);
+    let md = report::render_subpage(&j, &cov, None);
     expect![[r#"
         # Judgment `lonely` at fixture.rs:1
 
@@ -360,6 +371,16 @@ fn jsonl_reads_positive_and_negative_records() {
 
     let cov = jsonl::read(&path).unwrap();
     assert_eq!(cov.positive.len(), 1);
+
+    // The test location of the positive record is retained so the report can
+    // link the ✓ back to the test on GitHub.
+    let tests = cov
+        .positive_tests("j1", "r1")
+        .expect("rule r1 should be covered");
+    assert!(tests.contains(&TestLoc {
+        file: "a.rs".into(),
+        line: 1,
+    }));
 
     let causes = cov.premise_causes_for("f.rs", 11);
     let causes: Vec<&str> = causes.iter().map(String::as_str).collect();

--- a/crates/formality-mdbook/src/lib.rs
+++ b/crates/formality-mdbook/src/lib.rs
@@ -53,7 +53,7 @@ impl Preprocessor for JudgmentPreprocessor {
             }
         });
 
-        append_coverage_chapters(ctx, &root, &index, &mut book)?;
+        append_coverage_chapters(ctx, &root, &index, github_base.as_deref(), &mut book)?;
 
         Ok(book)
     }
@@ -72,6 +72,7 @@ fn append_coverage_chapters(
     ctx: &PreprocessorContext,
     root: &Path,
     index: &SourceIndex,
+    github_base: Option<&str>,
     book: &mut Book,
 ) -> anyhow::Result<()> {
     let jsonl_path: PathBuf = ctx
@@ -122,7 +123,7 @@ fn append_coverage_chapters(
         }
         let mut chapter = Chapter::new(
             &j.name,
-            report::render_subpage(j, &cov),
+            report::render_subpage(j, &cov, github_base),
             PathBuf::from(format!("{slug}.md")),
             vec!["Coverage report".to_string()],
         );
@@ -132,7 +133,7 @@ fn append_coverage_chapters(
 
     let mut index_chapter = Chapter::new(
         "Coverage report",
-        report::render_index(&judgments, &cov),
+        report::render_index(&judgments, &cov, github_base),
         PathBuf::from("coverage.md"),
         vec![],
     );


### PR DESCRIPTION
## What does this PR do?

Makes the ✓ positive-coverage marks in the mdbook coverage report clickable: each links to a test on GitHub that exercised that rule. One design choice: when a rule fires in many tests, the ✓ links to the first (deterministically sorted) one rather than listing every test, to avoid table cells full of links. This is a follow-up to #400 

## How does it work, what questions do you have?

Each possible check on the report page will lead directly to the line of code for the rule once clicked, I could make it open in a new tab instead of reloading the page in a follow up, possibly the negative cells follow up

## New Screenshot:
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/045a2d0c-f1ab-457e-b250-56f490b1d6dd" />

## AI disclosure

* I used an AI to author the main logic of the code
