### PR TITLE
Add a by-test view to the coverage report

### DIFF
--- a/crates/formality-coverage/src/jsonl.rs
+++ b/crates/formality-coverage/src/jsonl.rs
@@ -46,7 +46,7 @@ pub struct NoApplicableRuleLoc {
 /// What a single test covered: the rules it proved and the fallible premises it
 /// was observed to fail on. This is the inverse of the per-cell maps in
 /// [`Coverage`], for the by-test view of the report.
-#[derive(Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Default, Debug)]
 pub struct TestCoverage {
     pub rules: BTreeSet<CoveredRule>,
     pub premises: BTreeSet<PremiseLoc>,

--- a/crates/formality-coverage/src/jsonl.rs
+++ b/crates/formality-coverage/src/jsonl.rs
@@ -43,6 +43,15 @@ pub struct NoApplicableRuleLoc {
     pub line: u32,
 }
 
+/// What a single test covered: the rules it proved and the fallible premises it
+/// was observed to fail on. This is the inverse of the per-cell maps in
+/// [`Coverage`], for the by-test view of the report.
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
+pub struct TestCoverage {
+    pub rules: BTreeSet<CoveredRule>,
+    pub premises: BTreeSet<PremiseLoc>,
+}
+
 /// Aggregated coverage data from a JSONL file.
 #[derive(Default, Debug)]
 pub struct Coverage {
@@ -111,6 +120,31 @@ impl Coverage {
     /// The failed proof tree(s) recorded for `test`, or an empty slice if none.
     pub fn negative_trees_for(&self, test: &TestLoc) -> &[FailedTreeNode] {
         self.negative_trees.get(test).map_or(&[], Vec::as_slice)
+    }
+
+    /// Invert the per-cell maps into per-test coverage, keyed by test location.
+    /// A test appears once whether it proved rules, failed premises, or both.
+    /// `BTreeMap`/`BTreeSet` keep the result ordered by source location, so the
+    /// by-test pages are stable across builds.
+    pub fn by_test(&self) -> BTreeMap<TestLoc, TestCoverage> {
+        let mut out: BTreeMap<TestLoc, TestCoverage> = BTreeMap::new();
+        for (rule, locs) in &self.positive {
+            for loc in locs {
+                out.entry(loc.clone())
+                    .or_default()
+                    .rules
+                    .insert(rule.clone());
+            }
+        }
+        for (premise, locs) in &self.negative_premise_tests {
+            for loc in locs {
+                out.entry(loc.clone())
+                    .or_default()
+                    .premises
+                    .insert(premise.clone());
+            }
+        }
+        out
     }
 
     /// True if `judgment_name` (in a file overlapping `judgment_file`) was

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -10,8 +10,14 @@
 //! a rule's conclusion is positive coverage; the number on a premise is negative
 //! coverage. Both link to a per-cell detail page ([`render_detail_pages_for`])
 //! that lists each individual test with its source location and source.
+//!
+//! The same data is also rendered the other way round: [`render_by_test_index`]
+//! and [`render_test_pages`] give a view organized by *test*, where each test
+//! shows the rules it proves and the premises it fails on. The two views
+//! cross-link, so a reader can go from a premise to the tests that exercise it
+//! and from a test back to everything else that exercises the same premise.
 
-use crate::jsonl::{paths_overlap, Coverage, TestLoc};
+use crate::jsonl::{paths_overlap, Coverage, PremiseLoc, TestCoverage, TestLoc};
 use crate::scrape::{Judgment, Premise, Rule};
 use anyhow::{Context, Result};
 use formality_core::judgment::coverage::{FailedRuleNode, FailedTreeNode, ProofTreeNode};
@@ -529,6 +535,310 @@ pub fn render_detail_pages_for(
     pages
 }
 
+/// Stylesheet for the by-test pages' tables. Their cells hold source text with
+/// long unbroken tokens (paths, judgment calls), which the default table layout
+/// cannot shrink, so the last column runs off the page; allowing a break
+/// anywhere inside those cells keeps every column on screen. Scoped to `main`
+/// so it beats mdbook's bare `table` rules, and emitted with no blank lines for
+/// the reason given on [`STYLE`].
+const BY_TEST_STYLE: &str = "<style>\n\
+main table{width:100%;display:table}\n\
+main table code{overflow-wrap:anywhere;white-space:normal}\n\
+</style>\n";
+
+/// Render the index of the by-test view: every test that recorded coverage,
+/// grouped by source file, linking to its own page (see [`render_test_pages`]).
+pub fn render_by_test_index(cov: &Coverage, source_root: Option<&Path>) -> String {
+    let mut s = String::new();
+    s.push_str("# Coverage by test\n\n");
+    s.push_str(
+        "The same data as the [coverage report](./coverage.md), organized by test rather than \
+         by judgment: each test lists the rules it proves and the premises it is observed to \
+         fail on.\n",
+    );
+    let by_test = cov.by_test();
+    if by_test.is_empty() {
+        s.push_str("_No coverage recorded._\n");
+        return s;
+    }
+    let mut current_file = "";
+    for (loc, tc) in &by_test {
+        if loc.file != current_file {
+            current_file = &loc.file;
+            s.push_str(&format!("\n## `{current_file}`\n\n"));
+            s.push_str("| Test | Rules proved | Premises failed |\n| --- | --- | --- |\n");
+        }
+        s.push_str(&format!(
+            "| [{label}](./{slug}.md) | {rules} | {premises} |\n",
+            label = test_label(source_root, loc),
+            slug = test_page_slug(loc),
+            rules = tc.rules.len(),
+            premises = tc.premises.len(),
+        ));
+    }
+    s
+}
+
+/// Build one page per test: the test's source, the rules it proves, the premises
+/// it fails on, and its proof tree(s). Every rule and premise row links to that
+/// cell's detail page in the judgment-organized view, which is where the reader
+/// finds the *other* tests covering the same cell.
+///
+/// Unlike the per-cell detail pages, which cap how many trees they inline (see
+/// [`MAX_TREES_PER_CELL`]), a test page carries exactly one test's trees, so
+/// every recorded tree is reachable from here.
+pub fn render_test_pages(
+    judgments: &[Judgment],
+    cov: &Coverage,
+    github_base: Option<&str>,
+    source_root: Option<&Path>,
+) -> Vec<DetailPage> {
+    cov.by_test()
+        .iter()
+        .map(|(loc, tc)| render_test_page(judgments, cov, loc, tc, github_base, source_root))
+        .collect()
+}
+
+fn render_test_page(
+    judgments: &[Judgment],
+    cov: &Coverage,
+    loc: &TestLoc,
+    tc: &TestCoverage,
+    github_base: Option<&str>,
+    source_root: Option<&Path>,
+) -> DetailPage {
+    let slug = test_page_slug(loc);
+    let label = format!("{}:{}", loc.file, loc.line);
+    let name = test_fn_name(source_root, loc);
+    let heading = name.clone().unwrap_or_else(|| label.clone());
+
+    let mut content = format!("# Test `{heading}`\n\n{BY_TEST_STYLE}\n");
+    match github_base {
+        Some(base) => content.push_str(&format!(
+            "**Source location:** [{label}]({base}/{file}#L{line})\n\n",
+            file = loc.file,
+            line = loc.line,
+        )),
+        None => content.push_str(&format!("**Source location:** {label}\n\n")),
+    }
+    if let Some(root) = source_root {
+        if let Some(src) = extract_test_source(root, &loc.file, loc.line) {
+            content.push_str("```rust,ignore\n");
+            content.push_str(&src);
+            content.push_str("\n```\n\n");
+        }
+    }
+
+    content.push_str(&format!("## Rules proved ({})\n\n", tc.rules.len()));
+    if tc.rules.is_empty() {
+        content.push_str("_This test records no positive coverage._\n\n");
+    } else {
+        content.push_str("| Judgment | Rule | All tests of this rule |\n| --- | --- | --- |\n");
+        for cr in &tc.rules {
+            let scraped = judgments
+                .iter()
+                .find(|j| j.name == cr.judgment)
+                .and_then(|j| j.rules.iter().find(|r| r.name == cr.rule).map(|r| (j, r)));
+            match scraped {
+                Some((j, r)) => content.push_str(&format!(
+                    "| {judgment} | {rule} | {tests} |\n",
+                    judgment = judgment_link(j),
+                    rule = rule_link(j, r),
+                    tests = positive_cell(cov, &cr.judgment, &cr.rule),
+                )),
+                // A rule the tests exercised but the scraper does not find, so
+                // it has no page to link to. Both hand-rolled `ProofTree`s
+                // (which are not `judgment_fn!` rules at all) and judgments the
+                // scraper fails to parse land here, so the count is still worth
+                // showing.
+                None => {
+                    let n = cov
+                        .positive_tests(&cr.judgment, &cr.rule)
+                        .map_or(0, |t| t.len());
+                    content.push_str(&format!(
+                        "| `{judgment}` | `{rule}` | {n} {tests} (not in the report) |\n",
+                        judgment = cr.judgment,
+                        rule = cr.rule,
+                        tests = plural(n),
+                    ));
+                }
+            }
+        }
+        content.push('\n');
+    }
+
+    content.push_str(&format!("## Premises failed ({})\n\n", tc.premises.len()));
+    if tc.premises.is_empty() {
+        content.push_str("_This test records no negative coverage._\n\n");
+    } else {
+        content.push_str(
+            "The last column links to the premise's page when the judgment view counts this \
+             failure against that premise. It does not when the premise is read as infallible, \
+             or when the failure was blamed inside a multi-line premise that carries no record \
+             on its own first line.\n\n",
+        );
+        content.push_str(
+            "| Judgment | Rule | Premise | All tests of this premise |\n| --- | --- | --- | --- |\n",
+        );
+        for ploc in &tc.premises {
+            match resolve_premise(judgments, ploc) {
+                Some((j, r, p)) => {
+                    // The judgment view writes a premise's page under exactly
+                    // these conditions (see `render_detail_pages_for`), so they
+                    // are also what decides whether there is a page to link to.
+                    let tests = if p.fallible {
+                        cov.negative_premise_tests(&j.file, p.line)
+                    } else {
+                        Default::default()
+                    };
+                    let all_tests = if tests.is_empty() {
+                        "not counted by the judgment view".to_string()
+                    } else {
+                        format!(
+                            "[{n} {tests}](./{slug}.md)",
+                            n = tests.len(),
+                            tests = plural(tests.len()),
+                            slug = neg_detail_slug(&j.name, &r.name, p.line),
+                        )
+                    };
+                    content.push_str(&format!(
+                        "| {judgment} | {rule} | `{premise}` (line {line}) | {all_tests} |\n",
+                        judgment = judgment_link(j),
+                        rule = rule_link(j, r),
+                        premise = premise_cell(&p.raw_text),
+                        line = p.line,
+                    ));
+                }
+                // A blamed location inside no scraped premise at all: the
+                // judgment it names is one the scraper does not find.
+                None => content.push_str(&format!(
+                    "| - | - | `{}:{}` | not in the report |\n",
+                    ploc.file, ploc.line
+                )),
+            }
+        }
+        content.push('\n');
+    }
+
+    let mut sink = ArgSink::default();
+    let trees = format!(
+        "{}{}",
+        proof_tree_details(
+            cov.positive_trees_for(loc),
+            github_base,
+            source_root,
+            &mut sink,
+        ),
+        failed_tree_details(
+            cov.negative_trees_for(loc),
+            github_base,
+            source_root,
+            &mut sink,
+        ),
+    );
+    if !trees.is_empty() {
+        content.push_str("## Proof trees\n\n");
+        content.push_str(&trees);
+    }
+    if !sink.is_empty() {
+        content.push_str(&args_script(&slug));
+    }
+
+    DetailPage {
+        title: match name {
+            Some(name) => format!("{name} ({}:{})", short_file(&loc.file), loc.line),
+            None => format!("{}:{}", short_file(&loc.file), loc.line),
+        },
+        content,
+        args_json: sink.to_json(),
+        slug,
+    }
+}
+
+/// Filename stem for a test's page in the by-test view. Must match the links
+/// emitted by [`render_by_test_index`] and by the back-link in [`test_list`].
+pub fn test_page_slug(loc: &TestLoc) -> String {
+    format!("test__{}__{}", slug(&loc.file), loc.line)
+}
+
+/// Markdown link to a judgment's subpage in the judgment-organized view.
+fn judgment_link(j: &Judgment) -> String {
+    format!("[{name}](./{slug}.md)", name = j.name, slug = slug(&j.name))
+}
+
+/// Markdown link to one rule's chart on its judgment's subpage.
+fn rule_link(j: &Judgment, r: &Rule) -> String {
+    format!(
+        "[{rule}](./{slug}.md#{anchor})",
+        rule = r.name,
+        slug = slug(&j.name),
+        anchor = anchor(&r.name),
+    )
+}
+
+/// Locate the scraped premise a recorded negative-coverage location refers to:
+/// the premise whose source lines contain `loc`, in a file whose path overlaps
+/// (the record's path and the scraped path have different roots).
+///
+/// Matching is by line *span*, not by start line as
+/// [`Coverage::negative_premise_tests`] does. The macro respans a failure onto
+/// the exact sub-premise that failed, while the scraper reads a `for_all` block
+/// as a single premise, so most records inside such a block name a line the
+/// judgment view can attribute to no premise at all. Spans put those rows under
+/// the premise they belong to; whether the judgment view *counts* them is a
+/// separate question the caller answers with `negative_premise_tests`.
+fn resolve_premise<'a>(
+    judgments: &'a [Judgment],
+    loc: &PremiseLoc,
+) -> Option<(&'a Judgment, &'a Rule, &'a Premise)> {
+    judgments.iter().find_map(|j| {
+        if !paths_overlap(&loc.file, &j.file) {
+            return None;
+        }
+        j.rules.iter().find_map(|r| {
+            r.premises
+                .iter()
+                .find(|p| premise_spans_line(p, loc.line))
+                .map(|p| (j, r, p))
+        })
+    })
+}
+
+/// Whether `line` falls within the source lines `p` occupies. `Premise::line` is
+/// its first line and `raw_text` holds its full (possibly multi-line) source.
+fn premise_spans_line(p: &Premise, line: u32) -> bool {
+    let height = p.raw_text.lines().count().max(1) as u32;
+    (p.line..p.line + height).contains(&line)
+}
+
+/// The name of the test function enclosing `loc`, when the source is readable.
+/// Taken from the same block [`extract_test_source`] renders, so the two always
+/// agree on which function a recorded location belongs to.
+fn test_fn_name(source_root: Option<&Path>, loc: &TestLoc) -> Option<String> {
+    let src = extract_test_source(source_root?, &loc.file, loc.line)?;
+    // The block is dedented and starts with the test's attributes, so the first
+    // non-attribute line carrying `fn ` is the function header.
+    let header = src
+        .lines()
+        .find(|l| !l.starts_with("#[") && l.contains("fn "))?;
+    let name: String = header
+        .split("fn ")
+        .nth(1)?
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    (!name.is_empty()).then_some(name)
+}
+
+/// How a test is labelled in the by-test index: its function name when we can
+/// read the source, and always its line, which is what makes the row unique.
+fn test_label(source_root: Option<&Path>, loc: &TestLoc) -> String {
+    match test_fn_name(source_root, loc) {
+        Some(name) => format!("{name} (line {})", loc.line),
+        None => format!("line {}", loc.line),
+    }
+}
+
 /// Which proof tree to render under each test in a detail page.
 enum TreeSection<'a> {
     /// Positive page: render each test's success proof tree (the rules it fired).
@@ -566,16 +876,22 @@ fn test_list<'a>(
     let mut s = String::new();
     for (i, loc) in tests.iter().enumerate() {
         let label = format!("{}:{}", loc.file, loc.line);
+        // Every location listed here comes from the coverage data, so the test's
+        // page in the by-test view always exists.
+        let back = format!(
+            " ([all coverage from this test](./{}.md))",
+            test_page_slug(loc),
+        );
         s.push_str("---\n\n");
         match github_base {
             Some(base) => s.push_str(&format!(
-                "**Source location:** [{label}]({base}/{file}#L{line})\n\n",
+                "**Source location:** [{label}]({base}/{file}#L{line}){back}\n\n",
                 label = label,
                 base = base,
                 file = loc.file,
                 line = loc.line,
             )),
-            None => s.push_str(&format!("**Source location:** {label}\n\n")),
+            None => s.push_str(&format!("**Source location:** {label}{back}\n\n")),
         }
         if let Some(root) = source_root {
             if let Some(src) = extract_test_source(root, &loc.file, loc.line) {
@@ -588,7 +904,8 @@ fn test_list<'a>(
             s.push_str(&tree_details(&trees, loc, github_base, source_root, sink));
         } else if i == MAX_TREES_PER_CELL {
             s.push_str(&format!(
-                "_Proof trees omitted for the remaining {} tests._\n\n",
+                "_Proof trees omitted for the remaining {} tests; each one is on its test's page \
+                 in [Coverage by test](./coverage-by-test.md)._\n\n",
                 tests.len() - MAX_TREES_PER_CELL,
             ));
         }
@@ -1141,6 +1458,22 @@ fn negative_index_cell(cov: &Coverage, judgment_file: &str, rule: &Rule) -> Stri
     format!("{covered}/{}", fallible.len())
 }
 
+/// Longest premise source shown in a by-test table cell. Premises run to many
+/// lines (a `for_all` block, an inline `match`), and a cell that wide pushes the
+/// rest of the table off the page; the full source is on the premise's own page.
+const MAX_PREMISE_CELL: usize = 48;
+
+/// A premise's source for a by-test table cell: collapsed to one line as
+/// [`premise_label`] does, and truncated to [`MAX_PREMISE_CELL`].
+fn premise_cell(raw: &str) -> String {
+    let one_line = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+    let truncated = match one_line.char_indices().nth(MAX_PREMISE_CELL) {
+        Some((end, _)) => format!("{}…", &one_line[..end]),
+        None => one_line,
+    };
+    premise_label(&truncated)
+}
+
 /// Collapse a premise's source text to a single line and escape `|` so it
 /// can sit in a markdown table cell.
 fn premise_label(raw: &str) -> String {
@@ -1196,6 +1529,16 @@ pub fn write_all(
             write_args_json(&out_dir.join(ARGS_SUBDIR), &page)?;
             std::fs::write(out_dir.join(format!("{}.md", page.slug)), page.content)?;
         }
+    }
+
+    // The same coverage organized by test, cross-linked with the pages above.
+    std::fs::write(
+        out_dir.join("coverage-by-test.md"),
+        render_by_test_index(cov, source_root),
+    )?;
+    for page in render_test_pages(judgments, cov, github_base, source_root) {
+        write_args_json(&out_dir.join(ARGS_SUBDIR), &page)?;
+        std::fs::write(out_dir.join(format!("{}.md", page.slug)), page.content)?;
     }
     Ok(())
 }

--- a/crates/formality-coverage/src/report.rs
+++ b/crates/formality-coverage/src/report.rs
@@ -558,7 +558,9 @@ pub fn render_by_test_index(cov: &Coverage, source_root: Option<&Path>) -> Strin
     );
     let by_test = cov.by_test();
     if by_test.is_empty() {
-        s.push_str("_No coverage recorded._\n");
+        // Blank line first, or this joins the paragraph above into one run of
+        // text. This is the branch a book built without running the tests takes.
+        s.push_str("\n_No coverage recorded._\n");
         return s;
     }
     let mut current_file = "";
@@ -609,10 +611,18 @@ fn render_test_page(
 ) -> DetailPage {
     let slug = test_page_slug(loc);
     let label = format!("{}:{}", loc.file, loc.line);
-    let name = test_fn_name(source_root, loc);
+    // The heading's function name and the source block below come from the same
+    // block, so read it once.
+    let src = source_root.and_then(|root| extract_test_source(root, &loc.file, loc.line));
+    let name = src.as_deref().and_then(test_fn_name);
     let heading = name.clone().unwrap_or_else(|| label.clone());
 
-    let mut content = format!("# Test `{heading}`\n\n{BY_TEST_STYLE}\n");
+    // [`STYLE`] as well as [`BY_TEST_STYLE`]: the proof trees below are rendered
+    // by the same helpers the cell pages use, and their `cov-tree` rules live
+    // only in `STYLE`. Emitting it whole (rather than the tree rules alone)
+    // keeps this page in step if those rules ever change; the chart rules it
+    // also carries are inert on a page with no chart.
+    let mut content = format!("# Test `{heading}`\n\n{STYLE}\n{BY_TEST_STYLE}\n");
     match github_base {
         Some(base) => content.push_str(&format!(
             "**Source location:** [{label}]({base}/{file}#L{line})\n\n",
@@ -621,12 +631,10 @@ fn render_test_page(
         )),
         None => content.push_str(&format!("**Source location:** {label}\n\n")),
     }
-    if let Some(root) = source_root {
-        if let Some(src) = extract_test_source(root, &loc.file, loc.line) {
-            content.push_str("```rust,ignore\n");
-            content.push_str(&src);
-            content.push_str("\n```\n\n");
-        }
+    if let Some(src) = &src {
+        content.push_str("```rust,ignore\n");
+        content.push_str(src);
+        content.push_str("\n```\n\n");
     }
 
     content.push_str(&format!("## Rules proved ({})\n\n", tc.rules.len()));
@@ -701,12 +709,20 @@ fn render_test_page(
                             slug = neg_detail_slug(&j.name, &r.name, p.line),
                         )
                     };
+                    // Name the blamed line whenever it is not the premise's own
+                    // first line, so a reader can see where the span match in
+                    // `resolve_premise` put this row and check it against the
+                    // source.
+                    let at = if ploc.line == p.line {
+                        format!("line {}", p.line)
+                    } else {
+                        format!("line {}, blamed at line {}", p.line, ploc.line)
+                    };
                     content.push_str(&format!(
-                        "| {judgment} | {rule} | `{premise}` (line {line}) | {all_tests} |\n",
+                        "| {judgment} | {rule} | `{premise}` ({at}) | {all_tests} |\n",
                         judgment = judgment_link(j),
                         rule = rule_link(j, r),
                         premise = premise_cell(&p.raw_text),
-                        line = p.line,
                     ));
                 }
                 // A blamed location inside no scraped premise at all: the
@@ -811,11 +827,11 @@ fn premise_spans_line(p: &Premise, line: u32) -> bool {
     (p.line..p.line + height).contains(&line)
 }
 
-/// The name of the test function enclosing `loc`, when the source is readable.
-/// Taken from the same block [`extract_test_source`] renders, so the two always
-/// agree on which function a recorded location belongs to.
-fn test_fn_name(source_root: Option<&Path>, loc: &TestLoc) -> Option<String> {
-    let src = extract_test_source(source_root?, &loc.file, loc.line)?;
+/// The name of the test function whose source is `src`, as [`extract_test_source`]
+/// returns it. Taking the block rather than the location keeps the name and the
+/// rendered source in agreement, and lets a caller that needs both read the file
+/// once.
+fn test_fn_name(src: &str) -> Option<String> {
     // The block is dedented and starts with the test's attributes, so the first
     // non-attribute line carrying `fn ` is the function header.
     let header = src
@@ -833,7 +849,8 @@ fn test_fn_name(source_root: Option<&Path>, loc: &TestLoc) -> Option<String> {
 /// How a test is labelled in the by-test index: its function name when we can
 /// read the source, and always its line, which is what makes the row unique.
 fn test_label(source_root: Option<&Path>, loc: &TestLoc) -> String {
-    match test_fn_name(source_root, loc) {
+    let src = source_root.and_then(|root| extract_test_source(root, &loc.file, loc.line));
+    match src.as_deref().and_then(test_fn_name) {
         Some(name) => format!("{name} (line {})", loc.line),
         None => format!("line {}", loc.line),
     }
@@ -1537,6 +1554,12 @@ pub fn write_all(
         render_by_test_index(cov, source_root),
     )?;
     for page in render_test_pages(judgments, cov, github_base, source_root) {
+        if !seen_slugs.insert(page.slug.clone()) {
+            eprintln!(
+                "warning: slug collision for coverage test page `{}`, it will overwrite a sibling",
+                page.slug,
+            );
+        }
         write_args_json(&out_dir.join(ARGS_SUBDIR), &page)?;
         std::fs::write(out_dir.join(format!("{}.md", page.slug)), page.content)?;
     }

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -1015,11 +1015,30 @@ fn by_test_inverts_the_per_cell_maps() {
 
 #[test]
 fn by_test_index_groups_tests_by_file() {
-    let md = report::render_by_test_index(&prove_thing_coverage(), None);
+    // A second file, so the per-file heading is actually emitted more than once.
+    let mut cov = prove_thing_coverage();
+    cov.positive
+        .get_mut(&CoveredRule {
+            judgment: "prove_thing".into(),
+            rule: "positive".into(),
+        })
+        .unwrap()
+        .insert(TestLoc {
+            file: "tests/other.rs".into(),
+            line: 7,
+        });
+
+    let md = report::render_by_test_index(&cov, None);
     expect![[r#"
         # Coverage by test
 
         The same data as the [coverage report](./coverage.md), organized by test rather than by judgment: each test lists the rules it proves and the premises it is observed to fail on.
+
+        ## `tests/other.rs`
+
+        | Test | Rules proved | Premises failed |
+        | --- | --- | --- |
+        | [line 7](./test__tests_other_rs__7.md) | 1 | 0 |
 
         ## `tests/prove_thing.rs`
 
@@ -1027,6 +1046,20 @@ fn by_test_index_groups_tests_by_file() {
         | --- | --- | --- |
         | [line 42](./test__tests_prove_thing_rs__42.md) | 1 | 0 |
         | [line 99](./test__tests_prove_thing_rs__99.md) | 0 | 1 |
+    "#]]
+    .assert_eq(&md);
+}
+
+#[test]
+fn by_test_index_says_so_when_nothing_was_recorded() {
+    // The branch a book built without running the tests takes.
+    let md = report::render_by_test_index(&Coverage::default(), None);
+    expect![[r#"
+        # Coverage by test
+
+        The same data as the [coverage report](./coverage.md), organized by test rather than by judgment: each test lists the rules it proves and the premises it is observed to fail on.
+
+        _No coverage recorded._
     "#]]
     .assert_eq(&md);
 }
@@ -1052,6 +1085,33 @@ fn test_pages_link_to_the_cells_they_cover() {
         # Test `tests/prove_thing.rs:42`
 
         <style>
+        .cov-rule{border:1px solid var(--quote-border,#d0d0d0);border-radius:6px;margin:1rem 0;overflow:hidden}
+        .cov-rule-head{padding:.4rem .8rem;background:var(--quote-bg,#f6f7f9);font-weight:600}
+        table.cov-code{width:100%;border-collapse:collapse;font-family:var(--mono-font,monospace);font-size:.85em;margin:0}
+        table.cov-code td{padding:.15rem .6rem;border:0}
+        table.cov-code th{padding:.15rem .6rem;border:0;border-bottom:1px solid var(--quote-border,#d0d0d0);color:#888;font-weight:600;font-size:.9em}
+        .cov-ln{text-align:right;color:#999;user-select:none;width:3em;white-space:nowrap}
+        .cov-num{text-align:right;width:3.5em;white-space:nowrap;font-weight:600}
+        .cov-num.pos a{color:#1a7f37}
+        .cov-num.neg a{color:#b35900}
+        .cov-none{color:#bbb}
+        .cov-na{color:#bbb;font-weight:400}
+        .cov-src-line{white-space:pre-wrap}
+        tr.cov-sep td{color:#999}
+        tr.cov-concl{background:rgba(127,127,127,.08)}
+        table.cov-code tr.cov-current td{background:rgba(31,120,255,.28)}
+        ul.cov-tree,ul.cov-tree ul{list-style:none;margin:0;padding-left:1.2em;font-family:var(--mono-font,monospace)}
+        ul.cov-tree{font-size:.85em}
+        ul.cov-tree ul{font-size:1em}
+        ul.cov-tree code{font-size:inherit}
+        ul.cov-tree summary{cursor:pointer}
+        .cov-tree-loc{color:#888}
+        .cov-tree-fail{color:#b35900}
+        .cov-tree-scroll{overflow-x:auto}
+        ul.cov-tree li,ul.cov-tree summary{white-space:nowrap}
+        </style>
+
+        <style>
         main table{width:100%;display:table}
         main table code{overflow-wrap:anywhere;white-space:normal}
         </style>
@@ -1075,6 +1135,33 @@ fn test_pages_link_to_the_cells_they_cover() {
     // premise's cell page.
     expect![[r#"
         # Test `tests/prove_thing.rs:99`
+
+        <style>
+        .cov-rule{border:1px solid var(--quote-border,#d0d0d0);border-radius:6px;margin:1rem 0;overflow:hidden}
+        .cov-rule-head{padding:.4rem .8rem;background:var(--quote-bg,#f6f7f9);font-weight:600}
+        table.cov-code{width:100%;border-collapse:collapse;font-family:var(--mono-font,monospace);font-size:.85em;margin:0}
+        table.cov-code td{padding:.15rem .6rem;border:0}
+        table.cov-code th{padding:.15rem .6rem;border:0;border-bottom:1px solid var(--quote-border,#d0d0d0);color:#888;font-weight:600;font-size:.9em}
+        .cov-ln{text-align:right;color:#999;user-select:none;width:3em;white-space:nowrap}
+        .cov-num{text-align:right;width:3.5em;white-space:nowrap;font-weight:600}
+        .cov-num.pos a{color:#1a7f37}
+        .cov-num.neg a{color:#b35900}
+        .cov-none{color:#bbb}
+        .cov-na{color:#bbb;font-weight:400}
+        .cov-src-line{white-space:pre-wrap}
+        tr.cov-sep td{color:#999}
+        tr.cov-concl{background:rgba(127,127,127,.08)}
+        table.cov-code tr.cov-current td{background:rgba(31,120,255,.28)}
+        ul.cov-tree,ul.cov-tree ul{list-style:none;margin:0;padding-left:1.2em;font-family:var(--mono-font,monospace)}
+        ul.cov-tree{font-size:.85em}
+        ul.cov-tree ul{font-size:1em}
+        ul.cov-tree code{font-size:inherit}
+        ul.cov-tree summary{cursor:pointer}
+        .cov-tree-loc{color:#888}
+        .cov-tree-fail{color:#b35900}
+        .cov-tree-scroll{overflow-x:auto}
+        ul.cov-tree li,ul.cov-tree summary{white-space:nowrap}
+        </style>
 
         <style>
         main table{width:100%;display:table}
@@ -1167,6 +1254,14 @@ fn test_pages_render_the_tests_own_proof_trees() {
 
     assert!(
         pages[0].content.contains("<summary>Proof tree</summary>"),
+        "{}",
+        pages[0].content
+    );
+    // The tree markup is styled by rules that live only in the shared
+    // stylesheet, so a test page carrying a tree has to carry that too or the
+    // tree renders as a plain bulleted list.
+    assert!(
+        pages[0].content.contains("ul.cov-tree,ul.cov-tree ul{"),
         "{}",
         pages[0].content
     );
@@ -1275,9 +1370,12 @@ fn test_pages_attribute_a_failure_blamed_inside_a_multi_line_premise() {
 
     let pages = report::render_test_pages(&judgments, &cov, Some(GITHUB_BASE), None);
     let content = &pages[1].content;
+    // The row sits under the premise that spans the blamed line, and names both
+    // lines so the reader can check the span match against the source.
     assert!(
         content.contains("[prove_thing](./prove_thing.md)")
-            && content.contains("for_all(i in 0..n) (prove_thing(i) => ())` (line 8)"),
+            && content
+                .contains("for_all(i in 0..n) (prove_thing(i) => ())` (line 8, blamed at line 9)"),
         "{content}"
     );
     // The judgment view keys pages by the premise's own first line, and no test

--- a/crates/formality-coverage/tests/scrape.rs
+++ b/crates/formality-coverage/tests/scrape.rs
@@ -984,3 +984,306 @@ fn jsonl_reader_tolerates_malformed_lines() {
 
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// --- The by-test view (the same coverage organized the other way round) ---
+
+#[test]
+fn by_test_inverts_the_per_cell_maps() {
+    let by_test = prove_thing_coverage().by_test();
+    let locs: Vec<(&str, u32)> = by_test.keys().map(|l| (l.file.as_str(), l.line)).collect();
+    assert_eq!(
+        locs,
+        vec![("tests/prove_thing.rs", 42), ("tests/prove_thing.rs", 99)]
+    );
+
+    // The positive test proved one rule and failed no premise; the negative
+    // test is the mirror image.
+    let positive = &by_test[&TestLoc {
+        file: "tests/prove_thing.rs".into(),
+        line: 42,
+    }];
+    assert_eq!(positive.rules.len(), 1);
+    assert!(positive.premises.is_empty());
+
+    let negative = &by_test[&TestLoc {
+        file: "tests/prove_thing.rs".into(),
+        line: 99,
+    }];
+    assert!(negative.rules.is_empty());
+    assert_eq!(negative.premises.len(), 1);
+}
+
+#[test]
+fn by_test_index_groups_tests_by_file() {
+    let md = report::render_by_test_index(&prove_thing_coverage(), None);
+    expect![[r#"
+        # Coverage by test
+
+        The same data as the [coverage report](./coverage.md), organized by test rather than by judgment: each test lists the rules it proves and the premises it is observed to fail on.
+
+        ## `tests/prove_thing.rs`
+
+        | Test | Rules proved | Premises failed |
+        | --- | --- | --- |
+        | [line 42](./test__tests_prove_thing_rs__42.md) | 1 | 0 |
+        | [line 99](./test__tests_prove_thing_rs__99.md) | 0 | 1 |
+    "#]]
+    .assert_eq(&md);
+}
+
+#[test]
+fn test_pages_link_to_the_cells_they_cover() {
+    let judgments = vec![prove_thing_judgment()];
+    let cov = prove_thing_coverage();
+    let pages = report::render_test_pages(&judgments, &cov, Some(GITHUB_BASE), None);
+
+    let slugs: Vec<&str> = pages.iter().map(|p| p.slug.as_str()).collect();
+    assert_eq!(
+        slugs,
+        vec![
+            "test__tests_prove_thing_rs__42",
+            "test__tests_prove_thing_rs__99",
+        ]
+    );
+
+    // The positive test's page names the rule it proved and links to that
+    // rule's cell page, which is where the other tests of the rule are listed.
+    expect![[r#"
+        # Test `tests/prove_thing.rs:42`
+
+        <style>
+        main table{width:100%;display:table}
+        main table code{overflow-wrap:anywhere;white-space:normal}
+        </style>
+
+        **Source location:** [tests/prove_thing.rs:42](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L42)
+
+        ## Rules proved (1)
+
+        | Judgment | Rule | All tests of this rule |
+        | --- | --- | --- |
+        | [prove_thing](./prove_thing.md) | [positive](./prove_thing.md#positive) | [1 test](./prove_thing__positive__pos.md) |
+
+        ## Premises failed (0)
+
+        _This test records no negative coverage._
+
+    "#]]
+    .assert_eq(&pages[0].content);
+
+    // The negative test's page names the premise it blamed and links to that
+    // premise's cell page.
+    expect![[r#"
+        # Test `tests/prove_thing.rs:99`
+
+        <style>
+        main table{width:100%;display:table}
+        main table code{overflow-wrap:anywhere;white-space:normal}
+        </style>
+
+        **Source location:** [tests/prove_thing.rs:99](https://github.com/example/repo/blob/main/tests/prove_thing.rs#L99)
+
+        ## Rules proved (0)
+
+        _This test records no positive coverage._
+
+        ## Premises failed (1)
+
+        The last column links to the premise's page when the judgment view counts this failure against that premise. It does not when the premise is read as infallible, or when the failure was blamed inside a multi-line premise that carries no record on its own first line.
+
+        | Judgment | Rule | Premise | All tests of this premise |
+        | --- | --- | --- | --- |
+        | [prove_thing](./prove_thing.md) | [positive](./prove_thing.md#positive) | `if true` (line 9) | [1 test](./prove_thing__positive__p9__neg.md) |
+
+    "#]]
+    .assert_eq(&pages[1].content);
+}
+
+#[test]
+fn detail_pages_link_back_to_the_test_page() {
+    let j = prove_thing_judgment();
+    let cov = prove_thing_coverage();
+    let pages = report::render_detail_pages_for(&j, &cov, Some(GITHUB_BASE), None, "md");
+    for page in &pages {
+        assert!(
+            page.content
+                .contains("([all coverage from this test](./test__tests_prove_thing_rs__"),
+            "{}",
+            page.content
+        );
+    }
+}
+
+#[test]
+fn test_pages_render_the_tests_own_proof_trees() {
+    let judgments = vec![prove_thing_judgment()];
+    let mut cov = prove_thing_coverage();
+    cov.positive_trees.insert(
+        TestLoc {
+            file: "tests/prove_thing.rs".into(),
+            line: 42,
+        },
+        vec![ProofTreeNode {
+            judgment: "prove_thing".into(),
+            rule: Some("positive".into()),
+            file: "crates/sub/fixture.rs".into(),
+            line: 11,
+            attributes: vec![("x".into(), "1".into())],
+            children: vec![],
+        }],
+    );
+    // Both stacks of the negative test's failed tree, including the one blaming
+    // `zero` that a premise's detail page prunes away.
+    cov.negative_trees.insert(
+        TestLoc {
+            file: "tests/prove_thing.rs".into(),
+            line: 99,
+        },
+        vec![FailedTreeNode {
+            judgment: "prove_thing".into(),
+            args: "(-1)".into(),
+            file: "crates/sub/fixture.rs".into(),
+            line: 4,
+            rules: vec![
+                FailedRuleNode {
+                    rule: Some("positive".into()),
+                    file: "crates/sub/fixture.rs".into(),
+                    line: 9,
+                    cause: "if_false".into(),
+                    child: None,
+                },
+                FailedRuleNode {
+                    rule: Some("zero".into()),
+                    file: "crates/sub/fixture.rs".into(),
+                    line: 15,
+                    cause: "if_false".into(),
+                    child: None,
+                },
+            ],
+        }],
+    );
+
+    let pages = report::render_test_pages(&judgments, &cov, Some(GITHUB_BASE), None);
+
+    assert!(
+        pages[0].content.contains("<summary>Proof tree</summary>"),
+        "{}",
+        pages[0].content
+    );
+    // Arguments are lazily loaded here as on the cell pages: the placeholder is
+    // in the HTML, the values in the page's own sidecar JSON.
+    assert!(
+        pages[0]
+            .content
+            .contains("./coverage-args/test__tests_prove_thing_rs__42.args.json"),
+        "{}",
+        pages[0].content
+    );
+    assert_eq!(pages[0].args_json, r#"{"n0":[["x","1"]]}"#);
+
+    // A test page shows the test's whole failed tree, unpruned: both the stack
+    // blaming `positive` and the one blaming `zero` are present, which is the
+    // point of this view.
+    assert!(
+        pages[1]
+            .content
+            .contains("<summary>Failed proof tree</summary>"),
+        "{}",
+        pages[1].content
+    );
+    assert!(
+        pages[1].content.contains(r#"rule "positive""#)
+            && pages[1].content.contains(r#"rule "zero""#),
+        "{}",
+        pages[1].content
+    );
+}
+
+#[test]
+fn test_pages_do_not_link_rules_the_scraper_never_found() {
+    // Coverage can name a rule the report has no page for: `overlap_check` in
+    // the real tree builds its `ProofTree` by hand rather than through
+    // `judgment_fn!`, so the scraper never sees it. Such a row must render
+    // without a link, or the by-test page points at a page that was never
+    // written.
+    let judgments = vec![prove_thing_judgment()];
+    let mut cov = prove_thing_coverage();
+    cov.positive.insert(
+        CoveredRule {
+            judgment: "hand_rolled".into(),
+            rule: "made_up".into(),
+        },
+        BTreeSet::from([TestLoc {
+            file: "tests/prove_thing.rs".into(),
+            line: 42,
+        }]),
+    );
+
+    let pages = report::render_test_pages(&judgments, &cov, Some(GITHUB_BASE), None);
+    let content = &pages[0].content;
+    assert!(
+        content.contains("| `hand_rolled` | `made_up` | 1 test (not in the report) |"),
+        "{content}"
+    );
+    assert!(
+        !content.contains("hand_rolled__made_up__pos.md"),
+        "must not link to a page that is never written: {content}"
+    );
+}
+
+#[test]
+fn test_pages_do_not_link_premises_the_report_reads_as_infallible() {
+    // Real coverage data blames premises the scraper classifies as infallible
+    // (a `let` with no `?`). The judgment view renders those `N/A` and writes no
+    // detail page, so the by-test row must not link to one.
+    let mut j = prove_thing_judgment();
+    j.rules[0].premises = vec![premise(
+        "let y = f(x)",
+        PremiseKind::Let,
+        false, // infallible: no detail page is ever written for it
+        9,
+    )];
+    let judgments = vec![j];
+    let cov = prove_thing_coverage();
+
+    let pages = report::render_test_pages(&judgments, &cov, Some(GITHUB_BASE), None);
+    let content = &pages[1].content;
+    assert!(
+        content.contains("| not counted by the judgment view |"),
+        "{content}"
+    );
+    assert!(
+        !content.contains("__p9__neg.md"),
+        "must not link to a page that is never written: {content}"
+    );
+}
+
+#[test]
+fn test_pages_attribute_a_failure_blamed_inside_a_multi_line_premise() {
+    // The macro respans a failure onto the exact sub-premise that failed, so a
+    // record can name a line inside a `for_all` block that the scraper reads as
+    // one premise starting earlier. The row still belongs under that premise.
+    let mut j = prove_thing_judgment();
+    j.rules[0].premises = vec![premise(
+        "for_all(i in 0..n)\n    (prove_thing(i) => ())",
+        PremiseKind::Other,
+        true,
+        8, // spans lines 8-9; the record below blames line 9
+    )];
+    let judgments = vec![j];
+    let cov = prove_thing_coverage();
+
+    let pages = report::render_test_pages(&judgments, &cov, Some(GITHUB_BASE), None);
+    let content = &pages[1].content;
+    assert!(
+        content.contains("[prove_thing](./prove_thing.md)")
+            && content.contains("for_all(i in 0..n) (prove_thing(i) => ())` (line 8)"),
+        "{content}"
+    );
+    // The judgment view keys pages by the premise's own first line, and no test
+    // failed there, so there is no page for this row to link to.
+    assert!(
+        content.contains("| not counted by the judgment view |"),
+        "{content}"
+    );
+}

--- a/crates/formality-mdbook/src/lib.rs
+++ b/crates/formality-mdbook/src/lib.rs
@@ -211,6 +211,7 @@ fn append_coverage_chapters(
         root.parent(),
         &args_dir,
         next_top + 1,
+        &mut seen_slugs,
         book,
     )?;
 
@@ -229,6 +230,7 @@ fn append_by_test_chapters(
     source_root: Option<&Path>,
     args_dir: &Path,
     top: u32,
+    seen_slugs: &mut HashSet<String>,
     book: &mut Book,
 ) -> anyhow::Result<()> {
     let mut pages: Vec<BookItem> = Vec::new();
@@ -236,8 +238,16 @@ fn append_by_test_chapters(
         .into_iter()
         .enumerate()
     {
-        // Slugs are built from the test's file and line, so two tests can never
-        // collide and no collision warning is needed here.
+        // A test page's slug runs its file path through `report::slug`, which
+        // collapses `/`, `-` and `.` alike into `_`, so two test files whose
+        // paths differ only in those characters collide at the same line; warn,
+        // mirroring the pages above.
+        if !seen_slugs.insert(page.slug.clone()) {
+            eprintln!(
+                "warning: slug collision for coverage test page `{}`, it will overwrite a sibling",
+                page.slug,
+            );
+        }
         report::write_args_json(args_dir, &page)?;
         let mut chapter = Chapter::new(
             &page.title,

--- a/crates/formality-mdbook/src/lib.rs
+++ b/crates/formality-mdbook/src/lib.rs
@@ -204,6 +204,61 @@ fn append_coverage_chapters(
     index_chapter.sub_items = subpages;
     book.push_item(index_chapter);
 
+    append_by_test_chapters(
+        &cov,
+        &judgments,
+        github_base,
+        root.parent(),
+        &args_dir,
+        next_top + 1,
+        book,
+    )?;
+
+    Ok(())
+}
+
+/// Append the by-test view: an index of every test that recorded coverage plus
+/// one page per test, nested under it the same way the judgment subpages are
+/// nested under the coverage index (see [`append_coverage_chapters`]). The pages
+/// cross-link with the per-cell detail pages, so a reader can move between "what
+/// covers this premise" and "what else does this test cover".
+fn append_by_test_chapters(
+    cov: &jsonl::Coverage,
+    judgments: &[Judgment],
+    github_base: Option<&str>,
+    source_root: Option<&Path>,
+    args_dir: &Path,
+    top: u32,
+    book: &mut Book,
+) -> anyhow::Result<()> {
+    let mut pages: Vec<BookItem> = Vec::new();
+    for (i, page) in report::render_test_pages(judgments, cov, github_base, source_root)
+        .into_iter()
+        .enumerate()
+    {
+        // Slugs are built from the test's file and line, so two tests can never
+        // collide and no collision warning is needed here.
+        report::write_args_json(args_dir, &page)?;
+        let mut chapter = Chapter::new(
+            &page.title,
+            page.content,
+            PathBuf::from(format!("{}.md", page.slug)),
+            vec!["Coverage by test".to_string()],
+        );
+        chapter.number = Some(SectionNumber::new(vec![top, (i + 1) as u32]));
+        pages.push(BookItem::Chapter(chapter));
+    }
+
+    let mut index = Chapter::new(
+        "Coverage by test",
+        report::render_by_test_index(cov, source_root),
+        PathBuf::from("coverage-by-test.md"),
+        vec![],
+    );
+    index.number = Some(SectionNumber::new(vec![top]));
+    index.sub_items = pages;
+    book.push_item(index);
+
     Ok(())
 }
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #408
Adds a second coverage view organized by test: one page per test listing the rules it proves and the premises it is observed to fail on, plus that test's proof tree. The views cross-link both ways, so a premise's page reaches "what
else does this test cover" and a test's page reaches "what other tests cover this rule/premise". No change to the recorded data or the wire format; this is a reorganization of what #408 already records.

## a test page, e.g. `test__tests_drop_rs__38.html` 
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/bd718d29-daed-4ded-8499-d81e5efd9bd5" />

## a rule's existing page, e.g. `check_drop_impl_always_applicable__drop-impl-is-always-applicable__pos.html`
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/19e39f3a-e9fb-4098-88f2-93f4394fff46" />


## How does it work, what questions do you have?

Nothing new is recorded. The existing maps go rule → tests and premise → tests, I just built the inverse, test → rules/premises. It's the reason the view can't disagree with the judgment view.
One judgment call I made is the line-span matching. The macro blames the exact sub-premise that failed, the scraper sees a for_all block as one premise, so the blamed line sits inside the premise rather than at it. 
I clicked the loop (test → rule → other tests → another test) and there's a scripted check over every relative link in the built book. This is to convince myself the links aren't broken
Two questions:
Is the search-index growth acceptable, and should the two scraper gaps (prove_outlives failing to parse, overlap_check not being a judgment_fn! at all) become their own issues? 

## AI disclosure

* I used an AI to author the main logic of the code
