### PR TITLE
Run tests with rustc

### DIFF
--- a/crates/formality-core/src/test_util.rs
+++ b/crates/formality-core/src/test_util.rs
@@ -46,8 +46,14 @@ pub fn normalize_paths(s: impl Display) -> String {
     let s = s.to_string();
     // Capture the filename (without path) and strip line:column
     // Handle both forward slashes (Unix) and backslashes (Windows) as path separators
+
+    // Matches paths in the formality output
     let re = regex::Regex::new(r"\((?:[^()]+[/\\])?([^()/\\]+\.rs):\d+:\d+\)").unwrap();
-    re.replace_all(&s, "($1)").to_string()
+    let s = re.replace_all(&s, "($1)").to_string();
+
+    // Matches paths in the rustc output
+    let re = regex::Regex::new(r"--> (?:[^\r\n()]+[/\\])?([^()/\\]+\.rs):\d+:\d+").unwrap();
+    re.replace_all(&s, "--> $1").to_string()
 }
 
 /// Format an error, extracting just the leaf failures if it contains a FailedJudgment.

--- a/crates/formality-rust/src/grammar/feature.rs
+++ b/crates/formality-rust/src/grammar/feature.rs
@@ -14,4 +14,7 @@ pub enum FeatureGateName {
     PoloniusAlpha,
     #[grammar(non_lifetime_binders)]
     NonLifetimeBinders,
+    // #![feature(negative_impls)]
+    #[grammar(negative_impls)]
+    NegativeImpls,
 }

--- a/crates/formality-rust/src/to_rust/feature_gate.rs
+++ b/crates/formality-rust/src/to_rust/feature_gate.rs
@@ -7,6 +7,7 @@ pub fn lower_feature_gate(gate: &FeatureGate) -> Fallible<syntax::Attr> {
         FeatureGateName::PoloniusUnlocked => "polonius_unlocked",
         FeatureGateName::PoloniusAlpha => "polonius_alpha",
         FeatureGateName::NonLifetimeBinders => "non_lifetime_binders",
+        FeatureGateName::NegativeImpls => "negative_impls",
     };
     Ok(syntax::Attr::Feature(name.to_owned()))
 }

--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -33,7 +33,13 @@ pub fn check_workspace(
 
     let output = std::process::Command::new("cargo")
         .env("RUSTFLAGS", "-A warnings")
-        .args(["check", "--workspace", "--manifest-path", &root_toml])
+        .args([
+            "check",
+            "--workspace",
+            "--quiet",
+            "--manifest-path",
+            &root_toml,
+        ])
         .output()?;
     Ok(output)
 }

--- a/crates/formality-rust/src/to_rust/syntax.rs
+++ b/crates/formality-rust/src/to_rust/syntax.rs
@@ -906,7 +906,8 @@ impl Pretty for Stmt {
                 init,
             } => {
                 f.write_str("let ")?;
-                if *mutable {
+                if *mutable && name != "_" {
+                    // let mut _ = <expr> is invalid
                     f.write_str("mut ")?;
                 }
                 write!(f, "{name}: {ty}")?;

--- a/tests/coherence_orphan.rs
+++ b/tests/coherence_orphan.rs
@@ -8,23 +8,24 @@ fn neg_CoreTrait_for_CoreStruct_in_Foo() {
                 struct CoreStruct {}
             },
             crate foo {
+                #![feature(negative_impls)]
                 impl !CoreTrait for CoreStruct {}
             }]).err(expect_test::expect![[r#"
                 the rule "fundamental rigid type" at (is_local.rs) failed because
                   condition evaluated to false: `is_fundamental(decls, name)`
-                    decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl ! CoreTrait for CoreStruct {} }], 222)
+                    decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { #![feature(negative_impls)] impl ! CoreTrait for CoreStruct {} }], 222)
                     name = (adt CoreStruct)
 
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: CoreStruct, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false } }
 
                 the rule "local rigid type" at (is_local.rs) failed because
                   condition evaluated to false: `decls.is_local_adt_id(a)`
-                    decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl ! CoreTrait for CoreStruct {} }], 222)
+                    decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { #![feature(negative_impls)] impl ! CoreTrait for CoreStruct {} }], 222)
                     a = CoreStruct
 
                 the rule "local trait" at (is_local.rs) failed because
                   condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
-                    decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { impl ! CoreTrait for CoreStruct {} }], 222)
+                    decls = program([crate core { trait CoreTrait <ty> { } struct CoreStruct { } }, crate foo { #![feature(negative_impls)] impl ! CoreTrait for CoreStruct {} }], 222)
                     &goal.trait_id = CoreTrait"#]])
 }
 

--- a/tests/coherence_overlap.rs
+++ b/tests/coherence_overlap.rs
@@ -134,6 +134,7 @@ fn u32_not_u32_impls() {
 #[test]
 fn neg_CoreTrait_for_CoreStruct_implies_no_overlap() {
     FormalityTest::new(crates![crate core {
+        #![feature(negative_impls)]
         trait CoreTrait {}
         struct CoreStruct {}
         impl !CoreTrait for CoreStruct {}

--- a/tests/const_generics_rv_tsv_parse.rs
+++ b/tests/const_generics_rv_tsv_parse.rs
@@ -8,5 +8,6 @@ fn parse_minirust_22() {
         impl Trait<usize(22)> for u32 {}
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }

--- a/tests/decl_safety.rs
+++ b/tests/decl_safety.rs
@@ -25,6 +25,7 @@ fn safe_trait() {
 #[test]
 fn unsafe_trait_negative_impl() {
     FormalityTest::new(crates![crate baguette {
+        #![feature(negative_impls)]
         unsafe trait Foo {}
         impl !Foo for u32 {}
     }])

--- a/tests/decl_safety.rs
+++ b/tests/decl_safety.rs
@@ -9,6 +9,7 @@ fn unsafe_trait() {
         unsafe impl Foo for u32 {}
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -19,6 +20,7 @@ fn safe_trait() {
         safe impl Foo for u32 {}
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -30,15 +32,30 @@ fn unsafe_trait_negative_impl() {
         impl !Foo for u32 {}
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
 #[test]
 fn unsafe_trait_negative_impl_mismatch() {
     FormalityTest::new(crates![crate baguette {
+        #![feature(negative_impls)]
         unsafe trait Foo {}
         unsafe impl !Foo for u32 {}
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0198]: negative impls cannot be unsafe
+         --> lib.rs
+          |
+        5 | unsafe impl !Foo for u32 {}
+          | ------      -^^^
+          | |           |
+          | |           negative because of this
+          | unsafe because of this
+
+        For more information about this error, try `rustc --explain E0198`.
+        error: could not compile `baguette` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
         the rule "check_neg_trait_impl" at (impls.rs) failed because
           negative impls cannot be unsafe"#]])
@@ -47,9 +64,23 @@ fn unsafe_trait_negative_impl_mismatch() {
 #[test]
 fn safe_trait_negative_impl_mismatch() {
     FormalityTest::new(crates![crate baguette {
+        #![feature(negative_impls)]
         trait Foo {}
         unsafe impl !Foo for u32 {}
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0198]: negative impls cannot be unsafe
+         --> lib.rs
+          |
+        5 | unsafe impl !Foo for u32 {}
+          | ------      -^^^
+          | |           |
+          | |           negative because of this
+          | unsafe because of this
+
+        For more information about this error, try `rustc --explain E0198`.
+        error: could not compile `baguette` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
         the rule "check_neg_trait_impl" at (impls.rs) failed because
           negative impls cannot be unsafe"#]])
@@ -61,6 +92,22 @@ fn unsafe_trait_mismatch() {
         unsafe trait Foo {}
         impl Foo for u32 {}
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0200]: the trait `Foo` requires an `unsafe impl` declaration
+         --> lib.rs
+          |
+        3 | impl Foo for u32 {}
+          | ^^^^^^^^^^^^^^^^
+          |
+          = note: the trait `Foo` enforces invariants that the compiler can't check. Review the trait documentation and make sure this implementation upholds those invariants before adding the `unsafe` keyword
+        help: add `unsafe` to this trait implementation
+          |
+        3 | unsafe impl Foo for u32 {}
+          | ++++++
+
+        For more information about this error, try `rustc --explain E0200`.
+        error: could not compile `baguette` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
             the rule "safety matches" at (impls.rs) failed because
               condition evaluated to false: `trait_decl.safety == trait_impl.safety`"#]])
@@ -72,6 +119,22 @@ fn safe_trait_mismatch() {
         trait Foo {}
         unsafe impl Foo for u32 {}
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0199]: implementing the trait `Foo` is not unsafe
+         --> lib.rs
+          |
+        3 | unsafe impl Foo for u32 {}
+          | ^^^^^^^^^^^^^^^^^^^^^^^
+          |
+        help: remove `unsafe` from this trait implementation
+          |
+        3 - unsafe impl Foo for u32 {}
+        3 + impl Foo for u32 {}
+          |
+
+        For more information about this error, try `rustc --explain E0199`.
+        error: could not compile `baguette` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
             the rule "safety matches" at (impls.rs) failed because
               condition evaluated to false: `trait_decl.safety == trait_impl.safety`"#]])

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -21,6 +21,7 @@ fn ok() {
         fn multi_arg_ret<T, Y, U, I>(v0: T, v1: Y) -> (U, I) { trusted }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -34,5 +35,6 @@ fn lifetime() {
         { trusted }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }

--- a/tests/mir_typeck.rs
+++ b/tests/mir_typeck.rs
@@ -10,6 +10,7 @@ fn test_assign_statement_local_only() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -32,6 +33,7 @@ fn test_assign_constant() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -74,6 +76,7 @@ fn test_switch_statment() {
         };
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -86,6 +89,7 @@ fn test_goto_terminator() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -102,6 +106,7 @@ fn test_cyclic_goto() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -114,6 +119,7 @@ fn test_ret_true() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -130,6 +136,7 @@ fn if_else() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -137,14 +144,28 @@ fn if_else() {
 #[test]
 fn if_else_different_return_types() {
     FormalityTest::new(crates![crate Foo {
-                fn foo (b: bool) -> u32 {
-                    if b {
-                        return 1_u32;
-                    } else {
-                        return false;
-                    }
-                }
-            }]).err(expect_test::expect![[r#"
+        fn foo (b: bool) -> u32 {
+            if b {
+                return 1_u32;
+            } else {
+                return false;
+            }
+        }
+    }])
+        .rustc_err(expect_test::expect![[r#"
+            error[E0308]: mismatched types
+             --> lib.rs
+              |
+            1 | pub fn foo(mut b: bool) -> u32 {
+              |                            --- expected `u32` because of return type
+            ...
+            5 |         return false;
+              |                ^^^^^ expected `u32`, found `bool`
+
+            For more information about this error, try `rustc --explain E0308`.
+            error: could not compile `Foo` (lib) due to 1 previous error
+        "#]])
+        .err(expect_test::expect![[r#"
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: bool, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
@@ -168,6 +189,7 @@ fn test_call_terminator() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -188,6 +210,7 @@ fn test_place_mention_statement() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -212,6 +235,7 @@ fn test_storage_live_dead() {
         };
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -231,6 +255,7 @@ fn test_struct() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -247,6 +272,7 @@ fn test_let_with_well_formed_type() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -263,6 +289,35 @@ fn test_let_with_ill_formed_type() {
             let s2: S2<S1>;
         }
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0277]: the trait bound `S1: Trait1` is not satisfied
+          --> lib.rs
+           |
+        13 |     let mut s2: S2<S1>;
+           |                 ^^^^^^ unsatisfied trait bound
+           |
+        help: the trait `Trait1` is not implemented for `S1`
+          --> lib.rs
+           |
+         3 | pub struct S1 {}
+           | ^^^^^^^^^^^^^
+        help: this trait has no implementations, consider adding one
+          --> lib.rs
+           |
+         1 | pub trait Trait1 {}
+           | ^^^^^^^^^^^^^^^^
+        note: required by a bound in `S2`
+          --> lib.rs
+           |
+         5 | pub struct S2<T00>
+           |            -- required by a bound in this struct
+         6 | where
+         7 |     T00: Trait1,
+           |          ^^^^^^ required by this bound in `S2`
+
+        For more information about this error, try `rustc --explain E0277`.
+        error: could not compile `Foo` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
                 the rule "trait implied bound" at (prove_wc.rs) failed because
                   expression evaluated to an empty collection: `decls.trait_invariants()`"#]])
@@ -277,6 +332,16 @@ fn test_call_invalid_fn() {
             return v1;
         }
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0425]: cannot find function `foo` in this scope
+         --> lib.rs
+          |
+        2 |     let mut v1: u32 = foo(0_u32);
+          |                       ^^^ not found in this scope
+
+        For more information about this error, try `rustc --explain E0425`.
+        error: could not compile `Foo` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
             the rule "fn-name" at (nll.rs) failed because
               no fn named `foo`
@@ -297,7 +362,34 @@ fn test_pass_non_subtype_arg() {
                     let v0: () = foo(v1);
                     return v0;
                 }
-            }]).err(expect_test::expect![[r#"
+            }])
+        .rustc_err(expect_test::expect![[r#"
+            error[E0308]: mismatched types
+             --> lib.rs
+              |
+            6 |     let mut v0: () = foo(v1);
+              |                      --- ^^ expected `u32`, found `()`
+              |                      |
+              |                      arguments to this function are incorrect
+              |
+            note: function defined here
+             --> lib.rs
+              |
+            1 | pub fn foo(mut v1: u32) -> u32 {
+              |        ^^^ -----------
+
+            error[E0308]: mismatched types
+             --> lib.rs
+              |
+            6 |     let mut v0: () = foo(v1);
+              |                 --   ^^^^^^^ expected `()`, found `u32`
+              |                 |
+              |                 expected due to this
+
+            For more information about this error, try `rustc --explain E0308`.
+            error: could not compile `Foo` (lib) due to 2 previous errors
+        "#]])
+        .err(expect_test::expect![[r#"
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: (), assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
@@ -320,6 +412,7 @@ fn test_call_generic_fn_without_turbofish() {
             return v0;
         }
     }])
+    .rustc_ok() // rustc can deduce the generic type
     .err(expect_test::expect![[r#"
             the rule "fn-name" at (nll.rs) failed because
               condition evaluated to false: `fn_decl.binder.len() == 0`
@@ -342,6 +435,7 @@ fn test_call_generic_fn_with_turbofish() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -357,7 +451,41 @@ fn test_call_generic_fn_wrong_type_with_turbofish() {
                     let v0: u32 = identity::<bool>(v1);
                     return v0;
                 }
-            }]).err(expect_test::expect![[r#"
+            }])
+        .rustc_err(expect_test::expect![[r#"
+            error[E0308]: mismatched types
+             --> lib.rs
+              |
+            6 |     let mut v0: u32 = identity::<bool>(v1);
+              |                       ---------------- ^^ expected `bool`, found `u32`
+              |                       |
+              |                       arguments to this function are incorrect
+              |
+            help: the return type of this call is `u32` due to the type of the argument passed
+             --> lib.rs
+              |
+            6 |     let mut v0: u32 = identity::<bool>(v1);
+              |                       ^^^^^^^^^^^^^^^^^--^
+              |                                        |
+              |                                        this argument influences the return type of `identity`
+            note: function defined here
+             --> lib.rs
+              |
+            1 | pub fn identity<T00>(mut v1: T00) -> T00 {
+              |        ^^^^^^^^      -----------
+
+            error[E0308]: mismatched types
+             --> lib.rs
+              |
+            6 |     let mut v0: u32 = identity::<bool>(v1);
+              |                 ---   ^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `bool`
+              |                 |
+              |                 expected due to this
+
+            For more information about this error, try `rustc --explain E0308`.
+            error: could not compile `Foo` (lib) due to 2 previous errors
+        "#]])
+        .err(expect_test::expect![[r#"
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: bool, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
@@ -380,6 +508,27 @@ fn test_call_generic_fn_wrong_parameters_number_with_turbofish() {
             return v0;
         }
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0061]: this function takes 1 argument but 2 arguments were supplied
+         --> lib.rs
+          |
+        6 |     let mut v0: u32 = identity::<u32>(v1, v1);
+          |                       ^^^^^^^^^^^^^^^     -- unexpected argument #2 of type `u32`
+          |
+        note: function defined here
+         --> lib.rs
+          |
+        1 | pub fn identity<T00>(mut v1: T00) -> T00 {
+          |        ^^^^^^^^
+        help: remove the extra argument
+          |
+        6 -     let mut v0: u32 = identity::<u32>(v1, v1);
+        6 +     let mut v0: u32 = identity::<u32>(v1);
+          |
+
+        For more information about this error, try `rustc --explain E0061`.
+        error: could not compile `Foo` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
             the rule "call" at (nll.rs) failed because
               condition evaluated to false: `input_tys.len() == args.len()`"#]])
@@ -398,6 +547,24 @@ fn test_call_generic_fn_wrong_arity() {
             return v0;
         }
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0107]: function takes 1 generic argument but 2 generic arguments were supplied
+         --> lib.rs
+          |
+        6 |     let mut v0: u32 = identity::<u32, u32>(v1);
+          |                       ^^^^^^^^      ----- help: remove the unnecessary generic argument
+          |                       |
+          |                       expected 1 generic argument
+          |
+        note: function defined here, with 1 generic parameter: `T00`
+         --> lib.rs
+          |
+        1 | pub fn identity<T00>(mut v1: T00) -> T00 {
+          |        ^^^^^^^^ ---
+
+        For more information about this error, try `rustc --explain E0107`.
+        error: could not compile `Foo` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
             the rule "turbofish" at (nll.rs) failed because
               condition evaluated to false: `fn_decl.binder.len() == args.len()`"#]])
@@ -418,7 +585,20 @@ fn test_incompatible_return_type() {
                 fn foo (v1: ()) -> u32 {
                     return v1;
                 }
-            }]).err(expect_test::expect![[r#"
+            }])
+        .rustc_err(expect_test::expect![[r#"
+            error[E0308]: mismatched types
+             --> lib.rs
+              |
+            1 | pub fn foo(mut v1: ()) -> u32 {
+              |                           --- expected `u32` because of return type
+            2 |     return v1;
+              |            ^^ expected `u32`, found `()`
+
+            For more information about this error, try `rustc --explain E0308`.
+            error: could not compile `Foo` (lib) due to 1 previous error
+        "#]])
+        .err(expect_test::expect![[r#"
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: (), assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
@@ -445,6 +625,7 @@ fn test_uninitialised_return_type() {
         };
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -482,6 +663,7 @@ fn test_invalid_value_in_switch_terminator() {
             }
         };
     }])
+    .rustc_err(expect_test::expect![[r#""#]])
     .err(expect_test::expect![[r#"
             MaybeFnBody expected
 
@@ -534,6 +716,7 @@ fn test_ret_place_storage_dead() {
             }
         };
     }])
+    .rustc_err(expect_test::expect![[r#""#]])
     .err(expect_test::expect![[r#"
             MaybeFnBody expected
 
@@ -564,6 +747,7 @@ fn test_fn_arg_storage_dead() {
             }
         };
     }])
+    .rustc_err(expect_test::expect![[r#""#]])
     .err(expect_test::expect![[r#"
             MaybeFnBody expected
 
@@ -592,6 +776,18 @@ fn test_invalid_struct_field() {
             return v1;
         }
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0609]: no field `nonexistent` on type `Dummy`
+         --> lib.rs
+          |
+        7 |     v2.nonexistent = 2_u32;
+          |        ^^^^^^^^^^^ unknown field
+          |
+          = note: available field is: `value`
+
+        For more information about this error, try `rustc --explain E0609`.
+        error: could not compile `Foo` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
             the rule "struct field" at (nll.rs) failed because
               condition evaluated to false: `field.name == *field_name`"#]])
@@ -610,7 +806,18 @@ fn test_field_projection_root_non_adt() {
                     v1.value = 2_u32;
                     return v1;
                 }
-            }]).err(expect_test::expect![[r#"
+            }])
+        .rustc_err(expect_test::expect![[r#"
+            error[E0610]: `u32` is a primitive type and therefore doesn't have fields
+             --> lib.rs
+              |
+            7 |     v1.value = 2_u32;
+              |        ^^^^^
+
+            For more information about this error, try `rustc --explain E0610`.
+            error: could not compile `Foo` (lib) due to 1 previous error
+        "#]])
+        .err(expect_test::expect![[r#"
                 the rule "struct field" at (nll.rs) failed because
                   pattern `(RigidTy { name: RigidName::AdtId(adt_id), parameters }, state)` did not match value `(u32, flow_state([scope(none, None, {}, None, [(v1, u32)], [v1 : u32]), scope(none, None, {}, None, [(v2, Dummy)], [v2 : Dummy])], point_flow_state({}, {}, {}), {}, {}, {}))`"#]])
 }
@@ -627,7 +834,18 @@ fn test_struct_wrong_type_in_initialisation() {
                     let v2: Dummy = Dummy { value: false };
                     return v1;
                 }
-            }]).err(expect_test::expect![[r#"
+            }])
+        .rustc_err(expect_test::expect![[r#"
+            error[E0308]: mismatched types
+             --> lib.rs
+              |
+            6 |     let mut v2: Dummy = Dummy { value: false };
+              |                                        ^^^^^ expected `u32`, found `bool`
+
+            For more information about this error, try `rustc --explain E0308`.
+            error: could not compile `Foo` (lib) due to 1 previous error
+        "#]])
+        .err(expect_test::expect![[r#"
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: bool, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }
 
                 crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: u32, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: true } }"#]])
@@ -645,6 +863,16 @@ fn test_non_adt_ty_for_struct() {
             return v1;
         }
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0422]: cannot find struct, variant or union type `Nonexistent` in this scope
+         --> lib.rs
+          |
+        2 |     let mut v2: u32 = Nonexistent { value: false };
+          |                       ^^^^^^^^^^^ not found in this scope
+
+        For more information about this error, try `rustc --explain E0422`.
+        error: could not compile `Foo` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
             the rule "struct" at (nll.rs) failed because
               no ADT named `Nonexistent`"#]])
@@ -667,6 +895,7 @@ fn test_false_literal() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -690,6 +919,7 @@ fn test_ref_identity() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -707,6 +937,7 @@ fn test_ref_deref() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -726,6 +957,7 @@ fn test_ref_deref_generic_copy_bound() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -752,6 +984,7 @@ fn test_break_valid_loop_label() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -773,7 +1006,18 @@ fn test_break_nonexistent_label() {
                     }
                     return 0_u32;
                 }
-            }]).err(expect_test::expect![[r#"
+            }])
+        .rustc_err(expect_test::expect![[r#"
+            error[E0426]: use of undeclared label `'nonexistent`
+             --> lib.rs
+              |
+            3 |         break 'nonexistent;
+              |               ^^^^^^^^^^^^ undeclared label `'nonexistent`
+
+            For more information about this error, try `rustc --explain E0426`.
+            error: could not compile `Foo` (lib) due to 1 previous error
+        "#]])
+        .err(expect_test::expect![[r#"
                 crates/formality-rust/src/check/borrow_check/nll.rs:177:1: no applicable rules for borrow_check_statement { state: flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(none, None, {}, Some({}), [], []), scope(none, None, {}, None, [], [])], point_flow_state({}, {}, {}), {}, {}, {}), statement: break 'nonexistent ;, places_live_on_exit: {}, assumptions: {}, env: TypeckEnv { env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false }, output_ty: Some(u32) } }
 
                 crates/formality-rust/src/check/borrow_check/nll.rs:177:1: no applicable rules for borrow_check_statement { state: flow_state([scope(none, None, {}, None, [], []), scope(none, None, {}, None, [], []), scope(none, None, {}, Some({}), [], []), scope(none, None, {}, None, [], [])], point_flow_state({}, {}, {}), {}, {}, {}), statement: break 'nonexistent ;, places_live_on_exit: {}, assumptions: {}, env: TypeckEnv { env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false }, output_ty: Some(u32) } }"#]])
@@ -799,6 +1043,7 @@ fn test_continue_valid_loop_label() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -822,6 +1067,19 @@ fn test_continue_block_label() {
             return 0_u32;
         }
     }])
+    .rustc_err(expect_test::expect![[r#"
+        error[E0696]: `continue` pointing to a labeled block
+         --> lib.rs
+          |
+        2 | /     'a: {
+        3 | |         continue 'a;
+          | |         ^^^^^^^^^^^ labeled blocks cannot be `continue`'d
+        4 | |     }
+          | |_____- labeled block the `continue` points to
+
+        For more information about this error, try `rustc --explain E0696`.
+        error: could not compile `Foo` (lib) due to 1 previous error
+    "#]])
     .err(expect_test::expect![[r#"
             the rule "continue" at (nll.rs) failed because
               pattern `Some(places_live_on_continue)` did not match value `None`"#]])
@@ -854,6 +1112,7 @@ fn test_parens_place_expr() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -879,5 +1138,6 @@ fn test_break_block_label() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }

--- a/tests/return_validation.rs
+++ b/tests/return_validation.rs
@@ -16,6 +16,7 @@ fn empty_body_non_unit_return() {
         fn foo() -> u32 {
         }
     }])
+    .rustc_err(expect_test::expect![[r#""#]])
     .err(expect_test::expect![[r#"function may not return a value"#]])
 }
 
@@ -28,6 +29,7 @@ fn empty_body_unit_return() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -45,6 +47,7 @@ fn if_else_both_branches_return() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -62,6 +65,7 @@ fn if_else_one_branch_returns() {
             }
         }
     }])
+    .rustc_err(expect_test::expect![[r#""#]])
     .err(expect_test::expect![[r#"function may not return a value"#]])
 }
 
@@ -76,6 +80,7 @@ fn infinite_loop_no_return_needed() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -92,6 +97,7 @@ fn loop_with_break_no_return() {
             }
         }
     }])
+    .rustc_err(expect_test::expect![[r#""#]])
     .err(expect_test::expect![[r#"function may not return a value"#]])
 }
 
@@ -108,6 +114,7 @@ fn loop_with_break_then_return() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }
 
@@ -121,5 +128,6 @@ fn simple_return() {
         }
     }])
     .skip_execute()
+    .rustc_ok()
     .ok()
 }

--- a/tests/traits.rs
+++ b/tests/traits.rs
@@ -10,6 +10,7 @@ fn trait_with_valid_fn() {
         }
     ])
     .skip_execute()
+    .rustc_ok()
     .ok();
 }
 
@@ -23,6 +24,7 @@ fn trait_with_valid_associated_type() {
         }
     ])
     .skip_execute()
+    .rustc_ok()
     .ok();
 }
 
@@ -38,6 +40,7 @@ fn trait_with_ill_formed_where_clause() {
             }
         }
     ])
+    .rustc_err(expect_test::expect![[r#""#]])
     .err(expect_test::expect![[r#"
             the rule "trait implied bound" at (prove_wc.rs) failed because
               expression evaluated to an empty collection: `decls.trait_invariants()`"#]]);


### PR DESCRIPTION
## What does this PR do?

Runs part of the current a-mir-formality test suite with rustc enabled. I only updated the test modules, where the whole module passes with rustc. I'll add the remaining test modules, after discussion how to handle the discrepancy.

## How does it work, what questions do you have?

Add `rustc_ok()` or `rustc_err(...)` to the test cases.

## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools
