### PR TITLE
Make sure to consider trait ref projection unknowanle

### DIFF
--- a/crates/formality-rust/src/prove/prove/prove/is_local.rs
+++ b/crates/formality-rust/src/prove/prove/prove/is_local.rs
@@ -1,6 +1,7 @@
 use crate::{
     grammar::{
-        AliasTy, Lt, Parameter, PredicateTy, RigidName, RigidTy, TraitRef, TyData, Variable, Wcs,
+        AliasName, AliasTy, Lt, Parameter, PredicateTy, RigidName, RigidTy, TraitRef, TyData,
+        Variable, Wcs,
     },
     prove::prove::Constrained,
 };
@@ -58,7 +59,6 @@ judgment_fn! {
     ) => Constraints {
         debug(assumptions, goal, env)
         assert(env.bias() == Bias::Completeness)
-
         (
             (may_be_downstream_trait_ref(decls, env, assumptions, goal) => c)
             --- ("may be defined downstream")
@@ -104,6 +104,13 @@ judgment_fn! {
     ) => Constraints {
         debug(parameter, assumptions, env)
         assert(env.bias() == Bias::Completeness)
+        (
+            // Projections from remote traits are not safe to rule out during
+            // coherence, so we treat them as maybe downstream.
+            (if !decls.is_local_trait_id(&name.as_associated_ty_id().unwrap().trait_id))
+            --- ("projection from remote trait")
+            (may_be_downstream_parameter(decls, env, assumptions, AliasTy { name, parameters: _ }) => Constraints::none(env))
+        )
         (
             // existential variables *could* be inferred to downstream types; depends on the substitution
             // we ultimately have.

--- a/tests/coherence_overlap.rs
+++ b/tests/coherence_overlap.rs
@@ -304,22 +304,11 @@ fn is_local_unknowable_trait_ref() {
         impl Overlap<LocalType> for () {}
     }])
     .skip_execute()
-    .rustc_err(expect_test::expect![[r#"
-            Checking mycore v0.1.0 (/tmp/formality-NXqOxy/crates/mycore)
-            Checking foo v0.1.0 (/tmp/formality-NXqOxy/crates/foo)
-        error[E0119]: conflicting implementations of trait `Overlap<LocalType>` for type `()`
-         --> crates/foo/src/lib.rs:9:1
-          |
-        7 | impl<T00, T01> Overlap<T01> for T00 where <T00 as Project>::Assoc: Foo<T01> {}
-          | --------------------------------------------------------------------------- first implementation here
-        8 |
-        9 | impl Overlap<LocalType> for () {}
-          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
-
-        For more information about this error, try `rustc --explain E0119`.
-        error: could not compile `foo` (lib) due to 1 previous error
-    "#]])
-    .ok()
+    .err(expect_test::expect![[r#"
+        the rule "check_coherence" at (coherence.rs) failed because
+          impls may overlap:
+          impl <ty, ty> Overlap <^ty0_1> for ^ty0_0 where <^ty0_0 as Project>::Assoc : Foo <^ty0_1> { }
+          impl Overlap <LocalType> for () { }"#]]);
 }
 
 #[test]

--- a/tests/coherence_overlap.rs
+++ b/tests/coherence_overlap.rs
@@ -301,9 +301,24 @@ fn is_local_unknowable_trait_ref() {
         impl<T, U> Overlap<U> for T
         where
             <T as Project>::Assoc: Foo<U> {}
-        impl<T> Overlap<LocalType> for () {}
+        impl Overlap<LocalType> for () {}
     }])
     .skip_execute()
+    .rustc_err(expect_test::expect![[r#"
+            Checking mycore v0.1.0 (/tmp/formality-NXqOxy/crates/mycore)
+            Checking foo v0.1.0 (/tmp/formality-NXqOxy/crates/foo)
+        error[E0119]: conflicting implementations of trait `Overlap<LocalType>` for type `()`
+         --> crates/foo/src/lib.rs:9:1
+          |
+        7 | impl<T00, T01> Overlap<T01> for T00 where <T00 as Project>::Assoc: Foo<T01> {}
+          | --------------------------------------------------------------------------- first implementation here
+        8 |
+        9 | impl Overlap<LocalType> for () {}
+          | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
+
+        For more information about this error, try `rustc --explain E0119`.
+        error: could not compile `foo` (lib) due to 1 previous error
+    "#]])
     .ok()
 }
 


### PR DESCRIPTION
## What does this PR do?
closes: #387 

We have this discrepancy with the rustc in case if we have a remote trait ref with a projection, on formality side we would consider such a case to be ok considering some downstream might implement it, whereas in rustc we consider it unknowable. So, here we are now doing the same for formality, like checking if it is foreign trait reference and if it is we then see it is an alias and then we don't allow it. I am not entirely confident with this but it does not break any test fortunately :).

## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools

