### PR TITLE
Render per-test proof trees on coverage detail pages

### DIFF
--- a/crates/formality-core/src/judgment/coverage.rs
+++ b/crates/formality-core/src/judgment/coverage.rs
@@ -20,7 +20,8 @@ use std::io::Write;
 use std::panic::Location;
 use std::path::PathBuf;
 
-use super::{FailedJudgment, FailureReason, ProofTree};
+use super::proven_set::judgment_name_prefix;
+use super::{FailedJudgment, FailedRule, FailureReason, ProofTree, RuleFailureCause};
 
 /// A single (judgment, rule) pair as identified in positive coverage output.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
@@ -36,25 +37,137 @@ pub struct RuleId {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum CoverageRecord {
-    /// A test proved one or more judgments. We track only the rules that
-    /// fired: a successful proof means every premise of those rules held, so
-    /// premise-level detail adds nothing here.
+    /// A test proved one or more judgments. We track the rules that fired (a
+    /// successful proof means every premise of those rules held, so
+    /// premise-level detail adds nothing here) and, so the report can render
+    /// each test's proof, the success proof tree(s) themselves.
     Positive {
         test_file: String,
         test_line: u32,
         test_column: u32,
         rules: BTreeSet<RuleId>,
+        /// The success proof tree(s) this test produced, as a structural
+        /// snapshot (see [`ProofTreeNode`]). Defaulted so coverage files
+        /// written before trees were recorded still deserialize.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        trees: Vec<ProofTreeNode>,
     },
 
     /// A test asserted a judgment fails. We track the set of failure reasons
     /// (see [`FailureReason`]) so we can check that every fallible premise is
-    /// exercised by some negative test.
+    /// exercised by some negative test, and the failed proof tree(s) so the
+    /// report can render where each test's proof broke.
     Negative {
         test_file: String,
         test_line: u32,
         test_column: u32,
         reasons: BTreeSet<FailureReason>,
+        /// The failed proof tree(s) this test produced (see
+        /// [`FailedTreeNode`]). Defaulted for forward compatibility, as above.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        trees: Vec<FailedTreeNode>,
     },
+}
+
+/// A structural snapshot of a [`ProofTree`] node for embedding in positive
+/// coverage records. We keep the proof *shape* (judgment name, the rule that
+/// fired, the source location, and children) and drop the per-node attributes
+/// (argument/result `Debug` dumps), which are large and vary run-to-run.
+///
+/// We also drop "leaf" premise nodes that fired no rule and have no children:
+/// these are the macro's `if` / `let` / trivial side-conditions, whose names are
+/// large `Debug` dumps of bound values and which carry no inference structure.
+/// Every node we keep is therefore a rule application or a `for_all`, all of
+/// which have small, stable names. This keeps the snapshot both lean and a
+/// faithful tree of the rules that actually fired.
+///
+/// `rule` is owned because the live `ProofTree.rule_name` is `&'static str`,
+/// which serde can serialize but cannot deserialize into; a mirror type lets
+/// the report read trees back without changing the proving engine's hot type.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ProofTreeNode {
+    pub judgment: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rule: Option<String>,
+    pub file: String,
+    pub line: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<ProofTreeNode>,
+}
+
+impl From<&ProofTree> for ProofTreeNode {
+    fn from(t: &ProofTree) -> Self {
+        let children = t
+            .children
+            .iter()
+            .map(ProofTreeNode::from)
+            .filter(|c| c.rule.is_some() || !c.children.is_empty())
+            .collect();
+        ProofTreeNode {
+            judgment: t.judgment_name.clone(),
+            rule: t.rule_name.map(str::to_string),
+            file: t.file.replace('\\', "/"),
+            line: t.line,
+            children,
+        }
+    }
+}
+
+/// A structural snapshot of a [`FailedJudgment`] for embedding in negative
+/// coverage records: the judgment that failed and the rules that were tried.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FailedTreeNode {
+    pub judgment: String,
+    pub file: String,
+    pub line: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<FailedRuleNode>,
+}
+
+/// One tried-and-failed rule under a [`FailedTreeNode`]. `file`/`line` locate
+/// the rule's blamed premise (the macro respans failures onto it, so they match
+/// the premise position negative coverage is keyed by). A `failed_judgment`
+/// cause is represented structurally via `child`; every other cause is terminal
+/// and summarized by its `cause` discriminant tag, matching the deliberately
+/// payload-free, run-to-run-stable design of [`FailureReason`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FailedRuleNode {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rule: Option<String>,
+    pub file: String,
+    pub line: u32,
+    pub cause: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child: Option<Box<FailedTreeNode>>,
+}
+
+impl From<&FailedJudgment> for FailedTreeNode {
+    fn from(j: &FailedJudgment) -> Self {
+        FailedTreeNode {
+            judgment: judgment_name_prefix(&j.judgment),
+            file: j.location.file.replace('\\', "/"),
+            line: j.location.line,
+            rules: j.failed_rules.iter().map(FailedRuleNode::from).collect(),
+        }
+    }
+}
+
+impl From<&FailedRule> for FailedRuleNode {
+    fn from(r: &FailedRule) -> Self {
+        let child = match &r.cause {
+            RuleFailureCause::FailedJudgment(inner) => {
+                Some(Box::new(FailedTreeNode::from(&**inner)))
+            }
+            _ => None,
+        };
+        FailedRuleNode {
+            rule: r.rule_name.clone(),
+            file: r.file.replace('\\', "/"),
+            line: r.line,
+            cause: r.cause.discriminant_tag().to_string(),
+            child,
+        }
+    }
 }
 
 impl ProofTree {
@@ -103,8 +216,10 @@ pub fn record_coverage<'a>(trees: impl IntoIterator<Item = &'a ProofTree>) {
     let caller = Location::caller();
 
     let mut rules: BTreeSet<RuleId> = BTreeSet::new();
+    let mut snapshots: Vec<ProofTreeNode> = Vec::new();
     for tree in trees {
         tree.collect_rules_into(&mut rules);
+        snapshots.push(ProofTreeNode::from(tree));
     }
 
     let record = CoverageRecord::Positive {
@@ -112,6 +227,7 @@ pub fn record_coverage<'a>(trees: impl IntoIterator<Item = &'a ProofTree>) {
         test_line: caller.line(),
         test_column: caller.column(),
         rules,
+        trees: snapshots,
     };
     write_record(&path, &record);
 }
@@ -132,8 +248,10 @@ pub fn record_negative_coverage<'a>(failures: impl IntoIterator<Item = &'a Faile
     let caller = Location::caller();
 
     let mut reasons: BTreeSet<FailureReason> = BTreeSet::new();
+    let mut snapshots: Vec<FailedTreeNode> = Vec::new();
     for failure in failures {
         reasons.extend(failure.collect_failure_reasons());
+        snapshots.push(FailedTreeNode::from(failure));
     }
 
     let record = CoverageRecord::Negative {
@@ -141,6 +259,7 @@ pub fn record_negative_coverage<'a>(failures: impl IntoIterator<Item = &'a Faile
         test_line: caller.line(),
         test_column: caller.column(),
         reasons,
+        trees: snapshots,
     };
     write_record(&path, &record);
 }
@@ -182,11 +301,14 @@ fn coverage_dir() -> Option<PathBuf> {
     }
 }
 
-// Append-mode writes of small payloads are atomic under PIPE_BUF on POSIX and
-// have similar guarantees on Windows for ordinary files, so parallel `cargo test`
-// processes can safely append to the same file without locking, provided each
-// line stays small.
+// Parallel `cargo test` processes append to this file concurrently without
+// locking. Appends of a single payload are atomic for ordinary files, so we
+// build the record plus its trailing newline up front and emit it with one
+// `write_all` (rather than `writeln!`, which can issue separate writes for the
+// line and the newline and interleave under concurrency). The reader still
+// tolerates the occasional torn line, since embedding proof trees makes
+// individual lines larger and no atomicity guarantee is unconditional.
 fn append_line(path: &PathBuf, line: &str) -> std::io::Result<()> {
     let mut f = OpenOptions::new().create(true).append(true).open(path)?;
-    writeln!(f, "{line}")
+    f.write_all(format!("{line}\n").as_bytes())
 }

--- a/crates/formality-core/src/judgment/coverage.rs
+++ b/crates/formality-core/src/judgment/coverage.rs
@@ -12,6 +12,48 @@
 //! Recording is best-effort: I/O errors are swallowed so coverage never fails
 //! a test. Disable entirely with `FORMALITY_COVERAGE=0`. Redirect the output
 //! directory with `FORMALITY_COVERAGE_DIR` (used by the integration tests).
+//!
+//! # A worked example
+//!
+//! The snapshot types below ([`ProofTreeNode`], [`FailedTreeNode`]) are easiest
+//! to read against a concrete judgment. Take a one-rule judgment:
+//!
+//! ```text
+//! judgment_fn! {
+//!     pub fn is_positive(x: i32) => () {
+//!         debug(x)
+//!
+//!         (
+//!             (if x > 0)
+//!             ----------------------- ("positive")
+//!             (is_positive(x) => ())
+//!         )
+//!     }
+//! }
+//! ```
+//!
+//! and two tests: a positive one that proves `is_positive(1)`, and a negative
+//! one that asserts `is_positive(-1)` cannot be proven.
+//!
+//! The positive test fires the `"positive"` rule (its `if x > 0` premise
+//! holds), so [`record_coverage`] stores one [`ProofTreeNode`]:
+//!
+//! ```text
+//! ProofTreeNode { judgment: "is_positive", rule: Some("positive"), children: [] }
+//! ```
+//!
+//! The `if x > 0` premise is a leaf that fired no rule of its own, so it is
+//! dropped (see [`ProofTreeNode`]); only the rule application survives.
+//!
+//! The negative test fails because that rule's `if x > 0` premise is false, so
+//! [`record_negative_coverage`] stores one [`FailedTreeNode`]:
+//!
+//! ```text
+//! FailedTreeNode {
+//!     judgment: "is_positive",
+//!     rules: [FailedRuleNode { rule: Some("positive"), cause: "if_false", child: None }],
+//! }
+//! ```
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -72,7 +114,8 @@ pub enum CoverageRecord {
 /// A structural snapshot of a [`ProofTree`] node for embedding in positive
 /// coverage records. We keep the proof *shape* (judgment name, the rule that
 /// fired, the source location, and children) and drop the per-node attributes
-/// (argument/result `Debug` dumps), which are large and vary run-to-run.
+/// (the argument/result `Debug` dumps), which are large and which the report
+/// does not render.
 ///
 /// We also drop "leaf" premise nodes that fired no rule and have no children:
 /// these are the macro's `if` / `let` / trivial side-conditions, whose names are
@@ -86,7 +129,13 @@ pub enum CoverageRecord {
 /// the report read trees back without changing the proving engine's hot type.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProofTreeNode {
+    /// The name of the judgment this node proves, e.g. `"is_positive"` in the
+    /// module example (the identifier after `fn` in the `judgment_fn!`).
     pub judgment: String,
+    /// The rule that fired, e.g. `Some("positive")` (the name in quotes after
+    /// the rule's line). `None` marks a node that fired no named rule but is
+    /// kept because it groups children of its own, e.g. a `for_all` premise;
+    /// `None` leaves with no children are dropped (see the type doc).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rule: Option<String>,
     pub file: String,
@@ -301,14 +350,21 @@ fn coverage_dir() -> Option<PathBuf> {
     }
 }
 
-// Parallel `cargo test` processes append to this file concurrently without
-// locking. Appends of a single payload are atomic for ordinary files, so we
-// build the record plus its trailing newline up front and emit it with one
-// `write_all` (rather than `writeln!`, which can issue separate writes for the
-// line and the newline and interleave under concurrency). The reader still
-// tolerates the occasional torn line, since embedding proof trees makes
-// individual lines larger and no atomicity guarantee is unconditional.
+// Parallel `cargo test` processes append to this file concurrently. A bare
+// append is only atomic up to `PIPE_BUF` on POSIX, and an embedded proof tree
+// easily exceeds that, so without coordination two appends could interleave and
+// tear a line. We therefore hold an exclusive OS-level lock (`File::lock`,
+// released when `f` is dropped) for the duration of the write, which serializes
+// writers across processes. The record and its trailing newline are written in
+// a single `write_all` so the locked region is one call. We open with `read`
+// as well as `append` because Windows requires read access on the handle to
+// take the lock.
 fn append_line(path: &PathBuf, line: &str) -> std::io::Result<()> {
-    let mut f = OpenOptions::new().create(true).append(true).open(path)?;
+    let mut f = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .read(true)
+        .open(path)?;
+    f.lock()?;
     f.write_all(format!("{line}\n").as_bytes())
 }

--- a/crates/formality-core/src/judgment/proven_set.rs
+++ b/crates/formality-core/src/judgment/proven_set.rs
@@ -631,7 +631,7 @@ impl FailedJudgment {
 /// macro's `__JudgmentStruct` Debug impl is `debug_struct(stringify!(name))`,
 /// so the formatted string always starts with the judgment name followed
 /// by ` { ... }`. We grab characters up to the first non-identifier char.
-fn judgment_name_prefix(formatted: &str) -> String {
+pub(crate) fn judgment_name_prefix(formatted: &str) -> String {
     formatted
         .chars()
         .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')

--- a/crates/formality-coverage/src/jsonl.rs
+++ b/crates/formality-coverage/src/jsonl.rs
@@ -123,7 +123,12 @@ impl Coverage {
 }
 
 pub(crate) fn paths_overlap(a: &str, b: &str) -> bool {
-    a.ends_with(b) || b.ends_with(a)
+    // Coverage records normalize paths to forward slashes, but the scraped
+    // judgment paths use the host separator (backslashes on Windows), so
+    // normalize before comparing or every overlap check fails on Windows.
+    let a = a.replace('\\', "/");
+    let b = b.replace('\\', "/");
+    a.ends_with(&b) || b.ends_with(&a)
 }
 
 /// Parse the JSONL file at `path`. If the file does not exist, returns an
@@ -183,8 +188,11 @@ fn ingest(record: CoverageRecord, cov: &mut Coverage) {
                     .or_default()
                     .insert(loc.clone());
             }
+            // Keep one tree per test. The JSONL is append-only and accumulates
+            // across runs, so the same test can be recorded many times; its
+            // (deterministic) tree should be stored once, not duplicated.
             if !trees.is_empty() {
-                cov.positive_trees.entry(loc).or_default().extend(trees);
+                cov.positive_trees.entry(loc).or_insert(trees);
             }
         }
         CoverageRecord::Negative {
@@ -199,10 +207,7 @@ fn ingest(record: CoverageRecord, cov: &mut Coverage) {
                 line: test_line,
             };
             if !trees.is_empty() {
-                cov.negative_trees
-                    .entry(test.clone())
-                    .or_default()
-                    .extend(trees);
+                cov.negative_trees.entry(test.clone()).or_insert(trees);
             }
             for reason in reasons {
                 match reason {

--- a/crates/formality-coverage/src/jsonl.rs
+++ b/crates/formality-coverage/src/jsonl.rs
@@ -6,7 +6,7 @@
 //! in `formality-core` serializes, so the schema lives in exactly one place.
 
 use anyhow::{Context, Result};
-use formality_core::judgment::coverage::CoverageRecord;
+use formality_core::judgment::coverage::{CoverageRecord, FailedTreeNode, ProofTreeNode};
 use formality_core::judgment::FailureReason;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
@@ -56,6 +56,12 @@ pub struct Coverage {
     pub negative_premise_tests: BTreeMap<PremiseLoc, BTreeSet<TestLoc>>,
     /// Judgments observed to fail with no applicable rule.
     pub no_applicable_rule: BTreeSet<NoApplicableRuleLoc>,
+    /// Each positive test's success proof tree(s), so a positive detail page can
+    /// render the proof every listed test produced.
+    pub positive_trees: BTreeMap<TestLoc, Vec<ProofTreeNode>>,
+    /// Each negative test's failed proof tree(s), so a negative detail page can
+    /// render where each listed test's proof broke.
+    pub negative_trees: BTreeMap<TestLoc, Vec<FailedTreeNode>>,
 }
 
 impl Coverage {
@@ -97,6 +103,16 @@ impl Coverage {
         })
     }
 
+    /// The success proof tree(s) recorded for `test`, or an empty slice if none.
+    pub fn positive_trees_for(&self, test: &TestLoc) -> &[ProofTreeNode] {
+        self.positive_trees.get(test).map_or(&[], Vec::as_slice)
+    }
+
+    /// The failed proof tree(s) recorded for `test`, or an empty slice if none.
+    pub fn negative_trees_for(&self, test: &TestLoc) -> &[FailedTreeNode] {
+        self.negative_trees.get(test).map_or(&[], Vec::as_slice)
+    }
+
     /// True if `judgment_name` (in a file overlapping `judgment_file`) was
     /// observed to fail with no applicable rule.
     pub fn no_applicable_rule_observed(&self, judgment_file: &str, judgment_name: &str) -> bool {
@@ -106,7 +122,7 @@ impl Coverage {
     }
 }
 
-fn paths_overlap(a: &str, b: &str) -> bool {
+pub(crate) fn paths_overlap(a: &str, b: &str) -> bool {
     a.ends_with(b) || b.ends_with(a)
 }
 
@@ -151,6 +167,7 @@ fn ingest(record: CoverageRecord, cov: &mut Coverage) {
             test_file,
             test_line,
             rules,
+            trees,
             ..
         } => {
             let loc = TestLoc {
@@ -166,17 +183,27 @@ fn ingest(record: CoverageRecord, cov: &mut Coverage) {
                     .or_default()
                     .insert(loc.clone());
             }
+            if !trees.is_empty() {
+                cov.positive_trees.entry(loc).or_default().extend(trees);
+            }
         }
         CoverageRecord::Negative {
             test_file,
             test_line,
             reasons,
+            trees,
             ..
         } => {
             let test = TestLoc {
                 file: test_file,
                 line: test_line,
             };
+            if !trees.is_empty() {
+                cov.negative_trees
+                    .entry(test.clone())
+                    .or_default()
+                    .extend(trees);
+            }
             for reason in reasons {
                 match reason {
                     FailureReason::Premise {

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -11,9 +11,10 @@
 //! coverage. Both link to a per-cell detail page ([`render_detail_pages_for`])
 //! that lists each individual test with its source location and source.
 
-use crate::jsonl::{Coverage, TestLoc};
+use crate::jsonl::{paths_overlap, Coverage, TestLoc};
 use crate::scrape::{Judgment, Premise, Rule};
 use anyhow::{Context, Result};
+use formality_core::judgment::coverage::{FailedRuleNode, FailedTreeNode, ProofTreeNode};
 use std::collections::HashSet;
 use std::path::Path;
 
@@ -255,7 +256,12 @@ pub fn render_detail_pages_for(
                     locs.len(),
                     plural(locs.len()),
                 ));
-                content.push_str(&test_list(github_base, source_root, locs));
+                content.push_str(&test_list(
+                    github_base,
+                    source_root,
+                    locs,
+                    TreeSection::Positive(cov),
+                ));
                 pages.push(DetailPage {
                     slug: pos_detail_slug(&j.name, &r.name),
                     title: format!("{} / {} (positive)", j.name, r.name),
@@ -290,7 +296,16 @@ pub fn render_detail_pages_for(
                 tests.len(),
                 plural(tests.len()),
             ));
-            content.push_str(&test_list(github_base, source_root, &tests));
+            content.push_str(&test_list(
+                github_base,
+                source_root,
+                &tests,
+                TreeSection::Negative {
+                    cov,
+                    judgment_file: &j.file,
+                    premise_line: p.line,
+                },
+            ));
             pages.push(DetailPage {
                 slug: neg_detail_slug(&j.name, &r.name, p.line),
                 title: format!("{} / {} premise@{} (negative)", j.name, r.name, p.line),
@@ -301,14 +316,30 @@ pub fn render_detail_pages_for(
     pages
 }
 
+/// Which proof tree to render under each test in a detail page.
+enum TreeSection<'a> {
+    /// Positive page: render each test's success proof tree (the rules it fired).
+    Positive(&'a Coverage),
+    /// Negative page for one premise: render each test's failed proof tree,
+    /// pruned to the stacks that blame the premise at `judgment_file`/
+    /// `premise_line` (we show only the stacks that involve this premise).
+    Negative {
+        cov: &'a Coverage,
+        judgment_file: &'a str,
+        premise_line: u32,
+    },
+}
+
 /// A flat list of tests: for each, its source location (linked to GitHub when
-/// `github_base` is set) followed by the test function's source in a code block
-/// (when `source_root` is set and the file is readable). Plain markdown, so the
-/// location links rewrite to `.html` under mdbook like any other markdown link.
+/// `github_base` is set), the test function's source in a code block (when
+/// `source_root` is set and the file is readable), and the test's proof tree in
+/// a collapsed disclosure. Plain markdown, so the location links rewrite to
+/// `.html` under mdbook like any other markdown link.
 fn test_list<'a>(
     github_base: Option<&str>,
     source_root: Option<&Path>,
     tests: impl IntoIterator<Item = &'a TestLoc>,
+    trees: TreeSection<'_>,
 ) -> String {
     let mut s = String::new();
     for loc in tests {
@@ -331,8 +362,176 @@ fn test_list<'a>(
                 s.push_str("\n```\n\n");
             }
         }
+        s.push_str(&tree_details(&trees, loc));
     }
     s
+}
+
+/// The collapsed proof-tree disclosure for one test, or an empty string when no
+/// tree was recorded (or, on a negative page, none of the test's failed stacks
+/// involve the premise this page is about).
+fn tree_details(trees: &TreeSection<'_>, loc: &TestLoc) -> String {
+    match trees {
+        TreeSection::Positive(cov) => proof_tree_details(cov.positive_trees_for(loc)),
+        TreeSection::Negative {
+            cov,
+            judgment_file,
+            premise_line,
+        } => {
+            let pruned: Vec<FailedTreeNode> = cov
+                .negative_trees_for(loc)
+                .iter()
+                .filter_map(|t| prune_failed(t, judgment_file, *premise_line))
+                .collect();
+            failed_tree_details(&pruned)
+        }
+    }
+}
+
+/// Wrap pre-rendered tree text in a collapsed `<details>` disclosure. Emitted as
+/// one raw-HTML block with no internal blank lines: a blank line would close the
+/// HTML block under CommonMark and leak the rest as literal markdown.
+fn tree_disclosure(summary: &str, tree_text: &str) -> String {
+    format!(
+        "<details>\n<summary>{summary}</summary>\n<pre class=\"cov-tree\">\n{body}</pre>\n</details>\n\n",
+        summary = summary,
+        body = html_escape(tree_text),
+    )
+}
+
+/// The success proof tree(s) for one test, or `""` if none were recorded.
+fn proof_tree_details(nodes: &[ProofTreeNode]) -> String {
+    if nodes.is_empty() {
+        return String::new();
+    }
+    let mut text = String::new();
+    for n in nodes {
+        render_proof_node(n, "", &mut text);
+    }
+    tree_disclosure("Proof tree", &text)
+}
+
+fn render_proof_node(n: &ProofTreeNode, prefix: &str, out: &mut String) {
+    let rule = n
+        .rule
+        .as_deref()
+        .map(|r| format!(" ({r})"))
+        .unwrap_or_default();
+    out.push_str(&format!(
+        "{prefix}└─ {judgment}{rule} at {file}:{line}\n",
+        judgment = n.judgment,
+        rule = rule,
+        file = short_file(&n.file),
+        line = n.line,
+    ));
+    let child_prefix = format!("{prefix}   ");
+    for c in &n.children {
+        render_proof_node(c, &child_prefix, out);
+    }
+}
+
+/// The failed proof tree(s) for one test, already pruned to the relevant
+/// premise, or `""` if nothing survived the pruning.
+fn failed_tree_details(nodes: &[FailedTreeNode]) -> String {
+    if nodes.is_empty() {
+        return String::new();
+    }
+    let mut text = String::new();
+    for n in nodes {
+        render_failed_node(n, "", &mut text);
+    }
+    tree_disclosure("Failed proof tree", &text)
+}
+
+fn render_failed_node(j: &FailedTreeNode, prefix: &str, out: &mut String) {
+    out.push_str(&format!(
+        "{prefix}└─ {judgment} failed at {file}:{line}\n",
+        judgment = j.judgment,
+        file = short_file(&j.file),
+        line = j.line,
+    ));
+    let child_prefix = format!("{prefix}   ");
+    for r in &j.rules {
+        render_failed_rule(r, &child_prefix, out);
+    }
+}
+
+fn render_failed_rule(r: &FailedRuleNode, prefix: &str, out: &mut String) {
+    let label = match &r.rule {
+        Some(name) => format!("rule \"{name}\""),
+        None => "rule".to_string(),
+    };
+    match &r.child {
+        // A nested judgment failure: recurse to show where it broke.
+        Some(child) => {
+            out.push_str(&format!(
+                "{prefix}└─ {label} at {file}:{line}\n",
+                label = label,
+                file = short_file(&r.file),
+                line = r.line,
+            ));
+            let child_prefix = format!("{prefix}   ");
+            render_failed_node(child, &child_prefix, out);
+        }
+        // A terminal failure: show the cause tag.
+        None => out.push_str(&format!(
+            "{prefix}└─ {label} at {file}:{line} (failed: {cause})\n",
+            label = label,
+            file = short_file(&r.file),
+            line = r.line,
+            cause = r.cause,
+        )),
+    }
+}
+
+/// Prune a failed judgment tree to only the stacks that blame the premise at
+/// `judgment_file`/`premise_line`. The blamed premise is a failed rule at that
+/// location; we keep it (with its full subtree) plus every ancestor on the path
+/// to it, and drop sibling stacks that never reach it.
+fn prune_failed(
+    j: &FailedTreeNode,
+    judgment_file: &str,
+    premise_line: u32,
+) -> Option<FailedTreeNode> {
+    let rules: Vec<FailedRuleNode> = j
+        .rules
+        .iter()
+        .filter_map(|r| prune_failed_rule(r, judgment_file, premise_line))
+        .collect();
+    (!rules.is_empty()).then(|| FailedTreeNode {
+        judgment: j.judgment.clone(),
+        file: j.file.clone(),
+        line: j.line,
+        rules,
+    })
+}
+
+fn prune_failed_rule(
+    r: &FailedRuleNode,
+    judgment_file: &str,
+    premise_line: u32,
+) -> Option<FailedRuleNode> {
+    // The blamed premise itself: keep it and its full subtree.
+    if r.line == premise_line && paths_overlap(&r.file, judgment_file) {
+        return Some(r.clone());
+    }
+    // Otherwise keep this rule only if its sub-judgment reaches the premise.
+    let child = r
+        .child
+        .as_ref()
+        .and_then(|c| prune_failed(c, judgment_file, premise_line))?;
+    Some(FailedRuleNode {
+        rule: r.rule.clone(),
+        file: r.file.clone(),
+        line: r.line,
+        cause: r.cause.clone(),
+        child: Some(Box::new(child)),
+    })
+}
+
+/// The file name (final path component) of `path`, for compact tree labels.
+fn short_file(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
 }
 
 /// Extract the source of the test function enclosing `file:line`, dedented.

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -330,19 +330,27 @@ enum TreeSection<'a> {
     },
 }
 
+/// How many of a cell's tests get their proof tree rendered inline. A hot rule
+/// fires in hundreds of tests; rendering every tree would make the page (and the
+/// mdbook search index) enormous, so we show trees for the first few only. The
+/// source location and source are still listed for every test (they are cheap).
+const MAX_TREES_PER_CELL: usize = 10;
+
 /// A flat list of tests: for each, its source location (linked to GitHub when
 /// `github_base` is set), the test function's source in a code block (when
-/// `source_root` is set and the file is readable), and the test's proof tree in
-/// a collapsed disclosure. Plain markdown, so the location links rewrite to
-/// `.html` under mdbook like any other markdown link.
+/// `source_root` is set and the file is readable), and (for the first
+/// [`MAX_TREES_PER_CELL`]) the test's proof tree in a collapsed disclosure.
+/// Plain markdown, so the location links rewrite to `.html` under mdbook like
+/// any other markdown link.
 fn test_list<'a>(
     github_base: Option<&str>,
     source_root: Option<&Path>,
     tests: impl IntoIterator<Item = &'a TestLoc>,
     trees: TreeSection<'_>,
 ) -> String {
+    let tests: Vec<&TestLoc> = tests.into_iter().collect();
     let mut s = String::new();
-    for loc in tests {
+    for (i, loc) in tests.iter().enumerate() {
         let label = format!("{}:{}", loc.file, loc.line);
         s.push_str("---\n\n");
         match github_base {
@@ -362,7 +370,14 @@ fn test_list<'a>(
                 s.push_str("\n```\n\n");
             }
         }
-        s.push_str(&tree_details(&trees, loc));
+        if i < MAX_TREES_PER_CELL {
+            s.push_str(&tree_details(&trees, loc));
+        } else if i == MAX_TREES_PER_CELL {
+            s.push_str(&format!(
+                "_Proof trees omitted for the remaining {} tests._\n\n",
+                tests.len() - MAX_TREES_PER_CELL,
+            ));
+        }
     }
     s
 }
@@ -399,19 +414,36 @@ fn tree_disclosure(summary: &str, tree_text: &str) -> String {
     )
 }
 
+/// Largest proof tree we render inline. Where-clause solving recurses deeply,
+/// so a single success tree can reach thousands of nodes, which is neither
+/// readable nor cheap to ship in the search index. We render the first
+/// [`MAX_TREE_NODES`] (depth-first) and note how many were elided.
+const MAX_TREE_NODES: usize = 200;
+
 /// The success proof tree(s) for one test, or `""` if none were recorded.
 fn proof_tree_details(nodes: &[ProofTreeNode]) -> String {
     if nodes.is_empty() {
         return String::new();
     }
+    let total: usize = nodes.iter().map(count_proof_nodes).sum();
     let mut text = String::new();
+    let mut budget = MAX_TREE_NODES;
     for n in nodes {
-        render_proof_node(n, "", &mut text);
+        render_proof_node(n, "", &mut text, &mut budget);
     }
+    append_truncation_note(&mut text, total);
     tree_disclosure("Proof tree", &text)
 }
 
-fn render_proof_node(n: &ProofTreeNode, prefix: &str, out: &mut String) {
+fn count_proof_nodes(n: &ProofTreeNode) -> usize {
+    1 + n.children.iter().map(count_proof_nodes).sum::<usize>()
+}
+
+fn render_proof_node(n: &ProofTreeNode, prefix: &str, out: &mut String, budget: &mut usize) {
+    if *budget == 0 {
+        return;
+    }
+    *budget -= 1;
     let rule = n
         .rule
         .as_deref()
@@ -426,7 +458,7 @@ fn render_proof_node(n: &ProofTreeNode, prefix: &str, out: &mut String) {
     ));
     let child_prefix = format!("{prefix}   ");
     for c in &n.children {
-        render_proof_node(c, &child_prefix, out);
+        render_proof_node(c, &child_prefix, out, budget);
     }
 }
 
@@ -436,14 +468,29 @@ fn failed_tree_details(nodes: &[FailedTreeNode]) -> String {
     if nodes.is_empty() {
         return String::new();
     }
+    let total: usize = nodes.iter().map(count_failed_nodes).sum();
     let mut text = String::new();
+    let mut budget = MAX_TREE_NODES;
     for n in nodes {
-        render_failed_node(n, "", &mut text);
+        render_failed_node(n, "", &mut text, &mut budget);
     }
+    append_truncation_note(&mut text, total);
     tree_disclosure("Failed proof tree", &text)
 }
 
-fn render_failed_node(j: &FailedTreeNode, prefix: &str, out: &mut String) {
+fn count_failed_nodes(j: &FailedTreeNode) -> usize {
+    1 + j.rules.iter().map(count_failed_rule_nodes).sum::<usize>()
+}
+
+fn count_failed_rule_nodes(r: &FailedRuleNode) -> usize {
+    1 + r.child.as_deref().map_or(0, count_failed_nodes)
+}
+
+fn render_failed_node(j: &FailedTreeNode, prefix: &str, out: &mut String, budget: &mut usize) {
+    if *budget == 0 {
+        return;
+    }
+    *budget -= 1;
     out.push_str(&format!(
         "{prefix}└─ {judgment} failed at {file}:{line}\n",
         judgment = j.judgment,
@@ -452,11 +499,15 @@ fn render_failed_node(j: &FailedTreeNode, prefix: &str, out: &mut String) {
     ));
     let child_prefix = format!("{prefix}   ");
     for r in &j.rules {
-        render_failed_rule(r, &child_prefix, out);
+        render_failed_rule(r, &child_prefix, out, budget);
     }
 }
 
-fn render_failed_rule(r: &FailedRuleNode, prefix: &str, out: &mut String) {
+fn render_failed_rule(r: &FailedRuleNode, prefix: &str, out: &mut String, budget: &mut usize) {
+    if *budget == 0 {
+        return;
+    }
+    *budget -= 1;
     let label = match &r.rule {
         Some(name) => format!("rule \"{name}\""),
         None => "rule".to_string(),
@@ -471,7 +522,7 @@ fn render_failed_rule(r: &FailedRuleNode, prefix: &str, out: &mut String) {
                 line = r.line,
             ));
             let child_prefix = format!("{prefix}   ");
-            render_failed_node(child, &child_prefix, out);
+            render_failed_node(child, &child_prefix, out, budget);
         }
         // A terminal failure: show the cause tag.
         None => out.push_str(&format!(
@@ -481,6 +532,14 @@ fn render_failed_rule(r: &FailedRuleNode, prefix: &str, out: &mut String) {
             line = r.line,
             cause = r.cause,
         )),
+    }
+}
+
+/// Append a "N of M nodes shown" note when a tree was capped at
+/// [`MAX_TREE_NODES`].
+fn append_truncation_note(text: &mut String, total: usize) {
+    if total > MAX_TREE_NODES {
+        text.push_str(&format!("… ({MAX_TREE_NODES} of {total} nodes shown)\n"));
     }
 }
 

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -470,6 +470,83 @@ fn detail_pages_render_proof_trees() {
 }
 
 #[test]
+fn huge_proof_tree_is_capped() {
+    // A degenerate 500-node chain: where-clause solving really does produce
+    // trees this deep, so the renderer must cap them.
+    let mut node = ProofTreeNode {
+        judgment: "leaf".into(),
+        rule: Some("r".into()),
+        file: "f.rs".into(),
+        line: 1,
+        children: vec![],
+    };
+    for _ in 0..499 {
+        node = ProofTreeNode {
+            judgment: "j".into(),
+            rule: Some("r".into()),
+            file: "f.rs".into(),
+            line: 1,
+            children: vec![node],
+        };
+    }
+
+    let j = prove_thing_judgment();
+    let mut cov = prove_thing_coverage();
+    cov.positive_trees.insert(
+        TestLoc {
+            file: "tests/prove_thing.rs".into(),
+            line: 42,
+        },
+        vec![node],
+    );
+
+    let pages = report::render_detail_pages_for(&j, &cov, None, None);
+    let pos = &pages[0];
+    assert!(
+        pos.content.contains("of 500 nodes shown"),
+        "tree should be capped with a note"
+    );
+}
+
+#[test]
+fn proof_trees_are_capped_per_cell() {
+    // 12 tests exercise the `positive` rule; only the first 10 get a tree.
+    let j = prove_thing_judgment();
+    let mut cov = prove_thing_coverage();
+    let rule = CoveredRule {
+        judgment: "prove_thing".into(),
+        rule: "positive".into(),
+    };
+    for n in 0..12u32 {
+        let loc = TestLoc {
+            file: "tests/many.rs".into(),
+            line: 100 + n,
+        };
+        cov.positive.get_mut(&rule).unwrap().insert(loc.clone());
+        cov.positive_trees.insert(
+            loc,
+            vec![ProofTreeNode {
+                judgment: "prove_thing".into(),
+                rule: Some("positive".into()),
+                file: "f.rs".into(),
+                line: 1,
+                children: vec![],
+            }],
+        );
+    }
+
+    let pages = report::render_detail_pages_for(&j, &cov, None, None);
+    let pos = &pages[0];
+    let trees_shown = pos.content.matches("<summary>Proof tree</summary>").count();
+    assert_eq!(trees_shown, 10, "should cap inline trees at 10");
+    assert!(
+        pos.content
+            .contains("Proof trees omitted for the remaining 3 tests"),
+        "should note the omission (13 total: 1 original + 12 added)"
+    );
+}
+
+#[test]
 fn detail_pages_embed_test_source_when_root_given() {
     // A judgment with one rule, covered by one test that lives in a real file
     // on disk so the detail page can embed its source.

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -5,6 +5,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use expect_test::expect;
+use formality_core::judgment::coverage::{FailedRuleNode, FailedTreeNode, ProofTreeNode};
 use formality_coverage::jsonl::{
     self, Coverage, CoveredRule, NoApplicableRuleLoc, PremiseLoc, TestLoc,
 };
@@ -222,6 +223,7 @@ fn prove_thing_coverage() -> Coverage {
         negative_premises,
         negative_premise_tests,
         no_applicable_rule: BTreeSet::new(),
+        ..Default::default()
     }
 }
 
@@ -365,6 +367,106 @@ fn detail_pages_without_github_base_use_plain_locations() {
         pos.content
     );
     assert!(!pos.content.contains("https://"), "{}", pos.content);
+}
+
+#[test]
+fn detail_pages_render_proof_trees() {
+    let j = prove_thing_judgment();
+    let mut cov = prove_thing_coverage();
+
+    // The positive test (tests/prove_thing.rs:42) proved `prove_thing` via the
+    // `positive` rule, which in turn proved a sub-judgment.
+    cov.positive_trees.insert(
+        TestLoc {
+            file: "tests/prove_thing.rs".into(),
+            line: 42,
+        },
+        vec![ProofTreeNode {
+            judgment: "prove_thing".into(),
+            rule: Some("positive".into()),
+            file: "crates/sub/fixture.rs".into(),
+            line: 11,
+            children: vec![ProofTreeNode {
+                judgment: "prove_sub".into(),
+                rule: Some("sub".into()),
+                file: "crates/sub/other.rs".into(),
+                line: 3,
+                children: vec![],
+            }],
+        }],
+    );
+
+    // The negative test (tests/prove_thing.rs:99) failed two stacks: one blaming
+    // the `positive` premise on line 9 (which this page is about) and one blaming
+    // the `zero` premise on line 15 (which it is not).
+    cov.negative_trees.insert(
+        TestLoc {
+            file: "tests/prove_thing.rs".into(),
+            line: 99,
+        },
+        vec![FailedTreeNode {
+            judgment: "prove_thing".into(),
+            file: "crates/sub/fixture.rs".into(),
+            line: 4,
+            rules: vec![
+                FailedRuleNode {
+                    rule: Some("positive".into()),
+                    file: "crates/sub/fixture.rs".into(),
+                    line: 9,
+                    cause: "if_false".into(),
+                    child: None,
+                },
+                FailedRuleNode {
+                    rule: Some("zero".into()),
+                    file: "crates/sub/fixture.rs".into(),
+                    line: 15,
+                    cause: "if_false".into(),
+                    child: None,
+                },
+            ],
+        }],
+    );
+
+    let pages = report::render_detail_pages_for(&j, &cov, Some(GITHUB_BASE), None);
+    let pos = &pages[0];
+    let neg = &pages[1];
+
+    // The positive page shows the success tree behind a collapsed disclosure.
+    assert!(
+        pos.content.contains("<summary>Proof tree</summary>"),
+        "{}",
+        pos.content
+    );
+    assert!(
+        pos.content
+            .contains("└─ prove_thing (positive) at fixture.rs:11"),
+        "{}",
+        pos.content
+    );
+    assert!(
+        pos.content.contains("   └─ prove_sub (sub) at other.rs:3"),
+        "{}",
+        pos.content
+    );
+
+    // The negative page shows the failed tree pruned to the stack that blames
+    // premise line 9; the unrelated `zero` stack (line 15) is dropped.
+    assert!(
+        neg.content.contains("<summary>Failed proof tree</summary>"),
+        "{}",
+        neg.content
+    );
+    assert!(
+        neg.content
+            .contains(r#"└─ rule "positive" at fixture.rs:9 (failed: if_false)"#),
+        "{}",
+        neg.content
+    );
+    assert!(
+        !neg.content.contains("zero"),
+        "unrelated stack should be pruned: {}",
+        neg.content
+    );
 }
 
 #[test]
@@ -567,6 +669,42 @@ fn jsonl_reads_positive_and_negative_records() {
 
     assert!(cov.no_applicable_rule_observed("g.rs", "j2"));
     assert!(!cov.no_applicable_rule_observed("g.rs", "jX"));
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn jsonl_reads_embedded_proof_trees() {
+    let tmp = std::env::temp_dir().join(format!("formality-coverage-trees-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let path = tmp.join("test-coverage.jsonl");
+
+    let body = concat!(
+        r#"{"kind":"positive","test_file":"a.rs","test_line":1,"test_column":1,"rules":[{"judgment":"j1","rule":"r1","file":"f.rs","line":10}],"trees":[{"judgment":"j1","rule":"r1","file":"f.rs","line":10,"children":[{"judgment":"j2","rule":"r2","file":"g.rs","line":20}]}]}"#,
+        "\n",
+        r#"{"kind":"negative","test_file":"b.rs","test_line":2,"test_column":1,"reasons":[{"reason":"premise","judgment":"j1","rule":"r1","file":"f.rs","line":11,"cause":"if_false"}],"trees":[{"judgment":"j1","file":"f.rs","line":1,"rules":[{"rule":"r1","file":"f.rs","line":11,"cause":"if_false"}]}]}"#,
+        "\n",
+    );
+    std::fs::write(&path, body).unwrap();
+
+    let cov = jsonl::read(&path).unwrap();
+
+    let pos = cov.positive_trees_for(&TestLoc {
+        file: "a.rs".into(),
+        line: 1,
+    });
+    assert_eq!(pos.len(), 1);
+    assert_eq!(pos[0].judgment, "j1");
+    assert_eq!(pos[0].rule.as_deref(), Some("r1"));
+    assert_eq!(pos[0].children[0].judgment, "j2");
+
+    let neg = cov.negative_trees_for(&TestLoc {
+        file: "b.rs".into(),
+        line: 2,
+    });
+    assert_eq!(neg.len(), 1);
+    assert_eq!(neg[0].rules[0].rule.as_deref(), Some("r1"));
+    assert_eq!(neg[0].rules[0].cause, "if_false");
 
     let _ = std::fs::remove_dir_all(&tmp);
 }


### PR DESCRIPTION
## What does this PR do?

Renders per-test proof trees on the coverage detail pages (follow-up to #404). Positive cells show each test's success proof tree behind a collapsed disclosure; negative cells show the failed proof tree, pruned to the stacks that blame that premise plus their ancestors.

## How does it work, what questions do you have?

So the trees are stored in the JSONL as mirror structs not the real ProofTree. For positive trees I drop the if/let/trivial leaf nodes, so what's left is the rules that fired. For negative pages I prune each test's failed tree to only the stacks that reach the premise the page is about.

## Screenshots 
### Positive Proof Tree
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/a73808d1-b6ea-4029-8a6e-a7d7d6963c76" />

### Negative Proof Tree
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/80a9bc07-c673-497e-b049-abb4a6788d2f" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/37690ef8-62da-4ace-b8ea-6a68cf09307d" />



## AI disclosure

* I used an AI to author the main logic of the code

