### PR TITLE
Raw pointers are not fundamental types

### DIFF
--- a/crates/formality-rust/src/prove/is_local.rs
+++ b/crates/formality-rust/src/prove/is_local.rs
@@ -327,13 +327,13 @@ fn is_fundamental(_decls: &Program, name: &RigidName) -> bool {
         RigidName::AdtId(_) => false, // FIXME(#222)
 
         RigidName::Ref(_) => true,
-        RigidName::Raw(_) => true,
 
         RigidName::Never => false,
 
         RigidName::ScalarId(_)
         | RigidName::Tuple(_)
         | RigidName::FnPtr(_)
-        | RigidName::FnDef(_) => false,
+        | RigidName::FnDef(_)
+        | RigidName::Raw(_) => false,
     }
 }

--- a/tests/coherence_orphan.rs
+++ b/tests/coherence_orphan.rs
@@ -99,6 +99,30 @@ fn covered_VecT() {
 }
 
 #[test]
+fn raw_pointer_is_not_fundamental() {
+    FormalityTest::new(crates![crate core {
+        trait CoreTrait {}
+    },
+    crate foo {
+        struct FooStruct {}
+        impl CoreTrait for *mut FooStruct {}
+    }])
+    .skip_execute()
+    .err(expect_test::expect![[r#"
+        the rule "fundamental rigid type" at (is_local.rs) failed because
+          condition evaluated to false: `is_fundamental(decls, name)`
+            decls = program([crate core { trait CoreTrait <ty> { } }, crate foo { struct FooStruct { } impl CoreTrait for *mut FooStruct { } }], 222)
+            name = * mut
+
+        crates/formality-rust/src/prove/prove_normalize.rs:18:1: no applicable rules for prove_normalize { p: *mut FooStruct, assumptions: {}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false } }
+
+        the rule "local trait" at (is_local.rs) failed because
+          condition evaluated to false: `decls.is_local_trait_id(&goal.trait_id)`
+            decls = program([crate core { trait CoreTrait <ty> { } }, crate foo { struct FooStruct { } impl CoreTrait for *mut FooStruct { } }], 222)
+            &goal.trait_id = CoreTrait"#]])
+}
+
+#[test]
 fn uncovered_T() {
     FormalityTest::new(crates![crate core {
                 trait CoreTrait<T> {}


### PR DESCRIPTION
## What does this PR do?

I am currently investigating https://github.com/rust-lang/a-mir-formality/issues/387 In Formaility, we were incorrectly treating `RawPointer` as a fundamental type during coherence checking. This PR fixes that and also adds a regression test.

## How does it work, what questions do you have?

## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools

