### PR TITLE
Enforce that Drop impls are in the ADT's defining crate

### DIFF
--- a/crates/formality-rust/src/check/impls.rs
+++ b/crates/formality-rust/src/check/impls.rs
@@ -281,25 +281,45 @@ fn drop_impl_adt_id(trait_impl: &TraitImpl) -> Fallible<AdtId> {
     Ok(adt_id.clone())
 }
 
+/// Check that a `Drop` impl declared in crate `crate_id` is for an ADT defined in that
+/// same crate.
+fn check_drop_impl_in_defining_crate(
+    program: &Program,
+    adt_id: &AdtId,
+    crate_id: &CrateId,
+) -> Fallible<ProofTree> {
+    let defining_crate = program.program().crate_defining_adt(adt_id)?;
+    if defining_crate != crate_id {
+        bail!(
+            "`Drop` may only be implemented for types defined in the current crate: \
+            `{adt_id:?}` is defined in crate `{defining_crate:?}` but the impl is in crate `{crate_id:?}`"
+        );
+    }
+    Ok(ProofTree::leaf("check_drop_impl_in_defining_crate"))
+}
+
 judgment_fn! {
     /// Check that a `Drop` impl is "always applicable": for any instance of the ADT
     /// (with its where-clauses satisfied), the Drop impl must apply.
     pub(super) fn check_drop_impl_always_applicable(
         program: Program,
         trait_impl: TraitImpl,
+        crate_id: CrateId,
     ) => () {
-        debug(program, trait_impl)
+        debug(program, trait_impl, crate_id)
 
         (
             (if **trait_impl.trait_id() != *"Drop")!
             ---- ("not a Drop impl")
-            (check_drop_impl_always_applicable(program, trait_impl) => ())
+            (check_drop_impl_always_applicable(program, trait_impl, crate_id) => ())
         )
 
         (
             (if **trait_impl.trait_id() == *"Drop")!
             // Extract the ADT id and look up its definition.
             (let adt_id = drop_impl_adt_id(&trait_impl)?)
+            // `Drop` may only be implemented in the crate that defines the ADT.
+            (check_drop_impl_in_defining_crate(program, adt_id, crate_id) => ())
             (let adt = program.program().adt_item_named(adt_id)?.to_adt())
             // Universally instantiate the ADT: forall<T...> { (T: Bounds) => ... }
             (let (env, adt_vars) = Env::default().universal_substitution(&adt.binder))
@@ -311,7 +331,7 @@ judgment_fn! {
             (super::prove_goal(&program, &env, &adt_bound.where_clauses,
                 Predicate::IsImplemented(drop_trait_ref.clone())) => ())
             ---- ("Drop impl is always applicable")
-            (check_drop_impl_always_applicable(program, trait_impl) => ())
+            (check_drop_impl_always_applicable(program, trait_impl, crate_id) => ())
         )
     }
 }

--- a/crates/formality-rust/src/check/mod.rs
+++ b/crates/formality-rust/src/check/mod.rs
@@ -176,7 +176,7 @@ judgment_fn! {
 
         (
             (check_trait_impl(program, v, crate_id) => ())
-            (check_drop_impl_always_applicable(program, v) => ())
+            (check_drop_impl_always_applicable(program, v, crate_id) => ())
             ------------------------------------------------------------ ("trait impl")
             (check_crate_item(program, CrateItem::TraitImpl(v), crate_id) => ())
         )

--- a/crates/formality-rust/src/grammar/program.rs
+++ b/crates/formality-rust/src/grammar/program.rs
@@ -1,4 +1,4 @@
-use crate::grammar::{AdtId, AdtItem, Crate, CrateItem, Fn, Struct, Trait, ValueId};
+use crate::grammar::{AdtId, AdtItem, Crate, CrateId, CrateItem, Fn, Struct, Trait, ValueId};
 use crate::grammar::{Fallible, TraitId};
 use formality_core::term;
 
@@ -87,6 +87,20 @@ impl Crates {
         } else {
             Ok(structs.pop().unwrap())
         }
+    }
+
+    /// Returns the id of the crate that defines the ADT `adt_id`.
+    pub fn crate_defining_adt(&self, adt_id: &AdtId) -> Fallible<&CrateId> {
+        for krate in &self.crates {
+            if krate
+                .items
+                .iter()
+                .any(|item| matches!(item, CrateItem::AdtItem(a) if a.name() == adt_id))
+            {
+                return Ok(&krate.id);
+            }
+        }
+        anyhow::bail!("no ADT named `{adt_id:?}`")
     }
 
     pub fn adt_item_named(&self, adt_id: &AdtId) -> Fallible<&AdtItem> {

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -78,6 +78,39 @@ fn drop_impl_subset_where_clauses() {
     .ok()
 }
 
+/// Basic Drop impl for an enum.
+#[test]
+fn drop_impl_enum() {
+    FormalityTest::new(crates![
+        crate Foo {
+            enum MyEnum {
+                Variant{},
+            }
+
+            impl Drop for MyEnum {}
+        }
+    ])
+    .skip_execute()
+    .ok()
+}
+
+/// Drop impl in the same crate as the struct, with a downstream crate present.
+#[test]
+fn drop_impl_cross_crate_local() {
+    FormalityTest::new(crates![
+        crate a {
+            struct MyStruct {
+                value: u32,
+            }
+
+            impl Drop for MyStruct {}
+        },
+        crate b {}
+    ])
+    .skip_execute()
+    .ok()
+}
+
 // ===================================================================
 // Drop trait: invalid impls
 // ===================================================================
@@ -139,6 +172,48 @@ fn drop_impl_concrete_type_param() {
 
         the rule "trait implied bound" at (prove_wc.rs) failed because
           expression evaluated to an empty collection: `decls.trait_invariants()`"#]])
+}
+
+/// Drop impl for an enum with an extra where-clause not on the enum.
+#[test]
+fn drop_impl_enum_extra_where_clause() {
+    FormalityTest::new(crates![
+        crate Foo {
+            trait Clone {}
+
+            enum MyEnum<T> {
+                Value{value: T},
+            }
+
+            impl<T> Drop for MyEnum<T> where T: Clone {}
+        }
+    ])
+    .err(expect_test::expect![[r#"
+        crates/formality-rust/src/prove/prove_via.rs:8:1: no applicable rules for prove_via { goal: Clone(!ty_0), via: Drop(MyEnum<!ty_0>), assumptions: {Drop(MyEnum<!ty_0>)}, env: Env { variables: [!ty_0], bias: Soundness, pending: [], allow_pending_outlives: false } }
+
+        the rule "trait implied bound" at (prove_wc.rs) failed because
+          expression evaluated to an empty collection: `decls.trait_invariants()`
+
+        the rule "trait implied bound" at (prove_wc.rs) failed because
+          expression evaluated to an empty collection: `decls.trait_invariants()`"#]])
+}
+
+/// Drop impl for an ADT defined in another crate.
+#[test]
+fn drop_impl_foreign_adt() {
+    FormalityTest::new(crates![
+        crate a {
+            struct MyStruct {
+                value: u32,
+            }
+        },
+        crate b {
+            impl Drop for MyStruct {}
+        }
+    ])
+    .err(expect_test::expect![[r#"
+        the rule "Drop impl is always applicable" at (impls.rs) failed because
+          `Drop` may only be implemented for types defined in the current crate: `MyStruct` is defined in crate `a` but the impl is in crate `b`"#]])
 }
 
 /// Drop impl for a non-ADT type (e.g., u32).


### PR DESCRIPTION
## What does this PR do?

Most of #421 already landed in #369 (commit 3a799923): `check_drop_impl_always_applicable` proves the "always applicable" goal and rejects non-struct/enum self types, with tests in `tests/drop.rs`. This PR adds the remaining piece: a `Drop` impl must live in the crate that defines the ADT. Previously that case was only rejected indirectly by the coherence orphan check, with a generic `is_local` error. Now it fails fast with a Drop-specific message: ``` `Drop` may only be implemented for types defined in the current crate: `MyStruct` is defined in crate `a` but the impl is in crate `b` ``` 
Also adds test coverage the issue asked for that was missing: enums (OK and extra-where-clause error) and a cross-crate OK case.
Closes #421. 

## How does it work, what questions do you have?

So basically, "any valid instantiation" just means: take the struct's generics/where-clauses as given (like `T: Clone` for `MyStruct<T>`), and treat `T` as some opaque type that only satisfies those bounds, nothing more, nothing less. We're not allowed to assume extra stuff about `T`.
For `prove_goal`, the checker only has the ADT's own where-clauses to work with. It asks the trait solver "can this type prove `Drop`?" by unifying the self type with `MyStruct<T>` and trying to prove it. If the impl needs something the struct's bounds don't already guarantee (say `T: Debug`), the proof fails, so the impl gets rejected. That's what "always applicable" means: the impl has to work for every valid `T`, not just some.
The actual new part in this PR: before running the checker, we figure out which crate owns the struct/enum, and require the `Drop` impl to live in that same crate. Previously this was only caught by the general orphan rule, and errors just talked about locality. Now we can point at coherence directly and name both crates.

## AI disclosure

* I used an AI to author the main logic of the code