### PR TITLE
Add per-cell coverage detail pages listing tests

### DIFF
--- a/crates/formality-coverage/src/bin/formality-coverage.rs
+++ b/crates/formality-coverage/src/bin/formality-coverage.rs
@@ -45,7 +45,15 @@ fn main() -> Result<()> {
     let positive_count = cov.positive.len();
     let negative_premise_count = cov.negative_premises.len();
     let github_base = args.github_base.as_deref().map(|s| s.trim_end_matches('/'));
-    report::write_all(&args.out_dir, &judgments, &cov, github_base)?;
+    // Test source locations recorded in the JSONL are relative to the repo
+    // root, which is the directory the CLI is run from.
+    report::write_all(
+        &args.out_dir,
+        &judgments,
+        &cov,
+        github_base,
+        Some(std::path::Path::new(".")),
+    )?;
     eprintln!(
         "wrote {} judgments ({} positive rules, {} negatively-tested premises) to {}",
         judgments.len(),

--- a/crates/formality-coverage/src/jsonl.rs
+++ b/crates/formality-coverage/src/jsonl.rs
@@ -51,6 +51,9 @@ pub struct Coverage {
     pub positive: BTreeMap<CoveredRule, BTreeSet<TestLoc>>,
     /// Each failing-premise location with the set of clause-cause tags observed.
     pub negative_premises: BTreeMap<PremiseLoc, BTreeSet<String>>,
+    /// Each failing-premise location with the test locations that failed there,
+    /// so a negative cell can link to the tests that exercise it.
+    pub negative_premise_tests: BTreeMap<PremiseLoc, BTreeSet<TestLoc>>,
     /// Judgments observed to fail with no applicable rule.
     pub no_applicable_rule: BTreeSet<NoApplicableRuleLoc>,
 }
@@ -65,6 +68,22 @@ impl Coverage {
         for (loc, causes) in &self.negative_premises {
             if loc.line == premise_line && paths_overlap(&loc.file, judgment_file) {
                 out.extend(causes.iter().cloned());
+            }
+        }
+        out
+    }
+
+    /// Test locations that failed proving the premise at `premise_line` in a
+    /// file overlapping `judgment_file`. Matching mirrors `premise_causes_for`.
+    pub fn negative_premise_tests(
+        &self,
+        judgment_file: &str,
+        premise_line: u32,
+    ) -> BTreeSet<TestLoc> {
+        let mut out = BTreeSet::new();
+        for (loc, tests) in &self.negative_premise_tests {
+            if loc.line == premise_line && paths_overlap(&loc.file, judgment_file) {
+                out.extend(tests.iter().cloned());
             }
         }
         out
@@ -148,16 +167,30 @@ fn ingest(record: CoverageRecord, cov: &mut Coverage) {
                     .insert(loc.clone());
             }
         }
-        CoverageRecord::Negative { reasons, .. } => {
+        CoverageRecord::Negative {
+            test_file,
+            test_line,
+            reasons,
+            ..
+        } => {
+            let test = TestLoc {
+                file: test_file,
+                line: test_line,
+            };
             for reason in reasons {
                 match reason {
                     FailureReason::Premise {
                         file, line, cause, ..
                     } => {
+                        let ploc = PremiseLoc { file, line };
                         cov.negative_premises
-                            .entry(PremiseLoc { file, line })
+                            .entry(ploc.clone())
                             .or_default()
                             .insert(cause);
+                        cov.negative_premise_tests
+                            .entry(ploc)
+                            .or_default()
+                            .insert(test.clone());
                     }
                     FailureReason::NoApplicableRule {
                         judgment,

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -9,7 +9,7 @@
 //! with three columns (line number, coverage count, source line). The number on
 //! a rule's conclusion is positive coverage; the number on a premise is negative
 //! coverage. Both link to a per-cell detail page ([`render_detail_pages_for`])
-//! that lists the individual tests behind nested disclosure triangles.
+//! that lists each individual test with its source location and source.
 
 use crate::jsonl::{Coverage, TestLoc};
 use crate::scrape::{Judgment, Premise, Rule};
@@ -17,11 +17,11 @@ use anyhow::{Context, Result};
 use std::collections::HashSet;
 use std::path::Path;
 
-/// Inlined stylesheet for the code-view subpages and the disclosure-triangle
-/// detail pages. Emitted once per generated page so the CLI report
-/// ([`write_all`]) and the mdbook preprocessor render identically without any
-/// extra book configuration. Colors fall back gracefully when the mdbook theme
-/// variables are absent (e.g. the standalone CLI output viewed as raw HTML).
+/// Inlined stylesheet for the code-view subpages. Emitted once per subpage so
+/// the CLI report ([`write_all`]) and the mdbook preprocessor render
+/// identically without any extra book configuration. Colors fall back
+/// gracefully when the mdbook theme variables are absent (e.g. the standalone
+/// CLI output viewed as raw HTML).
 ///
 /// Kept as a single line-broken HTML block with no blank lines: a blank line
 /// would terminate the surrounding HTML block under CommonMark and leak the
@@ -41,9 +41,6 @@ table.cov-code th{padding:.15rem .6rem;border:0;border-bottom:1px solid var(--qu
 .cov-src-line{white-space:pre-wrap}\n\
 tr.cov-sep td{color:#999}\n\
 tr.cov-concl{background:rgba(127,127,127,.08)}\n\
-details.cov-tests{margin:1rem 0}\n\
-details.cov-test{margin:.3rem 0 .3rem 1rem}\n\
-summary{cursor:pointer}\n\
 </style>\n";
 
 /// Render the top-level coverage table. Each covered cell links to a per-cell
@@ -92,6 +89,11 @@ pub fn render_subpage(j: &Judgment, cov: &Coverage, link_ext: &str) -> String {
         "# Judgment `{}` at {}:{}\n\n",
         j.name, j.file, j.line,
     ));
+    if !j.signature.is_empty() {
+        s.push_str("**Signature:**\n\n```rust,ignore\n");
+        s.push_str(&j.signature);
+        s.push_str("\n```\n\n");
+    }
     if cov.no_applicable_rule_observed(&j.file, &j.name) {
         s.push_str("_No applicable rule observed: at least one test exercised this judgment with no matching rule._\n\n");
     }
@@ -233,27 +235,27 @@ pub struct DetailPage {
 
 /// Build the detail pages for one judgment: one per covered rule (positive) and
 /// one per fallible premise that was negatively tested. Cells produced by
-/// `positive_num` / `negative_num` link to exactly these pages. The tests are
-/// listed behind nested disclosure triangles: an outer triangle reveals the
-/// tests, and each test is itself a triangle revealing its source.
+/// `positive_num` / `negative_num` link to exactly these pages. Each page lists
+/// the tests with, for each, its source location and (when `source_root` is set
+/// and the file is readable) the test function's source inline.
 pub fn render_detail_pages_for(
     j: &Judgment,
     cov: &Coverage,
     github_base: Option<&str>,
+    source_root: Option<&Path>,
 ) -> Vec<DetailPage> {
     let mut pages = Vec::new();
     for r in &j.rules {
         // Positive: every test that exercised this rule.
         if let Some(locs) = cov.positive_tests(&j.name, &r.name) {
             if !locs.is_empty() {
-                let mut content = format!("# Positive coverage: `{}` / `{}`\n\n", j.name, r.name,);
-                content.push_str(STYLE);
-                content.push('\n');
-                content.push_str(&test_disclosure(
-                    github_base,
-                    &format!("{} {} exercised this rule", locs.len(), plural(locs.len())),
-                    locs,
+                let mut content = format!("# Positive coverage: `{}` / `{}`\n\n", j.name, r.name);
+                content.push_str(&format!(
+                    "{} {} exercised this rule:\n\n",
+                    locs.len(),
+                    plural(locs.len()),
                 ));
+                content.push_str(&test_list(github_base, source_root, locs));
                 pages.push(DetailPage {
                     slug: pos_detail_slug(&j.name, &r.name),
                     title: format!("{} / {} (positive)", j.name, r.name),
@@ -283,18 +285,12 @@ pub fn render_detail_pages_for(
                 let joined = causes.into_iter().collect::<Vec<_>>().join(", ");
                 content.push_str(&format!(" Observed failure causes: {joined}."));
             }
-            content.push_str("\n\n");
-            content.push_str(STYLE);
-            content.push('\n');
-            content.push_str(&test_disclosure(
-                github_base,
-                &format!(
-                    "{} {} failed proving this premise",
-                    tests.len(),
-                    plural(tests.len()),
-                ),
-                &tests,
+            content.push_str(&format!(
+                "\n\n{} {} failed proving this premise:\n\n",
+                tests.len(),
+                plural(tests.len()),
             ));
+            content.push_str(&test_list(github_base, source_root, &tests));
             pages.push(DetailPage {
                 slug: neg_detail_slug(&j.name, &r.name, p.line),
                 title: format!("{} / {} premise@{} (negative)", j.name, r.name, p.line),
@@ -305,38 +301,91 @@ pub fn render_detail_pages_for(
     pages
 }
 
-/// An outer disclosure triangle (summary = `summary`) revealing one inner
-/// triangle per test; each inner triangle reveals that test's source. Emitted
-/// as a single blank-line-free HTML block (see [`STYLE`]).
-fn test_disclosure<'a>(
+/// A flat list of tests: for each, its source location (linked to GitHub when
+/// `github_base` is set) followed by the test function's source in a code block
+/// (when `source_root` is set and the file is readable). Plain markdown, so the
+/// location links rewrite to `.html` under mdbook like any other markdown link.
+fn test_list<'a>(
     github_base: Option<&str>,
-    summary: &str,
+    source_root: Option<&Path>,
     tests: impl IntoIterator<Item = &'a TestLoc>,
 ) -> String {
-    let mut s = format!(
-        "<details class=\"cov-tests\" open>\n<summary>{}</summary>\n",
-        html_escape(summary),
-    );
+    let mut s = String::new();
     for loc in tests {
         let label = format!("{}:{}", loc.file, loc.line);
-        let source = match github_base {
-            Some(base) => format!(
-                "<a href=\"{base}/{file}#L{line}\" target=\"_blank\">{label}</a>",
+        s.push_str("---\n\n");
+        match github_base {
+            Some(base) => s.push_str(&format!(
+                "**Source location:** [{label}]({base}/{file}#L{line})\n\n",
+                label = label,
                 base = base,
                 file = loc.file,
                 line = loc.line,
-                label = html_escape(&label),
-            ),
-            None => html_escape(&label),
-        };
-        s.push_str(&format!(
-            "<details class=\"cov-test\"><summary>{label}</summary>\n<div>Source: {source}</div>\n</details>\n",
-            label = html_escape(&label),
-            source = source,
-        ));
+            )),
+            None => s.push_str(&format!("**Source location:** {label}\n\n")),
+        }
+        if let Some(root) = source_root {
+            if let Some(src) = extract_test_source(root, &loc.file, loc.line) {
+                s.push_str("```rust,ignore\n");
+                s.push_str(&src);
+                s.push_str("\n```\n\n");
+            }
+        }
     }
-    s.push_str("</details>\n");
     s
+}
+
+/// Extract the source of the test function enclosing `file:line`, dedented.
+/// `None` if the file can't be read or no enclosing `fn` is found.
+///
+/// Heuristic: scan up from `line` for the nearest `fn` header (with any leading
+/// `#[..]` attributes), then down for the closing brace at the same
+/// indentation. This relies on the rustfmt convention that a function's closing
+/// brace sits at the function's own indentation, which holds for the test
+/// functions we record.
+fn extract_test_source(root: &Path, file: &str, line: u32) -> Option<String> {
+    let text = std::fs::read_to_string(root.join(file)).ok()?;
+    let lines: Vec<&str> = text.lines().collect();
+    if line == 0 || line as usize > lines.len() {
+        return None;
+    }
+    let target = line as usize - 1;
+
+    let is_fn = |l: &str| {
+        let t = l.trim_start();
+        [
+            "fn ",
+            "pub fn ",
+            "pub(crate) fn ",
+            "async fn ",
+            "pub async fn ",
+        ]
+        .iter()
+        .any(|p| t.starts_with(p))
+    };
+    let fn_idx = (0..=target).rev().find(|&i| is_fn(lines[i]))?;
+    let indent = lines[fn_idx].len() - lines[fn_idx].trim_start().len();
+
+    // Include any attribute lines (e.g. `#[test]`) directly above the `fn`.
+    let mut start = fn_idx;
+    while start > 0 && lines[start - 1].trim_start().starts_with("#[") {
+        start -= 1;
+    }
+
+    let close = format!("{}}}", " ".repeat(indent));
+    let end = (fn_idx + 1..lines.len()).find(|&i| lines[i] == close)?;
+
+    let block: Vec<String> = lines[start..=end]
+        .iter()
+        .map(|l| {
+            if l.len() >= indent {
+                l[indent..].to_string()
+            } else {
+                l.trim_start().to_string()
+            }
+        })
+        .collect();
+    Some(block.join("\n"))
 }
 
 /// Positive-coverage cell for a rule in the index table: `✗` if no test
@@ -403,6 +452,7 @@ pub fn write_all(
     judgments: &[Judgment],
     cov: &Coverage,
     github_base: Option<&str>,
+    source_root: Option<&Path>,
 ) -> Result<()> {
     std::fs::create_dir_all(out_dir).with_context(|| format!("creating {}", out_dir.display()))?;
     let index = render_index(judgments, cov);
@@ -423,7 +473,7 @@ pub fn write_all(
         let body = render_subpage(j, cov, "md");
         std::fs::write(out_dir.join(format!("{}.md", slug)), body)?;
 
-        for page in render_detail_pages_for(j, cov, github_base) {
+        for page in render_detail_pages_for(j, cov, github_base, source_root) {
             if !seen_slugs.insert(page.slug.clone()) {
                 eprintln!(
                     "warning: slug collision for coverage detail page `{}`, it will overwrite a sibling",

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -10,10 +10,9 @@ use anyhow::{Context, Result};
 use std::collections::HashSet;
 use std::path::Path;
 
-/// Render the top-level coverage table. When `github_base` is set (e.g.
-/// `https://github.com/rust-lang/a-mir-formality/blob/main`), each ✓ links to
-/// a test that exercised the rule.
-pub fn render_index(judgments: &[Judgment], cov: &Coverage, github_base: Option<&str>) -> String {
+/// Render the top-level coverage table. Each covered cell links to a per-cell
+/// detail page (see [`render_detail_pages_for`]) listing the tests involved.
+pub fn render_index(judgments: &[Judgment], cov: &Coverage) -> String {
     let mut s = String::new();
     s.push_str("# Coverage report\n\n");
     s.push_str("| Judgment/Rule | Positive coverage | Negative coverage |\n");
@@ -31,7 +30,7 @@ pub fn render_index(judgments: &[Judgment], cov: &Coverage, github_base: Option<
             slug = slug,
         ));
         for r in &j.rules {
-            let pos = positive_cell(cov, &j.name, &r.name, github_base);
+            let pos = positive_cell(cov, &j.name, &r.name);
             let neg = negative_index_cell(cov, &j.file, r);
             s.push_str(&format!(
                 "| ↳ [{rname}](./{slug}.md#{anchor}) | {pos} | {neg} |\n",
@@ -47,7 +46,7 @@ pub fn render_index(judgments: &[Judgment], cov: &Coverage, github_base: Option<
 }
 
 /// Render one subpage per judgment.
-pub fn render_subpage(j: &Judgment, cov: &Coverage, github_base: Option<&str>) -> String {
+pub fn render_subpage(j: &Judgment, cov: &Coverage) -> String {
     let mut s = String::new();
     s.push_str(&format!(
         "# Judgment `{}` at {}:{}\n\n",
@@ -66,7 +65,7 @@ pub fn render_subpage(j: &Judgment, cov: &Coverage, github_base: Option<&str>) -
     s.push_str("| Rule | Line | Positive coverage |\n");
     s.push_str("| --- | --- | --- |\n");
     for r in &j.rules {
-        let pos = positive_cell(cov, &j.name, &r.name, github_base);
+        let pos = positive_cell(cov, &j.name, &r.name);
         s.push_str(&format!(
             "| <a id=\"{anchor}\"></a>`{rname}` | {line} | {pos} |\n",
             anchor = anchor(&r.name),
@@ -95,35 +94,129 @@ pub fn render_subpage(j: &Judgment, cov: &Coverage, github_base: Option<&str>) -
                 rname = r.name,
                 premise = premise_label(&p.raw_text),
                 line = p.line,
-                neg = premise_negative_cell(cov, &j.file, p),
+                neg = premise_negative_cell(cov, &j.name, &j.file, &r.name, p),
             ));
         }
     }
     s
 }
 
+/// A generated per-cell detail page. `slug` is the filename stem (cells link to
+/// `./{slug}.md`); `title` is a short heading for the mdbook sidebar; `content`
+/// is the markdown body.
+pub struct DetailPage {
+    pub slug: String,
+    pub title: String,
+    pub content: String,
+}
+
+/// Build the detail pages for one judgment: one per covered rule (positive) and
+/// one per fallible premise that was negatively tested. Cells produced by
+/// `positive_cell` / `premise_negative_cell` link to exactly these pages.
+pub fn render_detail_pages_for(
+    j: &Judgment,
+    cov: &Coverage,
+    github_base: Option<&str>,
+) -> Vec<DetailPage> {
+    let mut pages = Vec::new();
+    for r in &j.rules {
+        // Positive: every test that exercised this rule.
+        if let Some(locs) = cov.positive_tests(&j.name, &r.name) {
+            if !locs.is_empty() {
+                let mut content = format!(
+                    "# Positive coverage: `{}` / `{}`\n\n{} {} exercised this rule:\n\n",
+                    j.name,
+                    r.name,
+                    locs.len(),
+                    plural(locs.len()),
+                );
+                for loc in locs {
+                    content.push_str(&test_list_item(github_base, loc));
+                    content.push('\n');
+                }
+                pages.push(DetailPage {
+                    slug: pos_detail_slug(&j.name, &r.name),
+                    title: format!("{} / {} (positive)", j.name, r.name),
+                    content,
+                });
+            }
+        }
+
+        // Negative: every test that failed proving a given fallible premise.
+        for p in &r.premises {
+            if !p.fallible {
+                continue;
+            }
+            let tests = cov.negative_premise_tests(&j.file, p.line);
+            if tests.is_empty() {
+                continue;
+            }
+            let mut content = format!(
+                "# Negative coverage: `{}` / `{}` / premise `{}`\n\nPremise at line {}.",
+                j.name,
+                r.name,
+                premise_label(&p.raw_text),
+                p.line,
+            );
+            let causes = cov.premise_causes_for(&j.file, p.line);
+            if !causes.is_empty() {
+                let joined = causes.into_iter().collect::<Vec<_>>().join(", ");
+                content.push_str(&format!(" Observed failure causes: {joined}."));
+            }
+            content.push_str(&format!(
+                "\n\n{} {} failed proving this premise:\n\n",
+                tests.len(),
+                plural(tests.len()),
+            ));
+            for loc in &tests {
+                content.push_str(&test_list_item(github_base, loc));
+                content.push('\n');
+            }
+            pages.push(DetailPage {
+                slug: neg_detail_slug(&j.name, &r.name, p.line),
+                title: format!("{} / {} premise@{} (negative)", j.name, r.name, p.line),
+                content,
+            });
+        }
+    }
+    pages
+}
+
 /// Positive-coverage cell for a rule: `✗` if no test exercised it, otherwise a
-/// `✓` linking to one such test (the first, deterministically) when a
-/// `github_base` is configured, or a plain `✓` when it is not.
-fn positive_cell(cov: &Coverage, judgment: &str, rule: &str, github_base: Option<&str>) -> String {
-    match cov
-        .positive_tests(judgment, rule)
-        .and_then(|locs| locs.iter().next())
-    {
-        Some(loc) => test_link(github_base, loc),
-        None => "✗".to_string(),
+/// `[N tests]` link to a detail page listing every test that did.
+fn positive_cell(cov: &Coverage, judgment: &str, rule: &str) -> String {
+    match cov.positive_tests(judgment, rule) {
+        Some(locs) if !locs.is_empty() => {
+            let n = locs.len();
+            format!(
+                "[{n} {tests}](./{slug}.md)",
+                tests = plural(n),
+                slug = pos_detail_slug(judgment, rule),
+            )
+        }
+        _ => "✗".to_string(),
     }
 }
 
-/// A `✓` linking to `loc` on GitHub, or a plain `✓` when no base URL is set.
-fn test_link(github_base: Option<&str>, loc: &TestLoc) -> String {
+/// `"test"` for one, `"tests"` otherwise.
+fn plural(n: usize) -> &'static str {
+    if n == 1 {
+        "test"
+    } else {
+        "tests"
+    }
+}
+
+/// A bullet-list entry for `loc`: a GitHub link when `github_base` is set, or a
+/// plain `file:line` when it is not.
+fn test_list_item(github_base: Option<&str>, loc: &TestLoc) -> String {
     match github_base {
         Some(base) => format!(
-            "[✓]({base}/{file}#L{line})",
+            "- [{file}:{line}]({base}/{file}#L{line})",
             file = loc.file,
-            line = loc.line
+            line = loc.line,
         ),
-        None => "✓".to_string(),
+        None => format!("- {file}:{line}", file = loc.file, line = loc.line),
     }
 }
 
@@ -142,18 +235,35 @@ fn negative_index_cell(cov: &Coverage, judgment_file: &str, rule: &Rule) -> Stri
     format!("{covered}/{}", fallible.len())
 }
 
-/// Subpage cell for a single premise: `N/A` if infallible, `✓` plus the
-/// observed clause-cause tags if some test failed proving it, else `✗`.
-fn premise_negative_cell(cov: &Coverage, judgment_file: &str, premise: &Premise) -> String {
+/// Subpage cell for a single premise: `N/A` if infallible, a `[N tests]` link
+/// to a detail page (plus the observed clause-cause tags) if some test failed
+/// proving it, else `✗`.
+fn premise_negative_cell(
+    cov: &Coverage,
+    judgment: &str,
+    judgment_file: &str,
+    rule: &str,
+    premise: &Premise,
+) -> String {
     if !premise.fallible {
         return "N/A".to_string();
     }
+    let tests = cov.negative_premise_tests(judgment_file, premise.line);
+    if tests.is_empty() {
+        return "✗".to_string();
+    }
+    let link = format!(
+        "[{n} {tests_word}](./{slug}.md)",
+        n = tests.len(),
+        tests_word = plural(tests.len()),
+        slug = neg_detail_slug(judgment, rule, premise.line),
+    );
     let causes = cov.premise_causes_for(judgment_file, premise.line);
     if causes.is_empty() {
-        "✗".to_string()
+        link
     } else {
         let joined = causes.into_iter().collect::<Vec<_>>().join(", ");
-        format!("✓ ({joined})")
+        format!("{link} ({joined})")
     }
 }
 
@@ -174,7 +284,7 @@ pub fn write_all(
     github_base: Option<&str>,
 ) -> Result<()> {
     std::fs::create_dir_all(out_dir).with_context(|| format!("creating {}", out_dir.display()))?;
-    let index = render_index(judgments, cov, github_base);
+    let index = render_index(judgments, cov);
     std::fs::write(out_dir.join("coverage.md"), index)?;
 
     // Two judgments with the same name (or names that differ only by characters
@@ -189,8 +299,18 @@ pub fn write_all(
                 j.name, j.file, j.line,
             );
         }
-        let body = render_subpage(j, cov, github_base);
+        let body = render_subpage(j, cov);
         std::fs::write(out_dir.join(format!("{}.md", slug)), body)?;
+
+        for page in render_detail_pages_for(j, cov, github_base) {
+            if !seen_slugs.insert(page.slug.clone()) {
+                eprintln!(
+                    "warning: slug collision for coverage detail page `{}`, it will overwrite a sibling",
+                    page.slug,
+                );
+            }
+            std::fs::write(out_dir.join(format!("{}.md", page.slug)), page.content)?;
+        }
     }
     Ok(())
 }
@@ -215,4 +335,16 @@ fn anchor(name: &str) -> String {
             _ => '-',
         })
         .collect()
+}
+
+/// Filename stem for a rule's positive detail page. Must match the link emitted
+/// by `positive_cell`.
+fn pos_detail_slug(judgment: &str, rule: &str) -> String {
+    format!("{}__{}__pos", slug(judgment), anchor(rule))
+}
+
+/// Filename stem for a premise's negative detail page. Must match the link
+/// emitted by `premise_negative_cell`.
+fn neg_detail_slug(judgment: &str, rule: &str, premise_line: u32) -> String {
+    format!("{}__{}__p{premise_line}__neg", slug(judgment), anchor(rule))
 }

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -3,12 +3,48 @@
 //! Positive coverage is rule-level (a proof means every premise held).
 //! Negative coverage is premise-level: for each fallible premise we report
 //! whether some test failed trying to prove it.
+//!
+//! The index ([`render_index`]) is a plain markdown table. Each per-judgment
+//! subpage ([`render_subpage`]) is a "code view": the rule's source rendered
+//! with three columns (line number, coverage count, source line). The number on
+//! a rule's conclusion is positive coverage; the number on a premise is negative
+//! coverage. Both link to a per-cell detail page ([`render_detail_pages_for`])
+//! that lists the individual tests behind nested disclosure triangles.
 
 use crate::jsonl::{Coverage, TestLoc};
 use crate::scrape::{Judgment, Premise, Rule};
 use anyhow::{Context, Result};
 use std::collections::HashSet;
 use std::path::Path;
+
+/// Inlined stylesheet for the code-view subpages and the disclosure-triangle
+/// detail pages. Emitted once per generated page so the CLI report
+/// ([`write_all`]) and the mdbook preprocessor render identically without any
+/// extra book configuration. Colors fall back gracefully when the mdbook theme
+/// variables are absent (e.g. the standalone CLI output viewed as raw HTML).
+///
+/// Kept as a single line-broken HTML block with no blank lines: a blank line
+/// would terminate the surrounding HTML block under CommonMark and leak the
+/// rest as literal markdown.
+const STYLE: &str = "<style>\n\
+.cov-rule{border:1px solid var(--quote-border,#d0d0d0);border-radius:6px;margin:1rem 0;overflow:hidden}\n\
+.cov-rule-head{padding:.4rem .8rem;background:var(--quote-bg,#f6f7f9);font-weight:600}\n\
+table.cov-code{width:100%;border-collapse:collapse;font-family:var(--mono-font,monospace);font-size:.85em;margin:0}\n\
+table.cov-code td{padding:.15rem .6rem;border:0}\n\
+table.cov-code th{padding:.15rem .6rem;border:0;border-bottom:1px solid var(--quote-border,#d0d0d0);color:#888;font-weight:600;font-size:.9em}\n\
+.cov-ln{text-align:right;color:#999;user-select:none;width:3em;white-space:nowrap}\n\
+.cov-num{text-align:right;width:3.5em;white-space:nowrap;font-weight:600}\n\
+.cov-num.pos a{color:#1a7f37}\n\
+.cov-num.neg a{color:#b35900}\n\
+.cov-none{color:#bbb}\n\
+.cov-na{color:#bbb;font-weight:400}\n\
+.cov-src-line{white-space:pre-wrap}\n\
+tr.cov-sep td{color:#999}\n\
+tr.cov-concl{background:rgba(127,127,127,.08)}\n\
+details.cov-tests{margin:1rem 0}\n\
+details.cov-test{margin:.3rem 0 .3rem 1rem}\n\
+summary{cursor:pointer}\n\
+</style>\n";
 
 /// Render the top-level coverage table. Each covered cell links to a per-cell
 /// detail page (see [`render_detail_pages_for`]) listing the tests involved.
@@ -45,8 +81,12 @@ pub fn render_index(judgments: &[Judgment], cov: &Coverage) -> String {
     s
 }
 
-/// Render one subpage per judgment.
-pub fn render_subpage(j: &Judgment, cov: &Coverage) -> String {
+/// Render one subpage per judgment as a code view. `link_ext` is the extension
+/// used for the links from coverage numbers to detail pages: `"md"` for the
+/// standalone CLI report (viewed as markdown) and `"html"` for the mdbook
+/// preprocessor (mdbook only rewrites `.md`→`.html` for markdown-syntax links,
+/// not for the raw-HTML `<a>` we emit here).
+pub fn render_subpage(j: &Judgment, cov: &Coverage, link_ext: &str) -> String {
     let mut s = String::new();
     s.push_str(&format!(
         "# Judgment `{}` at {}:{}\n\n",
@@ -60,45 +100,126 @@ pub fn render_subpage(j: &Judgment, cov: &Coverage) -> String {
         return s;
     }
 
-    // Rule-level positive coverage.
-    s.push_str("## Rules\n\n");
-    s.push_str("| Rule | Line | Positive coverage |\n");
-    s.push_str("| --- | --- | --- |\n");
+    s.push_str(
+        "The number on each rule's conclusion is **positive** coverage; the number on each \
+         premise is **negative** coverage. Click a number to browse the tests.\n\n",
+    );
+    s.push_str(STYLE);
+    s.push('\n');
     for r in &j.rules {
-        let pos = positive_cell(cov, &j.name, &r.name);
+        s.push_str(&render_rule_block(j, r, cov, link_ext));
+        s.push('\n');
+    }
+    s
+}
+
+/// Render one rule as a three-column code view: line number, coverage count,
+/// source line. Premises (above the separator) carry their negative coverage;
+/// the conclusion (below it) carries the rule's positive coverage. Emitted as a
+/// single blank-line-free HTML block (see [`STYLE`]).
+fn render_rule_block(j: &Judgment, r: &Rule, cov: &Coverage, link_ext: &str) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        "<div class=\"cov-rule\" id=\"{}\">\n",
+        anchor(&r.name)
+    ));
+    s.push_str(&format!(
+        "<div class=\"cov-rule-head\"><code>{}</code></div>\n",
+        html_escape(&r.name),
+    ));
+    s.push_str("<table class=\"cov-code\">\n");
+    s.push_str(
+        "<thead><tr><th class=\"cov-ln\">Line</th><th class=\"cov-num\">Coverage</th>\
+         <th class=\"cov-src-line\">Source</th></tr></thead>\n",
+    );
+
+    // Premises: negative coverage.
+    for p in &r.premises {
         s.push_str(&format!(
-            "| <a id=\"{anchor}\"></a>`{rname}` | {line} | {pos} |\n",
-            anchor = anchor(&r.name),
-            rname = r.name,
-            line = r.line,
-            pos = pos,
+            "<tr><td class=\"cov-ln\">{ln}</td><td class=\"cov-num neg\">{num}</td>\
+             <td class=\"cov-src-line\">{code}</td></tr>\n",
+            ln = p.line,
+            num = negative_num(cov, j, r, p, link_ext),
+            code = html_escape(&format!("({})", p.raw_text)),
         ));
     }
 
-    // Premise-level negative coverage.
-    s.push_str("\n## Premises (negative coverage)\n\n");
-    s.push_str("| Rule | Premise | Line | Negatively tested |\n");
-    s.push_str("| --- | --- | --- | --- |\n");
-    for r in &j.rules {
-        if r.premises.is_empty() {
-            s.push_str(&format!(
-                "| `{rname}` | _(no premises)_ | {line} | N/A |\n",
-                rname = r.name,
-                line = r.line,
-            ));
-            continue;
-        }
-        for p in &r.premises {
-            s.push_str(&format!(
-                "| `{rname}` | `{premise}` | {line} | {neg} |\n",
-                rname = r.name,
-                premise = premise_label(&p.raw_text),
-                line = p.line,
-                neg = premise_negative_cell(cov, &j.name, &j.file, &r.name, p),
-            ));
-        }
-    }
+    // Separator carrying the rule name, mirroring the source syntax.
+    s.push_str(&format!(
+        "<tr class=\"cov-sep\"><td class=\"cov-ln\"></td><td class=\"cov-num\"></td>\
+         <td class=\"cov-src-line\">{}</td></tr>\n",
+        html_escape(&format!("──────── (\"{}\")", r.name)),
+    ));
+
+    // Conclusion: positive coverage. The conclusion sits just below the
+    // separator, so its source line is `r.line + 1` (`r.line` is the separator).
+    let concl = conclusion_of(&r.raw_text).unwrap_or_else(|| format!("({} => …)", j.name));
+    s.push_str(&format!(
+        "<tr class=\"cov-concl\"><td class=\"cov-ln\">{ln}</td><td class=\"cov-num pos\">{num}</td>\
+         <td class=\"cov-src-line\">{code}</td></tr>\n",
+        ln = r.line + 1,
+        num = positive_num(cov, j, r, link_ext),
+        code = html_escape(&concl),
+    ));
+
+    s.push_str("</table>\n</div>\n");
     s
+}
+
+/// The conclusion (everything below the `---` separator) of a rule's source
+/// text, with surrounding whitespace trimmed. `None` when `raw_text` has no
+/// separator (e.g. synthetic fixtures with empty source).
+fn conclusion_of(raw_text: &str) -> Option<String> {
+    let lines: Vec<&str> = raw_text.lines().collect();
+    let sep = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with("---"))?;
+    let concl = lines[sep + 1..].join("\n");
+    let concl = concl.trim();
+    (!concl.is_empty()).then(|| concl.to_string())
+}
+
+/// The positive-coverage number cell for a rule's conclusion: a link to the
+/// rule's detail page, or `✗` if no test exercised it.
+fn positive_num(cov: &Coverage, j: &Judgment, r: &Rule, link_ext: &str) -> String {
+    match cov.positive_tests(&j.name, &r.name) {
+        Some(locs) if !locs.is_empty() => format!(
+            "<a href=\"./{slug}.{ext}\">{n}</a>",
+            slug = pos_detail_slug(&j.name, &r.name),
+            ext = link_ext,
+            n = locs.len(),
+        ),
+        _ => "<span class=\"cov-none\">✗</span>".to_string(),
+    }
+}
+
+/// The negative-coverage number cell for a premise: `N/A` if the premise is
+/// infallible, a link to the premise's detail page if some test failed proving
+/// it (with the observed failure causes in the link title), else `✗`.
+fn negative_num(cov: &Coverage, j: &Judgment, r: &Rule, p: &Premise, link_ext: &str) -> String {
+    if !p.fallible {
+        return "<span class=\"cov-na\">N/A</span>".to_string();
+    }
+    let tests = cov.negative_premise_tests(&j.file, p.line);
+    if tests.is_empty() {
+        return "<span class=\"cov-none\">✗</span>".to_string();
+    }
+    let causes = cov.premise_causes_for(&j.file, p.line);
+    let title = if causes.is_empty() {
+        String::new()
+    } else {
+        format!(
+            " title=\"failure causes: {}\"",
+            html_escape(&causes.into_iter().collect::<Vec<_>>().join(", ")),
+        )
+    };
+    format!(
+        "<a href=\"./{slug}.{ext}\"{title}>{n}</a>",
+        slug = neg_detail_slug(&j.name, &r.name, p.line),
+        ext = link_ext,
+        title = title,
+        n = tests.len(),
+    )
 }
 
 /// A generated per-cell detail page. `slug` is the filename stem (cells link to
@@ -112,7 +233,9 @@ pub struct DetailPage {
 
 /// Build the detail pages for one judgment: one per covered rule (positive) and
 /// one per fallible premise that was negatively tested. Cells produced by
-/// `positive_cell` / `premise_negative_cell` link to exactly these pages.
+/// `positive_num` / `negative_num` link to exactly these pages. The tests are
+/// listed behind nested disclosure triangles: an outer triangle reveals the
+/// tests, and each test is itself a triangle revealing its source.
 pub fn render_detail_pages_for(
     j: &Judgment,
     cov: &Coverage,
@@ -123,17 +246,14 @@ pub fn render_detail_pages_for(
         // Positive: every test that exercised this rule.
         if let Some(locs) = cov.positive_tests(&j.name, &r.name) {
             if !locs.is_empty() {
-                let mut content = format!(
-                    "# Positive coverage: `{}` / `{}`\n\n{} {} exercised this rule:\n\n",
-                    j.name,
-                    r.name,
-                    locs.len(),
-                    plural(locs.len()),
-                );
-                for loc in locs {
-                    content.push_str(&test_list_item(github_base, loc));
-                    content.push('\n');
-                }
+                let mut content = format!("# Positive coverage: `{}` / `{}`\n\n", j.name, r.name,);
+                content.push_str(STYLE);
+                content.push('\n');
+                content.push_str(&test_disclosure(
+                    github_base,
+                    &format!("{} {} exercised this rule", locs.len(), plural(locs.len())),
+                    locs,
+                ));
                 pages.push(DetailPage {
                     slug: pos_detail_slug(&j.name, &r.name),
                     title: format!("{} / {} (positive)", j.name, r.name),
@@ -163,15 +283,18 @@ pub fn render_detail_pages_for(
                 let joined = causes.into_iter().collect::<Vec<_>>().join(", ");
                 content.push_str(&format!(" Observed failure causes: {joined}."));
             }
-            content.push_str(&format!(
-                "\n\n{} {} failed proving this premise:\n\n",
-                tests.len(),
-                plural(tests.len()),
+            content.push_str("\n\n");
+            content.push_str(STYLE);
+            content.push('\n');
+            content.push_str(&test_disclosure(
+                github_base,
+                &format!(
+                    "{} {} failed proving this premise",
+                    tests.len(),
+                    plural(tests.len()),
+                ),
+                &tests,
             ));
-            for loc in &tests {
-                content.push_str(&test_list_item(github_base, loc));
-                content.push('\n');
-            }
             pages.push(DetailPage {
                 slug: neg_detail_slug(&j.name, &r.name, p.line),
                 title: format!("{} / {} premise@{} (negative)", j.name, r.name, p.line),
@@ -182,8 +305,42 @@ pub fn render_detail_pages_for(
     pages
 }
 
-/// Positive-coverage cell for a rule: `✗` if no test exercised it, otherwise a
-/// `[N tests]` link to a detail page listing every test that did.
+/// An outer disclosure triangle (summary = `summary`) revealing one inner
+/// triangle per test; each inner triangle reveals that test's source. Emitted
+/// as a single blank-line-free HTML block (see [`STYLE`]).
+fn test_disclosure<'a>(
+    github_base: Option<&str>,
+    summary: &str,
+    tests: impl IntoIterator<Item = &'a TestLoc>,
+) -> String {
+    let mut s = format!(
+        "<details class=\"cov-tests\" open>\n<summary>{}</summary>\n",
+        html_escape(summary),
+    );
+    for loc in tests {
+        let label = format!("{}:{}", loc.file, loc.line);
+        let source = match github_base {
+            Some(base) => format!(
+                "<a href=\"{base}/{file}#L{line}\" target=\"_blank\">{label}</a>",
+                base = base,
+                file = loc.file,
+                line = loc.line,
+                label = html_escape(&label),
+            ),
+            None => html_escape(&label),
+        };
+        s.push_str(&format!(
+            "<details class=\"cov-test\"><summary>{label}</summary>\n<div>Source: {source}</div>\n</details>\n",
+            label = html_escape(&label),
+            source = source,
+        ));
+    }
+    s.push_str("</details>\n");
+    s
+}
+
+/// Positive-coverage cell for a rule in the index table: `✗` if no test
+/// exercised it, otherwise a `[N tests]` markdown link to a detail page.
 fn positive_cell(cov: &Coverage, judgment: &str, rule: &str) -> String {
     match cov.positive_tests(judgment, rule) {
         Some(locs) if !locs.is_empty() => {
@@ -207,19 +364,6 @@ fn plural(n: usize) -> &'static str {
     }
 }
 
-/// A bullet-list entry for `loc`: a GitHub link when `github_base` is set, or a
-/// plain `file:line` when it is not.
-fn test_list_item(github_base: Option<&str>, loc: &TestLoc) -> String {
-    match github_base {
-        Some(base) => format!(
-            "- [{file}:{line}]({base}/{file}#L{line})",
-            file = loc.file,
-            line = loc.line,
-        ),
-        None => format!("- {file}:{line}", file = loc.file, line = loc.line),
-    }
-}
-
 /// Index cell for a rule's negative coverage: a `covered/total` count over
 /// the rule's fallible premises, or `N/A` when the rule has none (so it can
 /// never fail once its conclusion matches).
@@ -235,38 +379,6 @@ fn negative_index_cell(cov: &Coverage, judgment_file: &str, rule: &Rule) -> Stri
     format!("{covered}/{}", fallible.len())
 }
 
-/// Subpage cell for a single premise: `N/A` if infallible, a `[N tests]` link
-/// to a detail page (plus the observed clause-cause tags) if some test failed
-/// proving it, else `✗`.
-fn premise_negative_cell(
-    cov: &Coverage,
-    judgment: &str,
-    judgment_file: &str,
-    rule: &str,
-    premise: &Premise,
-) -> String {
-    if !premise.fallible {
-        return "N/A".to_string();
-    }
-    let tests = cov.negative_premise_tests(judgment_file, premise.line);
-    if tests.is_empty() {
-        return "✗".to_string();
-    }
-    let link = format!(
-        "[{n} {tests_word}](./{slug}.md)",
-        n = tests.len(),
-        tests_word = plural(tests.len()),
-        slug = neg_detail_slug(judgment, rule, premise.line),
-    );
-    let causes = cov.premise_causes_for(judgment_file, premise.line);
-    if causes.is_empty() {
-        link
-    } else {
-        let joined = causes.into_iter().collect::<Vec<_>>().join(", ");
-        format!("{link} ({joined})")
-    }
-}
-
 /// Collapse a premise's source text to a single line and escape `|` so it
 /// can sit in a markdown table cell.
 fn premise_label(raw: &str) -> String {
@@ -276,7 +388,16 @@ fn premise_label(raw: &str) -> String {
         .replace('|', "\\|")
 }
 
-/// Write the index and per-judgment subpages into `out_dir`.
+/// Escape the HTML metacharacters in `s` so source text can sit inside the
+/// raw-HTML elements the code view emits.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Write the index and per-judgment subpages into `out_dir`. Standalone output
+/// is viewed as markdown, so detail-page links use the `.md` extension.
 pub fn write_all(
     out_dir: &Path,
     judgments: &[Judgment],
@@ -299,7 +420,7 @@ pub fn write_all(
                 j.name, j.file, j.line,
             );
         }
-        let body = render_subpage(j, cov);
+        let body = render_subpage(j, cov, "md");
         std::fs::write(out_dir.join(format!("{}.md", slug)), body)?;
 
         for page in render_detail_pages_for(j, cov, github_base) {
@@ -338,13 +459,13 @@ fn anchor(name: &str) -> String {
 }
 
 /// Filename stem for a rule's positive detail page. Must match the link emitted
-/// by `positive_cell`.
+/// by `positive_num` / `positive_cell`.
 fn pos_detail_slug(judgment: &str, rule: &str) -> String {
     format!("{}__{}__pos", slug(judgment), anchor(rule))
 }
 
 /// Filename stem for a premise's negative detail page. Must match the link
-/// emitted by `premise_negative_cell`.
+/// emitted by `negative_num`.
 fn neg_detail_slug(judgment: &str, rule: &str, premise_line: u32) -> String {
     format!("{}__{}__p{premise_line}__neg", slug(judgment), anchor(rule))
 }

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -178,7 +178,7 @@ fn prove_thing_judgment() -> Judgment {
     Judgment {
         name: "prove_thing".into(),
         doc_comment: String::new(),
-        signature: String::new(),
+        signature: "prove_thing(x: u32) => ()".into(),
         file: "fixture.rs".into(),
         line: 4,
         rules: vec![
@@ -253,6 +253,12 @@ fn markdown_subpage_snapshot() {
     expect![[r##"
         # Judgment `prove_thing` at fixture.rs:4
 
+        **Signature:**
+
+        ```rust,ignore
+        prove_thing(x: u32) => ()
+        ```
+
         The number on each rule's conclusion is **positive** coverage; the number on each premise is **negative** coverage. Click a number to browse the tests.
 
         <style>
@@ -270,9 +276,6 @@ fn markdown_subpage_snapshot() {
         .cov-src-line{white-space:pre-wrap}
         tr.cov-sep td{color:#999}
         tr.cov-concl{background:rgba(127,127,127,.08)}
-        details.cov-tests{margin:1rem 0}
-        details.cov-test{margin:.3rem 0 .3rem 1rem}
-        summary{cursor:pointer}
         </style>
 
         <div class="cov-rule" id="positive">
@@ -302,7 +305,7 @@ fn markdown_subpage_snapshot() {
 fn detail_pages_list_tests() {
     let j = prove_thing_judgment();
     let cov = prove_thing_coverage();
-    let pages = report::render_detail_pages_for(&j, &cov, Some(GITHUB_BASE));
+    let pages = report::render_detail_pages_for(&j, &cov, Some(GITHUB_BASE), None);
 
     // One positive page for the covered `positive` rule, one negative page for
     // its negatively-tested premise. `zero` is uncovered, so it gets no page.
@@ -323,12 +326,10 @@ fn detail_pages_list_tests() {
         pos.content
     );
     assert!(pos.content.contains("1 test exercised this rule"));
-    // The test is revealed behind a disclosure triangle, with its source as a
-    // GitHub link.
-    assert!(pos.content.contains("<details"), "{}", pos.content);
+    // Each test is listed flat with its source location linked to GitHub.
     assert!(
         pos.content.contains(
-            "<a href=\"https://github.com/example/repo/blob/main/tests/prove_thing.rs#L42\" target=\"_blank\">tests/prove_thing.rs:42</a>"
+            "**Source location:** [tests/prove_thing.rs:42](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L42)"
         ),
         "{}",
         pos.content
@@ -344,7 +345,7 @@ fn detail_pages_list_tests() {
     );
     assert!(
         neg.content.contains(
-            "<a href=\"https://github.com/example/repo/blob/main/tests/prove_thing.rs#L99\" target=\"_blank\">tests/prove_thing.rs:99</a>"
+            "**Source location:** [tests/prove_thing.rs:99](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L99)"
         ),
         "{}",
         neg.content
@@ -355,14 +356,58 @@ fn detail_pages_list_tests() {
 fn detail_pages_without_github_base_use_plain_locations() {
     let j = prove_thing_judgment();
     let cov = prove_thing_coverage();
-    let pages = report::render_detail_pages_for(&j, &cov, None);
+    let pages = report::render_detail_pages_for(&j, &cov, None, None);
     let pos = &pages[0];
     assert!(
-        pos.content.contains("tests/prove_thing.rs:42"),
+        pos.content
+            .contains("**Source location:** tests/prove_thing.rs:42"),
         "{}",
         pos.content
     );
     assert!(!pos.content.contains("https://"), "{}", pos.content);
+}
+
+#[test]
+fn detail_pages_embed_test_source_when_root_given() {
+    // A judgment with one rule, covered by one test that lives in a real file
+    // on disk so the detail page can embed its source.
+    let tmp = std::env::temp_dir().join(format!("formality-coverage-src-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let test_file = "my_module.rs";
+    let body = "// preamble\n#[test]\nfn my_test() {\n    let x = 1;\n    assert_eq!(x, 1);\n}\n";
+    std::fs::write(tmp.join(test_file), body).unwrap();
+
+    let j = Judgment {
+        name: "j".into(),
+        doc_comment: String::new(),
+        signature: String::new(),
+        file: "fixture.rs".into(),
+        line: 1,
+        rules: vec![rule_with_premise("r", 3, 2)],
+    };
+    let mut cov = Coverage::default();
+    cov.positive.insert(
+        CoveredRule {
+            judgment: "j".into(),
+            rule: "r".into(),
+        },
+        // The `assert_eq!` line (5) is inside `my_test`.
+        BTreeSet::from([TestLoc {
+            file: test_file.into(),
+            line: 5,
+        }]),
+    );
+
+    let pages = report::render_detail_pages_for(&j, &cov, None, Some(&tmp));
+    let pos = &pages[0];
+    // The whole enclosing test function (including the `#[test]` attribute) is
+    // embedded in a fenced code block.
+    assert!(pos.content.contains("```rust,ignore"), "{}", pos.content);
+    assert!(pos.content.contains("#[test]"), "{}", pos.content);
+    assert!(pos.content.contains("fn my_test() {"), "{}", pos.content);
+    assert!(pos.content.contains("assert_eq!(x, 1);"), "{}", pos.content);
+
+    let _ = std::fs::remove_dir_all(&tmp);
 }
 
 #[test]
@@ -414,9 +459,6 @@ fn infallible_premise_renders_as_na() {
         .cov-src-line{white-space:pre-wrap}
         tr.cov-sep td{color:#999}
         tr.cov-concl{background:rgba(127,127,127,.08)}
-        details.cov-tests{margin:1rem 0}
-        details.cov-test{margin:.3rem 0 .3rem 1rem}
-        summary{cursor:pointer}
         </style>
 
         <div class="cov-rule" id="trivial">

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -24,7 +24,7 @@ fn premise(raw: &str, kind: PremiseKind, fallible: bool, line: u32) -> Premise {
 fn rule_with_premise(name: &str, line: u32, premise_line: u32) -> Rule {
     Rule {
         name: name.into(),
-        raw_text: String::new(),
+        raw_text: format!("(if true)\n----- (\"{name}\")\n(prove_thing(x) => ())"),
         line,
         premises: vec![premise("if true", PremiseKind::If, true, premise_line)],
     }
@@ -249,25 +249,53 @@ fn markdown_index_snapshot() {
 fn markdown_subpage_snapshot() {
     let j = prove_thing_judgment();
     let cov = prove_thing_coverage();
-    let md = report::render_subpage(&j, &cov);
-    expect![[r#"
+    let md = report::render_subpage(&j, &cov, "md");
+    expect![[r##"
         # Judgment `prove_thing` at fixture.rs:4
 
-        ## Rules
+        The number on each rule's conclusion is **positive** coverage; the number on each premise is **negative** coverage. Click a number to browse the tests.
 
-        | Rule | Line | Positive coverage |
-        | --- | --- | --- |
-        | <a id="positive"></a>`positive` | 10 | [1 test](./prove_thing__positive__pos.md) |
-        | <a id="zero"></a>`zero` | 16 | ✗ |
+        <style>
+        .cov-rule{border:1px solid var(--quote-border,#d0d0d0);border-radius:6px;margin:1rem 0;overflow:hidden}
+        .cov-rule-head{padding:.4rem .8rem;background:var(--quote-bg,#f6f7f9);font-weight:600}
+        table.cov-code{width:100%;border-collapse:collapse;font-family:var(--mono-font,monospace);font-size:.85em;margin:0}
+        table.cov-code td{padding:.15rem .6rem;border:0}
+        table.cov-code th{padding:.15rem .6rem;border:0;border-bottom:1px solid var(--quote-border,#d0d0d0);color:#888;font-weight:600;font-size:.9em}
+        .cov-ln{text-align:right;color:#999;user-select:none;width:3em;white-space:nowrap}
+        .cov-num{text-align:right;width:3.5em;white-space:nowrap;font-weight:600}
+        .cov-num.pos a{color:#1a7f37}
+        .cov-num.neg a{color:#b35900}
+        .cov-none{color:#bbb}
+        .cov-na{color:#bbb;font-weight:400}
+        .cov-src-line{white-space:pre-wrap}
+        tr.cov-sep td{color:#999}
+        tr.cov-concl{background:rgba(127,127,127,.08)}
+        details.cov-tests{margin:1rem 0}
+        details.cov-test{margin:.3rem 0 .3rem 1rem}
+        summary{cursor:pointer}
+        </style>
 
-        ## Premises (negative coverage)
+        <div class="cov-rule" id="positive">
+        <div class="cov-rule-head"><code>positive</code></div>
+        <table class="cov-code">
+        <thead><tr><th class="cov-ln">Line</th><th class="cov-num">Coverage</th><th class="cov-src-line">Source</th></tr></thead>
+        <tr><td class="cov-ln">9</td><td class="cov-num neg"><a href="./prove_thing__positive__p9__neg.md" title="failure causes: if_false">1</a></td><td class="cov-src-line">(if true)</td></tr>
+        <tr class="cov-sep"><td class="cov-ln"></td><td class="cov-num"></td><td class="cov-src-line">──────── ("positive")</td></tr>
+        <tr class="cov-concl"><td class="cov-ln">11</td><td class="cov-num pos"><a href="./prove_thing__positive__pos.md">1</a></td><td class="cov-src-line">(prove_thing(x) =&gt; ())</td></tr>
+        </table>
+        </div>
 
-        | Rule | Premise | Line | Negatively tested |
-        | --- | --- | --- | --- |
-        | `positive` | `if true` | 9 | [1 test](./prove_thing__positive__p9__neg.md) (if_false) |
-        | `zero` | `if true` | 15 | ✗ |
-    "#]]
-    .assert_eq(&md);
+        <div class="cov-rule" id="zero">
+        <div class="cov-rule-head"><code>zero</code></div>
+        <table class="cov-code">
+        <thead><tr><th class="cov-ln">Line</th><th class="cov-num">Coverage</th><th class="cov-src-line">Source</th></tr></thead>
+        <tr><td class="cov-ln">15</td><td class="cov-num neg"><span class="cov-none">✗</span></td><td class="cov-src-line">(if true)</td></tr>
+        <tr class="cov-sep"><td class="cov-ln"></td><td class="cov-num"></td><td class="cov-src-line">──────── ("zero")</td></tr>
+        <tr class="cov-concl"><td class="cov-ln">17</td><td class="cov-num pos"><span class="cov-none">✗</span></td><td class="cov-src-line">(prove_thing(x) =&gt; ())</td></tr>
+        </table>
+        </div>
+
+    "##]].assert_eq(&md);
 }
 
 #[test]
@@ -295,9 +323,12 @@ fn detail_pages_list_tests() {
         pos.content
     );
     assert!(pos.content.contains("1 test exercised this rule"));
+    // The test is revealed behind a disclosure triangle, with its source as a
+    // GitHub link.
+    assert!(pos.content.contains("<details"), "{}", pos.content);
     assert!(
         pos.content.contains(
-            "- [tests/prove_thing.rs:42](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L42)"
+            "<a href=\"https://github.com/example/repo/blob/main/tests/prove_thing.rs#L42\" target=\"_blank\">tests/prove_thing.rs:42</a>"
         ),
         "{}",
         pos.content
@@ -313,7 +344,7 @@ fn detail_pages_list_tests() {
     );
     assert!(
         neg.content.contains(
-            "- [tests/prove_thing.rs:99](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L99)"
+            "<a href=\"https://github.com/example/repo/blob/main/tests/prove_thing.rs#L99\" target=\"_blank\">tests/prove_thing.rs:99</a>"
         ),
         "{}",
         neg.content
@@ -326,7 +357,11 @@ fn detail_pages_without_github_base_use_plain_locations() {
     let cov = prove_thing_coverage();
     let pages = report::render_detail_pages_for(&j, &cov, None);
     let pos = &pages[0];
-    assert!(pos.content.contains("- tests/prove_thing.rs:42"));
+    assert!(
+        pos.content.contains("tests/prove_thing.rs:42"),
+        "{}",
+        pos.content
+    );
     assert!(!pos.content.contains("https://"), "{}", pos.content);
 }
 
@@ -340,7 +375,7 @@ fn infallible_premise_renders_as_na() {
         line: 1,
         rules: vec![Rule {
             name: "trivial".into(),
-            raw_text: String::new(),
+            raw_text: "(let x = y)\n----- (\"trivial\")\n(easy(y) => x)".into(),
             line: 7,
             premises: vec![premise("let x = y", PremiseKind::Let, false, 6)],
         }],
@@ -358,23 +393,43 @@ fn infallible_premise_renders_as_na() {
     "#]]
     .assert_eq(&index);
 
-    let subpage = report::render_subpage(&j, &cov);
-    expect![[r#"
+    let subpage = report::render_subpage(&j, &cov, "md");
+    expect![[r##"
         # Judgment `easy` at fixture.rs:1
 
-        ## Rules
+        The number on each rule's conclusion is **positive** coverage; the number on each premise is **negative** coverage. Click a number to browse the tests.
 
-        | Rule | Line | Positive coverage |
-        | --- | --- | --- |
-        | <a id="trivial"></a>`trivial` | 7 | ✗ |
+        <style>
+        .cov-rule{border:1px solid var(--quote-border,#d0d0d0);border-radius:6px;margin:1rem 0;overflow:hidden}
+        .cov-rule-head{padding:.4rem .8rem;background:var(--quote-bg,#f6f7f9);font-weight:600}
+        table.cov-code{width:100%;border-collapse:collapse;font-family:var(--mono-font,monospace);font-size:.85em;margin:0}
+        table.cov-code td{padding:.15rem .6rem;border:0}
+        table.cov-code th{padding:.15rem .6rem;border:0;border-bottom:1px solid var(--quote-border,#d0d0d0);color:#888;font-weight:600;font-size:.9em}
+        .cov-ln{text-align:right;color:#999;user-select:none;width:3em;white-space:nowrap}
+        .cov-num{text-align:right;width:3.5em;white-space:nowrap;font-weight:600}
+        .cov-num.pos a{color:#1a7f37}
+        .cov-num.neg a{color:#b35900}
+        .cov-none{color:#bbb}
+        .cov-na{color:#bbb;font-weight:400}
+        .cov-src-line{white-space:pre-wrap}
+        tr.cov-sep td{color:#999}
+        tr.cov-concl{background:rgba(127,127,127,.08)}
+        details.cov-tests{margin:1rem 0}
+        details.cov-test{margin:.3rem 0 .3rem 1rem}
+        summary{cursor:pointer}
+        </style>
 
-        ## Premises (negative coverage)
+        <div class="cov-rule" id="trivial">
+        <div class="cov-rule-head"><code>trivial</code></div>
+        <table class="cov-code">
+        <thead><tr><th class="cov-ln">Line</th><th class="cov-num">Coverage</th><th class="cov-src-line">Source</th></tr></thead>
+        <tr><td class="cov-ln">6</td><td class="cov-num neg"><span class="cov-na">N/A</span></td><td class="cov-src-line">(let x = y)</td></tr>
+        <tr class="cov-sep"><td class="cov-ln"></td><td class="cov-num"></td><td class="cov-src-line">──────── ("trivial")</td></tr>
+        <tr class="cov-concl"><td class="cov-ln">8</td><td class="cov-num pos"><span class="cov-none">✗</span></td><td class="cov-src-line">(easy(y) =&gt; x)</td></tr>
+        </table>
+        </div>
 
-        | Rule | Premise | Line | Negatively tested |
-        | --- | --- | --- | --- |
-        | `trivial` | `let x = y` | 6 | N/A |
-    "#]]
-    .assert_eq(&subpage);
+    "##]].assert_eq(&subpage);
 }
 
 #[test]
@@ -399,7 +454,7 @@ fn no_applicable_rule_renders_in_index_and_subpage() {
     "#]]
     .assert_eq(&index);
 
-    let subpage = report::render_subpage(&j, &cov);
+    let subpage = report::render_subpage(&j, &cov, "md");
     assert!(subpage.contains("_No applicable rule observed:"));
 }
 
@@ -414,7 +469,7 @@ fn empty_rules_renders_no_rules_message() {
         rules: vec![],
     };
     let cov = Coverage::default();
-    let md = report::render_subpage(&j, &cov);
+    let md = report::render_subpage(&j, &cov, "md");
     expect![[r#"
         # Judgment `lonely` at fixture.rs:1
 

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -191,13 +191,22 @@ fn prove_thing_judgment() -> Judgment {
 /// Coverage where `prove_thing`'s `positive` premise (line 9) failed in a
 /// negative test with cause `if_false`, but `zero`'s premise (line 15) never did.
 fn prove_thing_coverage() -> Coverage {
+    let positive_premise = PremiseLoc {
+        file: "crates/sub/fixture.rs".into(),
+        line: 9,
+    };
     let mut negative_premises = BTreeMap::new();
     negative_premises.insert(
-        PremiseLoc {
-            file: "crates/sub/fixture.rs".into(),
-            line: 9,
-        },
+        positive_premise.clone(),
         BTreeSet::from(["if_false".to_string()]),
+    );
+    let mut negative_premise_tests = BTreeMap::new();
+    negative_premise_tests.insert(
+        positive_premise,
+        BTreeSet::from([TestLoc {
+            file: "tests/prove_thing.rs".into(),
+            line: 99,
+        }]),
     );
     Coverage {
         positive: BTreeMap::from([(
@@ -211,6 +220,7 @@ fn prove_thing_coverage() -> Coverage {
             }]),
         )]),
         negative_premises,
+        negative_premise_tests,
         no_applicable_rule: BTreeSet::new(),
     }
 }
@@ -222,14 +232,14 @@ const GITHUB_BASE: &str = "https://github.com/example/repo/blob/main";
 fn markdown_index_snapshot() {
     let judgments = vec![prove_thing_judgment()];
     let cov = prove_thing_coverage();
-    let md = report::render_index(&judgments, &cov, Some(GITHUB_BASE));
+    let md = report::render_index(&judgments, &cov);
     expect![[r#"
         # Coverage report
 
         | Judgment/Rule | Positive coverage | Negative coverage |
         | --- | --- | --- |
         | **[prove_thing](./prove_thing.md)** | - | - |
-        | ↳ [positive](./prove_thing.md#positive) | [✓](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L42) | 1/1 |
+        | ↳ [positive](./prove_thing.md#positive) | [1 test](./prove_thing__positive__pos.md) | 1/1 |
         | ↳ [zero](./prove_thing.md#zero) | ✗ | 0/1 |
     "#]]
     .assert_eq(&md);
@@ -239,7 +249,7 @@ fn markdown_index_snapshot() {
 fn markdown_subpage_snapshot() {
     let j = prove_thing_judgment();
     let cov = prove_thing_coverage();
-    let md = report::render_subpage(&j, &cov, Some(GITHUB_BASE));
+    let md = report::render_subpage(&j, &cov);
     expect![[r#"
         # Judgment `prove_thing` at fixture.rs:4
 
@@ -247,17 +257,77 @@ fn markdown_subpage_snapshot() {
 
         | Rule | Line | Positive coverage |
         | --- | --- | --- |
-        | <a id="positive"></a>`positive` | 10 | [✓](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L42) |
+        | <a id="positive"></a>`positive` | 10 | [1 test](./prove_thing__positive__pos.md) |
         | <a id="zero"></a>`zero` | 16 | ✗ |
 
         ## Premises (negative coverage)
 
         | Rule | Premise | Line | Negatively tested |
         | --- | --- | --- | --- |
-        | `positive` | `if true` | 9 | ✓ (if_false) |
+        | `positive` | `if true` | 9 | [1 test](./prove_thing__positive__p9__neg.md) (if_false) |
         | `zero` | `if true` | 15 | ✗ |
     "#]]
     .assert_eq(&md);
+}
+
+#[test]
+fn detail_pages_list_tests() {
+    let j = prove_thing_judgment();
+    let cov = prove_thing_coverage();
+    let pages = report::render_detail_pages_for(&j, &cov, Some(GITHUB_BASE));
+
+    // One positive page for the covered `positive` rule, one negative page for
+    // its negatively-tested premise. `zero` is uncovered, so it gets no page.
+    let slugs: Vec<&str> = pages.iter().map(|p| p.slug.as_str()).collect();
+    assert_eq!(
+        slugs,
+        vec![
+            "prove_thing__positive__pos",
+            "prove_thing__positive__p9__neg",
+        ]
+    );
+
+    let pos = &pages[0];
+    assert!(
+        pos.content
+            .contains("# Positive coverage: `prove_thing` / `positive`"),
+        "{}",
+        pos.content
+    );
+    assert!(pos.content.contains("1 test exercised this rule"));
+    assert!(
+        pos.content.contains(
+            "- [tests/prove_thing.rs:42](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L42)"
+        ),
+        "{}",
+        pos.content
+    );
+
+    let neg = &pages[1];
+    assert!(neg.content.contains("premise `if true`"), "{}", neg.content);
+    assert!(
+        neg.content
+            .contains("Premise at line 9. Observed failure causes: if_false."),
+        "{}",
+        neg.content
+    );
+    assert!(
+        neg.content.contains(
+            "- [tests/prove_thing.rs:99](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L99)"
+        ),
+        "{}",
+        neg.content
+    );
+}
+
+#[test]
+fn detail_pages_without_github_base_use_plain_locations() {
+    let j = prove_thing_judgment();
+    let cov = prove_thing_coverage();
+    let pages = report::render_detail_pages_for(&j, &cov, None);
+    let pos = &pages[0];
+    assert!(pos.content.contains("- tests/prove_thing.rs:42"));
+    assert!(!pos.content.contains("https://"), "{}", pos.content);
 }
 
 #[test]
@@ -277,7 +347,7 @@ fn infallible_premise_renders_as_na() {
     };
     let cov = Coverage::default();
 
-    let index = report::render_index(&[j.clone()], &cov, None);
+    let index = report::render_index(&[j.clone()], &cov);
     expect![[r#"
         # Coverage report
 
@@ -288,7 +358,7 @@ fn infallible_premise_renders_as_na() {
     "#]]
     .assert_eq(&index);
 
-    let subpage = report::render_subpage(&j, &cov, None);
+    let subpage = report::render_subpage(&j, &cov);
     expect![[r#"
         # Judgment `easy` at fixture.rs:1
 
@@ -317,7 +387,7 @@ fn no_applicable_rule_renders_in_index_and_subpage() {
         line: 4,
     });
 
-    let index = report::render_index(&[j.clone()], &cov, None);
+    let index = report::render_index(&[j.clone()], &cov);
     expect![[r#"
         # Coverage report
 
@@ -329,7 +399,7 @@ fn no_applicable_rule_renders_in_index_and_subpage() {
     "#]]
     .assert_eq(&index);
 
-    let subpage = report::render_subpage(&j, &cov, None);
+    let subpage = report::render_subpage(&j, &cov);
     assert!(subpage.contains("_No applicable rule observed:"));
 }
 
@@ -344,7 +414,7 @@ fn empty_rules_renders_no_rules_message() {
         rules: vec![],
     };
     let cov = Coverage::default();
-    let md = report::render_subpage(&j, &cov, None);
+    let md = report::render_subpage(&j, &cov);
     expect![[r#"
         # Judgment `lonely` at fixture.rs:1
 
@@ -385,6 +455,14 @@ fn jsonl_reads_positive_and_negative_records() {
     let causes = cov.premise_causes_for("f.rs", 11);
     let causes: Vec<&str> = causes.iter().map(String::as_str).collect();
     assert_eq!(causes, vec!["if_false", "if_let"]);
+
+    // The negative record's test location is retained so the report can link
+    // the failing premise back to the test that exercised it.
+    let neg_tests = cov.negative_premise_tests("f.rs", 11);
+    assert!(neg_tests.contains(&TestLoc {
+        file: "b.rs".into(),
+        line: 2,
+    }));
     // Different file should not match.
     assert!(cov.premise_causes_for("other.rs", 11).is_empty());
     // Different line should not match.

--- a/crates/formality-mdbook/src/lib.rs
+++ b/crates/formality-mdbook/src/lib.rs
@@ -123,7 +123,7 @@ fn append_coverage_chapters(
         }
         let mut chapter = Chapter::new(
             &j.name,
-            report::render_subpage(j, &cov),
+            report::render_subpage(j, &cov, "html"),
             PathBuf::from(format!("{slug}.md")),
             vec!["Coverage report".to_string()],
         );

--- a/crates/formality-mdbook/src/lib.rs
+++ b/crates/formality-mdbook/src/lib.rs
@@ -133,7 +133,9 @@ fn append_coverage_chapters(
         // hang off this judgment's subpage with a third section-number
         // component, so they fold under it in the sidebar.
         let mut detail_items: Vec<BookItem> = Vec::new();
-        for (k, page) in report::render_detail_pages_for(j, &cov, github_base)
+        // Recorded test locations are relative to the repo root, which is the
+        // book directory's parent.
+        for (k, page) in report::render_detail_pages_for(j, &cov, github_base, root.parent())
             .into_iter()
             .enumerate()
         {

--- a/crates/formality-mdbook/src/lib.rs
+++ b/crates/formality-mdbook/src/lib.rs
@@ -123,17 +123,46 @@ fn append_coverage_chapters(
         }
         let mut chapter = Chapter::new(
             &j.name,
-            report::render_subpage(j, &cov, github_base),
+            report::render_subpage(j, &cov),
             PathBuf::from(format!("{slug}.md")),
             vec!["Coverage report".to_string()],
         );
         chapter.number = Some(SectionNumber::new(vec![next_top, (i + 1) as u32]));
+
+        // Per-cell detail pages (the test lists each coverage cell links to)
+        // hang off this judgment's subpage with a third section-number
+        // component, so they fold under it in the sidebar.
+        let mut detail_items: Vec<BookItem> = Vec::new();
+        for (k, page) in report::render_detail_pages_for(j, &cov, github_base)
+            .into_iter()
+            .enumerate()
+        {
+            if !seen_slugs.insert(page.slug.clone()) {
+                eprintln!(
+                    "warning: slug collision for coverage detail page `{}`, it will overwrite a sibling",
+                    page.slug,
+                );
+            }
+            let mut detail = Chapter::new(
+                &page.title,
+                page.content,
+                PathBuf::from(format!("{}.md", page.slug)),
+                vec!["Coverage report".to_string(), j.name.clone()],
+            );
+            detail.number = Some(SectionNumber::new(vec![
+                next_top,
+                (i + 1) as u32,
+                (k + 1) as u32,
+            ]));
+            detail_items.push(BookItem::Chapter(detail));
+        }
+        chapter.sub_items = detail_items;
         subpages.push(BookItem::Chapter(chapter));
     }
 
     let mut index_chapter = Chapter::new(
         "Coverage report",
-        report::render_index(&judgments, &cov, github_base),
+        report::render_index(&judgments, &cov),
         PathBuf::from("coverage.md"),
         vec![],
     );


### PR DESCRIPTION
## What does this PR do?

Follow-up to #401. Coverage cells now link to a per-cell **detail page** listing every test involved, instead of the ✓ linking only to the first test.

## How does it work, what questions do you have?

Each cell links to `./<slug>.md`, and the same `slug` helpers produce the detail pages, so links and pages always line up. The negative test locations were already in the JSONL; the reader just wasn't keeping them so changes there.

## The Coverage Table
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/e1e8f733-4c00-4b35-898b-fb2bb42ef31d" />

## The Detail Page
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/4f1eae02-bb6b-4ab7-8bd9-23216a3d2c13" />


## AI disclosure

* I used an AI to author the main logic of the code
