### PR TITLE
Check for duplicate trait impl item

### DIFF
--- a/crates/formality-rust/src/check/impls.rs
+++ b/crates/formality-rust/src/check/impls.rs
@@ -1,4 +1,5 @@
 use anyhow::bail;
+use formality_core::Set;
 
 use crate::grammar::{
     AdtId, AssociatedTy, AssociatedTyBoundData, AssociatedTyValue, AssociatedTyValueBoundData,
@@ -31,6 +32,7 @@ judgment_fn! {
             (let TraitBoundData { where_clauses: _, trait_items } = trait_decl.binder.instantiate_with(&trait_ref.parameters)?)
             (check_safety_matches(&trait_decl, &trait_impl) => ())
 
+            (check_duplicate_impl_items(impl_items) => ())
             (for_all(impl_item in impl_items)
                 (check_trait_impl_item(program, env, where_clauses, trait_items, impl_item, crate_id) => ()))
 
@@ -125,6 +127,27 @@ fn check_all_required_items_present(
         }
     }
     Ok(ProofTree::leaf("check_all_required_items_present"))
+}
+
+fn check_duplicate_impl_items(impl_items: &[ImplItem]) -> Fallible<ProofTree> {
+    let mut functions = Set::new();
+    let mut types = Set::new();
+
+    for impl_item in impl_items {
+        match impl_item {
+            ImplItem::AssociatedTyValue(AssociatedTyValue { id, .. }) => {
+                if !types.insert(id) {
+                    bail!("Assoc ty {id:?} defined multiple times");
+                }
+            }
+            ImplItem::Fn(fun) => {
+                if !functions.insert(&fun.id) {
+                    bail!("Function item {:?} defined multiple times", &fun.id);
+                }
+            }
+        }
+    }
+    Ok(ProofTree::leaf("check_duplicate_impl_items"))
 }
 
 judgment_fn! {

--- a/crates/formality-rust/src/check/impls.rs
+++ b/crates/formality-rust/src/check/impls.rs
@@ -137,12 +137,12 @@ fn check_duplicate_impl_items(impl_items: &[ImplItem]) -> Fallible<ProofTree> {
         match impl_item {
             ImplItem::AssociatedTyValue(AssociatedTyValue { id, .. }) => {
                 if !types.insert(id) {
-                    bail!("Assoc ty {id:?} defined multiple times");
+                    bail!("assoc ty {id:?} is defined multiple times");
                 }
             }
             ImplItem::Fn(fun) => {
                 if !functions.insert(&fun.id) {
-                    bail!("Function item {:?} defined multiple times", &fun.id);
+                    bail!("function item {:?} is defined multiple times", &fun.id);
                 }
             }
         }

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -383,6 +383,37 @@ fn basic_neg_impl_dup() {
 }
 
 #[test]
+fn impl_items_with_duplicate_fn_names() {
+    FormalityTest::new(crates![crate core {
+        trait Foo {
+            fn bar(self_: u32) -> u32;
+        }
+        struct MyStruct {}
+        impl Foo for MyStruct {
+            fn bar(self_: u32) -> u32 { trusted }
+            fn bar(x: u32) -> u32 { trusted }
+        }
+    }])
+    .err(expect_test::expect![[r#"
+        the rule "check_trait_impl" at (impls.rs) failed because
+          function item bar is defined multiple times"#]]);
+
+    FormalityTest::new(crates![crate core {
+        trait Foo {
+            type Assoc : [];
+        }
+        struct MyStruct {}
+        impl Foo for MyStruct {
+            type Assoc = u32;
+            type Assoc = u64;
+        }
+    }])
+    .err(expect_test::expect![[r#"
+        the rule "check_trait_impl" at (impls.rs) failed because
+          assoc ty Assoc is defined multiple times"#]]);
+}
+
+#[test]
 fn impl_missing_required_fn() {
     FormalityTest::new(crates![crate core {
         trait Foo {


### PR DESCRIPTION
## What does this PR do?

We didn't had any check for duplicate trait impl item. This PR adds that. I am currently working through https://github.com/rust-lang/a-mir-formality/issues/419, and going across all checks to understand better. I believe there might be more such cases, I will try to spot more.

## AI disclosure

* I did not use any AI tools

