### PR TITLE
add: optional-fn-return-type

### DIFF
--- a/crates/formality-macros/src/debug.rs
+++ b/crates/formality-macros/src/debug.rs
@@ -325,7 +325,12 @@ fn debug_field_with_mode(name: &Ident, mode: &FieldMode) -> TokenStream {
         }
 
         FieldMode::Guarded { guard, mode } => {
-            let guard = as_literal(guard);
+            // The guard can be a keyword (`where`) or an operator (`->`) print
+            // its text either way.
+            let guard = match guard {
+                spec::Guard::Keyword(ident) => Literal::string(&ident.to_string()),
+                spec::Guard::Operator(operator) => Literal::string(operator),
+            };
             let base = debug_field_with_mode(name, mode);
 
             quote_spanned! { name.span() =>

--- a/crates/formality-macros/src/parse.rs
+++ b/crates/formality-macros/src/parse.rs
@@ -500,132 +500,60 @@ fn wrap_field_mode(
         }
 
         FieldMode::Guarded { guard, mode } => {
-            let guard_keyword = as_literal(guard);
-            match mode.as_ref() {
+            // A guard is present when its leading token matches. `cond` is a
+            // `bool` expression that consumes the leading token on success (and
+            // nothing on failure) `after` consumes any remaining guard tokens
+            // once we have committed to the guard.
+            let (cond, after) = match guard {
+                spec::Guard::Keyword(ident) => {
+                    let keyword = as_literal(ident);
+                    (quote!(__p.expect_keyword(#keyword).is_ok()), quote!())
+                }
+                spec::Guard::Operator(operator) => {
+                    let mut chars = operator.chars();
+                    let first = chars
+                        .next()
+                        .expect("operator guard must have at least one character");
+                    let rest: Vec<TokenStream> =
+                        chars.map(|c| quote!(__p.expect_char(#c)?;)).collect();
+                    (quote!(__p.expect_char(#first).is_ok()), quote!(#(#rest)*))
+                }
+            };
+
+            // How to parse the field once the guard has matched.
+            let parse_present = match mode.as_ref() {
                 FieldMode::Single => {
                     if let Some(ty) = field_ty {
-                        quote_spanned!(name.span() =>
-                            match __p.expect_keyword(#guard_keyword) {
-                                Ok(()) => {
-                                    __p.each_nonterminal(|#name: #ty, __p| {
-                                        #inner
-                                    })
-                                }
-                                Err(_) => {
-                                    let #name: #ty = Default::default();
-                                    #inner
-                                }
-                            }
-                        )
+                        quote!(__p.each_nonterminal(|#name: #ty, __p| { #inner }))
                     } else {
-                        quote_spanned!(name.span() =>
-                            match __p.expect_keyword(#guard_keyword) {
-                                Ok(()) => {
-                                    __p.each_nonterminal(|#name, __p| {
-                                        #inner
-                                    })
-                                }
-                                Err(_) => {
-                                    let #name = Default::default();
-                                    #inner
-                                }
-                            }
-                        )
+                        quote!(__p.each_nonterminal(|#name, __p| { #inner }))
                     }
                 }
                 FieldMode::Optional => {
                     if let Some(ty) = field_ty {
-                        quote_spanned!(name.span() =>
-                            match __p.expect_keyword(#guard_keyword) {
-                                Ok(()) => {
-                                    __p.each_opt_nonterminal(|#name: Option<#ty>, __p| {
-                                        let #name: #ty = #name.unwrap_or_default();
-                                        #inner
-                                    })
-                                }
-                                Err(_) => {
-                                    let #name: #ty = Default::default();
-                                    #inner
-                                }
-                            }
-                        )
+                        quote!(__p.each_opt_nonterminal(|#name: Option<#ty>, __p| {
+                            let #name: #ty = #name.unwrap_or_default();
+                            #inner
+                        }))
                     } else {
-                        quote_spanned!(name.span() =>
-                            match __p.expect_keyword(#guard_keyword) {
-                                Ok(()) => {
-                                    __p.each_opt_nonterminal(|#name, __p| {
-                                        let #name = #name.unwrap_or_default();
-                                        #inner
-                                    })
-                                }
-                                Err(_) => {
-                                    let #name = Default::default();
-                                    #inner
-                                }
-                            }
-                        )
+                        quote!(__p.each_opt_nonterminal(|#name, __p| {
+                            let #name = #name.unwrap_or_default();
+                            #inner
+                        }))
                     }
                 }
                 FieldMode::Many => {
                     if let Some(ty) = field_ty {
-                        quote_spanned!(name.span() =>
-                            match __p.expect_keyword(#guard_keyword) {
-                                Ok(()) => {
-                                    __p.each_many_nonterminal(|#name: #ty, __p| {
-                                        #inner
-                                    })
-                                }
-                                Err(_) => {
-                                    let #name: #ty = Default::default();
-                                    #inner
-                                }
-                            }
-                        )
+                        quote!(__p.each_many_nonterminal(|#name: #ty, __p| { #inner }))
                     } else {
-                        quote_spanned!(name.span() =>
-                            match __p.expect_keyword(#guard_keyword) {
-                                Ok(()) => {
-                                    __p.each_many_nonterminal(|#name, __p| {
-                                        #inner
-                                    })
-                                }
-                                Err(_) => {
-                                    let #name = Default::default();
-                                    #inner
-                                }
-                            }
-                        )
+                        quote!(__p.each_many_nonterminal(|#name, __p| { #inner }))
                     }
                 }
                 FieldMode::Comma => {
                     if let Some(ty) = field_ty {
-                        quote_spanned!(name.span() =>
-                            match __p.expect_keyword(#guard_keyword) {
-                                Ok(()) => {
-                                    __p.each_comma_nonterminal(|#name: #ty, __p| {
-                                        #inner
-                                    })
-                                }
-                                Err(_) => {
-                                    let #name: #ty = Default::default();
-                                    #inner
-                                }
-                            }
-                        )
+                        quote!(__p.each_comma_nonterminal(|#name: #ty, __p| { #inner }))
                     } else {
-                        quote_spanned!(name.span() =>
-                            match __p.expect_keyword(#guard_keyword) {
-                                Ok(()) => {
-                                    __p.each_comma_nonterminal(|#name, __p| {
-                                        #inner
-                                    })
-                                }
-                                Err(_) => {
-                                    let #name = Default::default();
-                                    #inner
-                                }
-                            }
-                        )
+                        quote!(__p.each_comma_nonterminal(|#name, __p| { #inner }))
                     }
                 }
                 FieldMode::DelimitedVec {
@@ -636,40 +564,32 @@ fn wrap_field_mode(
                     let open = Literal::character(*open);
                     let close = Literal::character(*close);
                     if let Some(ty) = field_ty {
-                        quote_spanned!(name.span() =>
-                            match __p.expect_keyword(#guard_keyword) {
-                                Ok(()) => {
-                                    __p.each_delimited_nonterminal(#open, #optional, #close, |#name: #ty, __p| {
-                                        #inner
-                                    })
-                                }
-                                Err(_) => {
-                                    let #name: #ty = Default::default();
-                                    #inner
-                                }
-                            }
-                        )
+                        quote!(__p.each_delimited_nonterminal(#open, #optional, #close, |#name: #ty, __p| { #inner }))
                     } else {
-                        quote_spanned!(name.span() =>
-                            match __p.expect_keyword(#guard_keyword) {
-                                Ok(()) => {
-                                    __p.each_delimited_nonterminal(#open, #optional, #close, |#name, __p| {
-                                        #inner
-                                    })
-                                }
-                                Err(_) => {
-                                    let #name = Default::default();
-                                    #inner
-                                }
-                            }
-                        )
+                        quote!(__p.each_delimited_nonterminal(#open, #optional, #close, |#name, __p| { #inner }))
                     }
                 }
                 FieldMode::Guarded { .. } => {
                     // Nested guarded — unlikely but handle by falling back
                     panic!("nested Guarded modes are not supported");
                 }
-            }
+            };
+
+            // How to fill the field in when the guard is absent.
+            let parse_absent = if let Some(ty) = field_ty {
+                quote!(let #name: #ty = Default::default(); #inner)
+            } else {
+                quote!(let #name = Default::default(); #inner)
+            };
+
+            quote_spanned!(name.span() =>
+                if #cond {
+                    #after
+                    #parse_present
+                } else {
+                    #parse_absent
+                }
+            )
         }
     }
 }

--- a/crates/formality-macros/src/spec.rs
+++ b/crates/formality-macros/src/spec.rs
@@ -34,13 +34,25 @@ pub enum FormalitySpecSymbol {
     Delimeter { text: char },
 }
 
+/// The token that gates a [`FieldMode::Guarded`] field. It is parsed only if
+/// the guard is present in the input.
+#[derive(Debug)]
+pub enum Guard {
+    /// A keyword guard, e.g. the `where` in `$:where $,where_clauses`.
+    Keyword(Ident),
+
+    /// A run of punctuation, e.g. the `->` in `$:-> $output_ty`.
+    Operator(String),
+}
+
 #[derive(Debug)]
 pub enum FieldMode {
     /// $x -- just parse `x`
     Single,
 
-    /// $:ident $nt -- try to parse `ident` and, if present, parse `$nt`
-    Guarded { guard: Ident, mode: Arc<FieldMode> },
+    /// $:ident $nt -- try to parse the guard (a keyword like `where` or an
+    /// operator like `->`) and, if present, parse `$nt`; otherwise use `Default`.
+    Guarded { guard: Guard, mode: Arc<FieldMode> },
 
     /// $<x> -- `x` is a `Vec<E>`, parse `<E0,...,En>`
     /// $[x] -- `x` is a `Vec<E>`, parse `[E0,...,En]`
@@ -229,12 +241,37 @@ fn parse_variable_binding(
         guard_token: TokenTree,
         tokens: &mut Peekable<impl Iterator<Item = TokenTree>>,
     ) -> syn::Result<FormalitySpecSymbol> {
-        // The next token should be an identifier
-        let Some(TokenTree::Ident(guard_ident)) = tokens.next() else {
-            return error(
-                &guard_token,
-                "expected an identifier after a `:` in a field reference",
-            );
+        // The guard is either a single keyword identifier (e.g. `where`) or a
+        // run of punctuation (e.g. `->`). It is terminated by the `$` that
+        // begins the guarded field reference.
+        let guard = match tokens.peek() {
+            Some(TokenTree::Ident(_)) => {
+                let Some(TokenTree::Ident(guard_ident)) = tokens.next() else {
+                    unreachable!()
+                };
+                Guard::Keyword(guard_ident)
+            }
+
+            Some(TokenTree::Punct(punct)) if punct.as_char() != '$' => {
+                let mut operator = String::new();
+                while let Some(TokenTree::Punct(punct)) = tokens.peek() {
+                    let ch = punct.as_char();
+                    // The `$` that introduces the guarded field ends the guard.
+                    if ch == '$' {
+                        break;
+                    }
+                    operator.push(ch);
+                    tokens.next();
+                }
+                Guard::Operator(operator)
+            }
+
+            _ => {
+                return error(
+                    &guard_token,
+                    "expected an identifier or operator after a `:` in a field reference",
+                );
+            }
         };
 
         // The next token should be a `$`, beginning another variable binding
@@ -262,7 +299,7 @@ fn parse_variable_binding(
         };
 
         let guard_mode = FieldMode::Guarded {
-            guard: guard_ident,
+            guard,
             mode: Arc::new(mode),
         };
 

--- a/crates/formality-rust/src/grammar/fns.rs
+++ b/crates/formality-rust/src/grammar/fns.rs
@@ -10,7 +10,7 @@ pub struct Fn {
     pub binder: Binder<FnBoundData>,
 }
 
-#[term($(input_args) -> $output_ty $:where $,where_clauses $body)]
+#[term($(input_args) $:-> $output_ty $:where $,where_clauses $body)]
 pub struct FnBoundData {
     pub input_args: Vec<InputArg>,
     pub output_ty: Ty,

--- a/crates/formality-rust/src/grammar/ty.rs
+++ b/crates/formality-rust/src/grammar/ty.rs
@@ -94,6 +94,13 @@ impl Ty {
     }
 }
 
+/// The default type is the unit type `()`.
+impl Default for Ty {
+    fn default() -> Self {
+        Ty::unit()
+    }
+}
+
 // ANCHOR: RigidTy_decl
 #[term((rigid $name $*parameters))]
 #[customize(parse, debug)]

--- a/crates/formality-rust/src/test.rs
+++ b/crates/formality-rust/src/test.rs
@@ -188,6 +188,52 @@ fn test_parse_trusted_fn() {
 }
 
 #[test]
+fn test_parse_fn_without_return_type() {
+    // Same as `test_parse_trusted_fn`, but the return type is omitted. The
+    // parsed structure is identical `output_ty` defaults to the unit type
+    // `()`, exactly as if `-> ()` had been written.
+    let r: Crates = term(
+        "[
+            crate core {
+              fn run() {trusted}
+            }
+        ]",
+    );
+
+    expect_test::expect![[r#"
+        Crates {
+            crates: [
+                Crate {
+                    id: core,
+                    items: [
+                        Fn(
+                            Fn {
+                                id: run,
+                                safety: Safe,
+                                binder: Binder {
+                                    kinds: [],
+                                    term: FnBoundData {
+                                        input_args: [],
+                                        output_ty: RigidTy(
+                                            (),
+                                        ),
+                                        where_clauses: [],
+                                        body: FnBody(
+                                            TrustedFnBody,
+                                        ),
+                                    },
+                                },
+                            },
+                        ),
+                    ],
+                },
+            ],
+        }
+    "#]]
+    .assert_debug_eq(&r);
+}
+
+#[test]
 fn test_place_expr_ambiguity_deref_vs_field() {
     let p: PlaceExpr = term("*p.f");
     expect_test::expect![[r#"

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -36,3 +36,19 @@ fn lifetime() {
     .skip_execute()
     .ok()
 }
+
+#[test]
+fn omitted_return_type() {
+    FormalityTest::new(crates![
+        crate Foo {
+            fn simple_fn() { trusted }
+            fn one_arg<T>(v0: T) { trusted }
+            fn with_where<'a, T>(v0: &'a T)
+            where
+                T: 'a,
+            { trusted }
+        }
+    ])
+    .skip_execute()
+    .ok()
+}


### PR DESCRIPTION
## What does this PR do?
This PR implements optional function return type as discussed in https://github.com/rust-lang/a-mir-formality/issues/393

e.g., closes #393

## How does it work, what questions do you have?

Functions can now be written `fn foo() { }` instead of requiring`fn foo() -> () { }`. When the return type is omitted, it defaults to the unit type `()`.      

Added tests demonstrating that `fn run() {trusted}` parses identically to`fn run() -> () {trusted}`.
 
## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools


