### PR TITLE
Check neg trait decl

### DIFF
--- a/crates/formality-rust/src/check/impls.rs
+++ b/crates/formality-rust/src/check/impls.rs
@@ -61,6 +61,10 @@ judgment_fn! {
             (let trait_ref = trait_id.with(self_ty, trait_parameters))
             (super::where_clauses::prove_where_clauses_well_formed(program, &env, &where_clauses, &where_clauses) => ())
             (super::prove_goal(program, &env, &where_clauses, Predicate::not_implemented(&trait_ref)) => ())
+
+            (let trait_decl = program.program().trait_named(&trait_ref.trait_id)?)
+            (let TraitBoundData { where_clauses: _, trait_items: _ } = trait_decl.binder.instantiate_with(&trait_ref.parameters)?)
+
             ---- ("check_neg_trait_impl")
             (check_neg_trait_impl(program, NegTraitImpl { binder, safety: Safety::Safe }) => ())
         )

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -425,3 +425,14 @@ fn impl_with_default_fn_body_ok() {
     .skip_execute()
     .ok();
 }
+
+#[test]
+fn nonexistant_trait() {
+    FormalityTest::new(crates![crate core {
+        struct S {}
+        impl !Nonexistent for S {}
+    }])
+    .err(expect_test::expect![[r#"
+        the rule "check_neg_trait_impl" at (impls.rs) failed because
+          no trait named `Nonexistent`"#]]);
+}


### PR DESCRIPTION
## What does this PR do?

We didn't check if the trait for actually present during neg trait impl check, this PR adds that check

## How does it work, what questions do you have?

Adds the check for trait decls

## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools

