### PR TITLE
Merge Relation into Predicate

### DIFF
--- a/crates/formality-rust/src/check/adts.rs
+++ b/crates/formality-rust/src/check/adts.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::check::{prove_goal, where_clauses::prove_where_clauses_well_formed};
 use crate::grammar::Fallible;
-use crate::grammar::{Adt, AdtBoundData, Field, Relation, Variant};
+use crate::grammar::{Adt, AdtBoundData, Field, Predicate, Variant};
 use crate::prove::{Env, Program};
 use anyhow::bail;
 use formality_core::judgment::ProofTree;
@@ -23,7 +23,7 @@ judgment_fn! {
                 (let Variant { fields, .. } = variant)
                 (for_all(field in fields)
                     (let Field { ty, .. } = field)
-                    (prove_goal(program, env, where_clauses, Relation::well_formed(ty)) => ())))
+                    (prove_goal(program, env, where_clauses, Predicate::well_formed(ty)) => ())))
             ------------------------------------------------------------ ("check adt")
             (check_adt(program, adt) => ())
         )

--- a/crates/formality-rust/src/check/borrow_check/env.rs
+++ b/crates/formality-rust/src/check/borrow_check/env.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use crate::check::borrow_check::flow_state::{FlowState, PendingOutlives};
 
 use crate::check::borrow_check::outlives::verify_universal_outlives;
-use crate::grammar::{Binder, ExistentialVar, Relation, Ty, UniversalVar, Wcs};
+use crate::grammar::{Binder, ExistentialVar, Predicate, Ty, UniversalVar, Wcs};
 use crate::grammar::{Crates, Parameter};
 use crate::prove::{prove_normalize, Constrained, Constraints, Env, Program};
 use crate::rust::Fold;
@@ -265,8 +265,8 @@ impl TypeckEnv {
         let mut c_outlives = BTreeSet::default();
 
         for pending in c.env.pending() {
-            match pending.downcast::<Relation>() {
-                Some(Relation::Outlives(a, b)) => {
+            match pending.downcast::<Predicate>() {
+                Some(Predicate::Outlives(a, b)) => {
                     c_outlives.insert(PendingOutlives { a, b });
                 }
 

--- a/crates/formality-rust/src/check/borrow_check/nll.rs
+++ b/crates/formality-rust/src/check/borrow_check/nll.rs
@@ -9,8 +9,8 @@ use crate::check::feature_gate_enabled_in_program;
 use crate::grammar::expr::{Block, Expr, Init, Literal, PlaceExpr, Stmt};
 use crate::grammar::{
     AliasName, AliasTy, AssociatedItemId, ExistentialVar, FeatureGateName, FieldName, Fn, Lt,
-    Parameter, Predicate, RefKind, Relation, RigidName, RigidTy, ScalarId, Struct, StructBoundData,
-    TraitId, TraitRef, Ty, Variable, VariantId, Wcs, WhereClause,
+    Parameter, Predicate, RefKind, RigidName, RigidTy, ScalarId, Struct, StructBoundData, TraitId,
+    TraitRef, Ty, Variable, VariantId, Wcs, WhereClause,
 };
 use crate::grammar::{FnBoundData, PredicateTy};
 use crate::prove::Safety;
@@ -23,7 +23,7 @@ use crate::check::borrow_check::liveness::{Assignment, Either, LiveBefore, LiveP
 fn wf_assumptions_for_existential_subst(subst: &[ExistentialVar]) -> Wcs {
     subst
         .iter()
-        .map(|v| Relation::well_formed(v.clone()))
+        .map(|v| Predicate::well_formed(v.clone()))
         .collect()
 }
 
@@ -1096,7 +1096,7 @@ fn prove_sub_type(
     a: impl Upcast<Parameter>,
     b: impl Upcast<Parameter>,
 ) -> ProvenSet<FlowState> {
-    TypeckEnv::prove_goal(env, assumptions, state, Relation::sub(a, b))
+    TypeckEnv::prove_goal(env, assumptions, state, Predicate::sub(a, b))
 }
 
 fn prove_where_clauses(
@@ -1114,7 +1114,7 @@ fn prove_ty_is_wf(
     state: &FlowState,
     ty: &Ty,
 ) -> ProvenSet<FlowState> {
-    TypeckEnv::prove_goal(env, assumptions, state, Relation::well_formed(ty))
+    TypeckEnv::prove_goal(env, assumptions, state, Predicate::well_formed(ty))
 }
 
 fn prove_normalize_ty(

--- a/crates/formality-rust/src/check/borrow_check/outlives.rs
+++ b/crates/formality-rust/src/check/borrow_check/outlives.rs
@@ -1,7 +1,7 @@
 use crate::check::borrow_check::env::TypeckEnv;
 use crate::check::borrow_check::flow_state::PendingOutlives;
 
-use crate::grammar::{Parameter, Relation, Variable, Wcs};
+use crate::grammar::{Parameter, Predicate, Variable, Wcs};
 use crate::prove::prove;
 use formality_core::{judgment_fn, Set, Upcast};
 
@@ -78,7 +78,7 @@ judgment_fn! {
         // Prove that T: !a -- must prove from assumptions
         (
             (if var_b.is_universal())!
-            (prove(&env.program, &env.env, assumptions, Relation::outlives(param_a, var_b)) => c)
+            (prove(&env.program, &env.env, assumptions, Predicate::outlives(param_a, var_b)) => c)
             (if c.unconditionally_true())
             --- ("universal target")
             (can_outlive(env, assumptions, _outlives, param_a, var_b: Variable) => ())

--- a/crates/formality-rust/src/check/fns.rs
+++ b/crates/formality-rust/src/check/fns.rs
@@ -3,7 +3,7 @@ use crate::check::borrow_check::flow_state::FlowState;
 use crate::check::borrow_check::nll::borrow_check;
 use crate::check::prove_goal;
 use crate::check::where_clauses::prove_where_clauses_well_formed;
-use crate::grammar::{CrateId, FnBody, MaybeFnBody, Relation, Wcs};
+use crate::grammar::{CrateId, FnBody, MaybeFnBody, Predicate, Wcs};
 use crate::prove::{Env, Program};
 use crate::{
     grammar::{Fn, FnBoundData},
@@ -50,8 +50,8 @@ judgment_fn! {
             (let assumptions: Wcs = (assumptions, where_clauses).to_wcs())
             (prove_where_clauses_well_formed(program, env, assumptions, where_clauses) => ())
             (for_all(input_arg in input_args)
-                (prove_goal(program, env, assumptions, Relation::well_formed(&input_arg.ty)) => ()))
-            (prove_goal(program, env, assumptions, Relation::well_formed(output_ty)) => ())
+                (prove_goal(program, env, assumptions, Predicate::well_formed(&input_arg.ty)) => ()))
+            (prove_goal(program, env, assumptions, Predicate::well_formed(output_ty)) => ())
             (check_fn_body(program, env, assumptions, body, input_args, output_ty) => ())
             ------------------------------------------------------------ ("check fn")
             (check_fn(program, env, assumptions, f, crate_id) => ())

--- a/crates/formality-rust/src/check/impls.rs
+++ b/crates/formality-rust/src/check/impls.rs
@@ -3,8 +3,8 @@ use anyhow::bail;
 use crate::grammar::{
     AdtId, AssociatedTy, AssociatedTyBoundData, AssociatedTyValue, AssociatedTyValueBoundData,
     Binder, CrateId, Fallible, Fn, FnBoundData, ImplItem, MaybeFnBody, NegTraitImpl,
-    NegTraitImplBoundData, Predicate, Relation, RigidName, Substitution, Trait, TraitBoundData,
-    TraitImpl, TraitImplBoundData, TraitItem, Ty, Wcs,
+    NegTraitImplBoundData, Predicate, RigidName, Substitution, Trait, TraitBoundData, TraitImpl,
+    TraitImplBoundData, TraitItem, Ty, Wcs,
 };
 use crate::prove::{Env, Program, Safety};
 use crate::rust::Term;
@@ -182,10 +182,10 @@ judgment_fn! {
             // Check each argument: trait arg is subtype of impl arg (contravariance)
             (for_all(pair in ii_input_args.iter().zip(ti_input_args.iter()))
                 (let (ii_input_arg, ti_input_arg) = pair)
-                (super::prove_goal(program, &env, (&impl_assumptions, &ii_where_clauses), Relation::sub(&ti_input_arg.ty, &ii_input_arg.ty)) => ()))
+                (super::prove_goal(program, &env, (&impl_assumptions, &ii_where_clauses), Predicate::sub(&ti_input_arg.ty, &ii_input_arg.ty)) => ()))
 
             // Check return type: impl return is subtype of trait return (covariance)
-            (super::prove_goal(program, &env, (&impl_assumptions, &ii_where_clauses), Relation::sub(ii_output_ty, ti_output_ty)) => ())
+            (super::prove_goal(program, &env, (&impl_assumptions, &ii_where_clauses), Predicate::sub(ii_output_ty, ti_output_ty)) => ())
 
             ---- ("check_fn_in_impl")
             (check_fn_in_impl(program, env, impl_assumptions, trait_items, ii_fn, crate_id) => ())
@@ -223,7 +223,7 @@ judgment_fn! {
             (super::prove_goal(program, &env, (&impl_assumptions, &ti_where_clauses), &ii_where_clauses) => ())
 
             // Prove the impl type is well-formed
-            (super::prove_goal(program, env, (impl_assumptions, ii_where_clauses), Relation::well_formed(ii_ty)) => ())
+            (super::prove_goal(program, env, (impl_assumptions, ii_where_clauses), Predicate::well_formed(ii_ty)) => ())
 
             // Prove the ensures clauses
             (let ensures: Wcs = ti_ensures.iter().map(|e| e.to_wc(&ii_ty)).collect())

--- a/crates/formality-rust/src/grammar/formulas.rs
+++ b/crates/formality-rust/src/grammar/formulas.rs
@@ -14,8 +14,25 @@ pub type Fallible<T> = anyhow::Result<T>;
 
 /// Atomic predicates are the base goals we can try to prove; the rules for proving them
 /// are derived (at least in part) based on the Rust source declarations.
+///
+/// The first few variants are *relations*: built-in goals implemented in custom Rust
+/// logic rather than derived from declarations. They are matched more strictly than the
+/// other predicates (see the `relation-axiom` rule in `prove_via`), so they can be told
+/// apart with [`Skeleton::is_relation`][].
 #[term]
 pub enum Predicate {
+    #[grammar($v0 = $v1)]
+    Equals(Parameter, Parameter),
+
+    #[grammar($v0 <: $v1)]
+    Sub(Parameter, Parameter),
+
+    #[grammar($v0 : $v1)]
+    Outlives(Parameter, Parameter),
+
+    #[grammar(@wf($v0))]
+    WellFormed(Parameter),
+
     /// True if a trait is fully implemented (along with all its where clauses).
     #[cast]
     IsImplemented(TraitRef),
@@ -77,7 +94,23 @@ pub enum Skeleton {
     Equals,
     Sub,
     Outlives,
-    IsInt,
+}
+
+impl Skeleton {
+    /// True if this skeleton belongs to a *relation*, i.e. one of the built-in goals
+    /// implemented in custom Rust logic. Relations require their parameters to match
+    /// exactly, whereas other predicates only require them to be provably equal.
+    pub fn is_relation(&self) -> bool {
+        match self {
+            Skeleton::Equals | Skeleton::Sub | Skeleton::Outlives | Skeleton::WellFormed => true,
+            Skeleton::IsImplemented(_)
+            | Skeleton::NotImplemented(_)
+            | Skeleton::AliasEq(_)
+            | Skeleton::WellFormedTraitRef(_)
+            | Skeleton::IsLocal(_)
+            | Skeleton::ConstHasType => false,
+        }
+    }
 }
 
 impl Predicate {
@@ -86,6 +119,10 @@ impl Predicate {
     #[tracing::instrument(level = "trace", ret)]
     pub fn debone(&self) -> (Skeleton, Vec<Parameter>) {
         match self {
+            Predicate::Equals(a, b) => (Skeleton::Equals, vec![a.clone(), b.clone()]),
+            Predicate::Sub(a, b) => (Skeleton::Sub, vec![a.clone(), b.clone()]),
+            Predicate::Outlives(a, b) => (Skeleton::Outlives, vec![a.clone(), b.clone()]),
+            Predicate::WellFormed(p) => (Skeleton::WellFormed, vec![p.clone()]),
             Predicate::IsImplemented(TraitRef {
                 trait_id,
                 parameters,
@@ -124,34 +161,6 @@ impl Predicate {
     }
 }
 
-/// Relations are built-in goals which are implemented in custom Rust logic.
-#[term]
-pub enum Relation {
-    #[grammar($v0 = $v1)]
-    Equals(Parameter, Parameter),
-
-    #[grammar($v0 <: $v1)]
-    Sub(Parameter, Parameter),
-
-    #[grammar($v0 : $v1)]
-    Outlives(Parameter, Parameter),
-
-    #[grammar(@wf($v0))]
-    WellFormed(Parameter),
-}
-
-impl Relation {
-    #[tracing::instrument(level = "trace", ret)]
-    pub fn debone(&self) -> (Skeleton, Vec<Parameter>) {
-        match self {
-            Relation::Equals(a, b) => (Skeleton::Equals, vec![a.clone(), b.clone()]),
-            Relation::Sub(a, b) => (Skeleton::Sub, vec![a.clone(), b.clone()]),
-            Relation::Outlives(a, b) => (Skeleton::Outlives, vec![a.clone(), b.clone()]),
-            Relation::WellFormed(p) => (Skeleton::WellFormed, vec![p.clone()]),
-        }
-    }
-}
-
 #[term($trait_id ( $,parameters ))]
 pub struct TraitRef {
     pub trait_id: TraitId,
@@ -173,20 +182,3 @@ impl TraitId {
         self.with(self_ty, Vec::<Parameter>::new())
     }
 }
-
-pub trait Debone {
-    fn debone(&self) -> (Skeleton, Vec<Parameter>);
-}
-
-macro_rules! debone_impl {
-    ($t:ty) => {
-        impl Debone for $t {
-            fn debone(&self) -> (Skeleton, Vec<Parameter>) {
-                self.debone()
-            }
-        }
-    };
-}
-
-debone_impl!(Predicate);
-debone_impl!(Relation);

--- a/crates/formality-rust/src/grammar/traits_and_impls.rs
+++ b/crates/formality-rust/src/grammar/traits_and_impls.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
+use crate::grammar::Fn;
 use crate::grammar::{
     AliasTy, AssociatedItemId, Binder, Const, Fallible, Lt, Parameter, ParameterKind, Predicate,
     TraitId, TraitRef, Ty, Wc, Wcs,
 };
-use crate::grammar::{Fn, Relation};
 use crate::prove::Safety;
 use crate::rust::Term;
 use formality_core::{term, Upcast};
@@ -166,11 +166,11 @@ impl WhereClause {
                 Predicate::well_formed_trait_ref(trait_id.with(self_ty, parameters)).upcast()
             }
             WhereClause::AliasEq(alias_ty, ty) => {
-                [Relation::well_formed(alias_ty), Relation::well_formed(ty)]
+                [Predicate::well_formed(alias_ty), Predicate::well_formed(ty)]
                     .into_iter()
                     .collect()
             }
-            WhereClause::Outlives(a, b) => [Relation::well_formed(a), Relation::well_formed(b)]
+            WhereClause::Outlives(a, b) => [Predicate::well_formed(a), Predicate::well_formed(b)]
                 .into_iter()
                 .collect(),
             WhereClause::ForAll(binder) => {
@@ -181,7 +181,7 @@ impl WhereClause {
                     .collect()
             }
             WhereClause::TypeOfConst(ct, ty) => {
-                [Relation::well_formed(ct), Relation::well_formed(ty)]
+                [Predicate::well_formed(ct), Predicate::well_formed(ty)]
                     .into_iter()
                     .collect()
             }

--- a/crates/formality-rust/src/grammar/wc.rs
+++ b/crates/formality-rust/src/grammar/wc.rs
@@ -6,7 +6,7 @@ use formality_core::{
 
 use crate::{grammar::WhereClause, prove::ToWcs};
 
-use super::{Binder, Parameter, Predicate, Relation, TraitRef};
+use super::{Binder, Parameter, Predicate, TraitRef};
 
 #[term($set)]
 #[derive(Default)]
@@ -26,7 +26,7 @@ impl Wcs {
         assert_eq!(a.len(), b.len());
         a.into_iter()
             .zip(b)
-            .map(|(a, b)| Relation::equals(a, b))
+            .map(|(a, b)| Predicate::equals(a, b))
             .collect()
     }
 
@@ -39,7 +39,7 @@ impl Wcs {
         assert_eq!(a.len(), b.len());
         a.into_iter()
             .zip(b)
-            .map(|(a, b)| Relation::sub(a, b))
+            .map(|(a, b)| Predicate::sub(a, b))
             .collect()
     }
 
@@ -47,7 +47,7 @@ impl Wcs {
     pub fn all_outlives(a: impl Upcast<Vec<Parameter>>, b: impl Upcast<Parameter>) -> Wcs {
         let a: Vec<Parameter> = a.upcast();
         let b: Parameter = b.upcast();
-        a.into_iter().map(|a| Relation::outlives(a, &b)).collect()
+        a.into_iter().map(|a| Predicate::outlives(a, &b)).collect()
     }
 
     /// Iterate over where-clauses
@@ -147,10 +147,6 @@ impl DowncastTo<()> for Wcs {
 
 #[term]
 pub enum Wc {
-    /// Means the built-in relation holds.
-    #[cast]
-    Relation(Relation),
-
     /// Means the predicate holds.
     #[cast]
     Predicate(Predicate),
@@ -184,6 +180,5 @@ impl DowncastTo<Wc> for Wcs {
     }
 }
 
-cast_impl!((Relation) <: (Wc) <: (Wcs));
 cast_impl!((Predicate) <: (Wc) <: (Wcs));
 cast_impl!((TraitRef) <: (Wc) <: (Wcs));

--- a/crates/formality-rust/src/prove.rs
+++ b/crates/formality-rust/src/prove.rs
@@ -7,7 +7,7 @@
 //! * [`prove`][] -- prove a set of where-clauses to be true
 //! * [`prove_normalize`][] -- normalize a type one step (typically used in a recursive setup)
 
-use crate::grammar::{Binder, Crates, Predicate, Relation, Ty, Wc, Wcs, WhereBound, WhereClause};
+use crate::grammar::{Binder, Crates, Predicate, Ty, Wc, Wcs, WhereBound, WhereClause};
 use crate::rust::FormalityLang;
 use formality_core::judgment::{EachProof, FailedRule, FailureLocation, ProofTree};
 use formality_core::visit::CoreVisit;
@@ -157,7 +157,6 @@ upcast_to_wcs! {
     Wc,
     Wcs,
     Predicate,
-    Relation,
 }
 
 impl ToWcs for () {
@@ -215,7 +214,7 @@ impl ToWcs for WhereClause {
             WhereClause::AliasEq(alias_ty, ty) => {
                 Predicate::AliasEq(alias_ty.clone(), ty.clone()).upcast()
             }
-            WhereClause::Outlives(a, b) => Relation::outlives(a, b).upcast(),
+            WhereClause::Outlives(a, b) => Predicate::outlives(a, b).upcast(),
             WhereClause::ForAll(binder) => {
                 let (vars, wc) = binder.open();
                 wc.to_wcs()
@@ -238,7 +237,7 @@ impl WhereBound {
             WhereBound::IsImplemented(trait_id, parameters) => {
                 trait_id.with(self_ty, parameters).upcast()
             }
-            WhereBound::Outlives(lt) => Relation::outlives(self_ty, lt).upcast(),
+            WhereBound::Outlives(lt) => Predicate::outlives(self_ty, lt).upcast(),
             WhereBound::ForAll(binder) => {
                 let (vars, bound) = binder.open();
                 Wc::for_all(Binder::new(&vars, bound.to_wc(self_ty)))

--- a/crates/formality-rust/src/prove/decls.rs
+++ b/crates/formality-rust/src/prove/decls.rs
@@ -1,8 +1,8 @@
 use crate::grammar::{
     AdtId, AliasName, AliasTy, AssociatedTyValue, AssociatedTyValueBoundData, Binder, Crate,
     CrateId, CrateItem, Crates, ImplItem, NegTraitImpl, NegTraitImplBoundData, Parameter,
-    Predicate, Relation, Trait, TraitBoundData, TraitId, TraitImpl, TraitImplBoundData, TraitRef,
-    Ty, Wc, Wcs,
+    Predicate, Trait, TraitBoundData, TraitId, TraitImpl, TraitImplBoundData, TraitRef, Ty, Wc,
+    Wcs,
 };
 use crate::prove::ToWcs;
 use formality_core::{seq, Downcasted, Set, To, Upcast, Upcasted};
@@ -342,9 +342,8 @@ impl TraitDecl {
                 Wc::Predicate(Predicate::IsImplemented(trait_ref)) => {
                     trait_ref.parameters[0] == *self_var
                 }
-                Wc::Relation(Relation::Outlives(a, _)) => *a == *self_var,
+                Wc::Predicate(Predicate::Outlives(a, _)) => *a == *self_var,
                 Wc::Predicate(_) => false,
-                Wc::Relation(_) => false,
                 Wc::ForAll(binder) => is_supertrait(self_var, binder.peek()),
                 Wc::Implies(_, c) => is_supertrait(self_var, c),
             }

--- a/crates/formality-rust/src/prove/prove_eq.rs
+++ b/crates/formality-rust/src/prove/prove_eq.rs
@@ -1,5 +1,5 @@
 use crate::grammar::{
-    AliasTy, ExistentialVar, Parameter, Relation, RigidTy, Substitution, Ty, UniversalVar,
+    AliasTy, ExistentialVar, Parameter, Predicate, RigidTy, Substitution, Ty, UniversalVar,
     Variable, Wcs,
 };
 use crate::prove::Constrained;
@@ -16,8 +16,8 @@ use crate::prove::{
 use super::{constraints::Constraints, env::Env};
 
 /// Goal(s) to prove `a` and `b` are equal
-pub fn eq(a: impl Upcast<Parameter>, b: impl Upcast<Parameter>) -> Relation {
-    Relation::equals(a, b)
+pub fn eq(a: impl Upcast<Parameter>, b: impl Upcast<Parameter>) -> Predicate {
+    Predicate::equals(a, b)
 }
 
 judgment_fn! {

--- a/crates/formality-rust/src/prove/prove_normalize.rs
+++ b/crates/formality-rust/src/prove/prove_normalize.rs
@@ -1,5 +1,5 @@
 use crate::{
-    grammar::{AliasTy, ExistentialVar, Parameter, Relation, RigidTy, Ty, Variable, Wc, Wcs},
+    grammar::{AliasTy, ExistentialVar, Parameter, Predicate, RigidTy, Ty, Variable, Wc, Wcs},
     prove::Constrained,
 };
 use formality_core::{judgment_fn, Downcast};
@@ -71,14 +71,14 @@ judgment_fn! {
             (if let Some(Variable::ExistentialVar(v_a)) = a.downcast())
             (if v_goal == v_a)!
             ----------------------------- ("var-axiom-l")
-            (prove_normalize_via(_decls, env, _assumptions, Relation::Equals(a, b), Variable::ExistentialVar(v_goal)) => Constrained::none(env, b))
+            (prove_normalize_via(_decls, env, _assumptions, Predicate::Equals(a, b), Variable::ExistentialVar(v_goal)) => Constrained::none(env, b))
         )
 
         (
             (if let Some(Variable::ExistentialVar(v_a)) = a.downcast())
             (if v_goal == v_a)!
             ----------------------------- ("var-axiom-r")
-            (prove_normalize_via(_decls, env, _assumptions, Relation::Equals(b, a), Variable::ExistentialVar(v_goal)) => Constrained::none(env, b))
+            (prove_normalize_via(_decls, env, _assumptions, Predicate::Equals(b, a), Variable::ExistentialVar(v_goal)) => Constrained::none(env, b))
         )
 
         // The following 2 rules handle normalization of a type `X` given an assumption `X = Y`.
@@ -95,7 +95,7 @@ judgment_fn! {
             (prove_syntactically_eq(decls, env, assumptions, a, goal) => c)
             (let b = c.substitution().apply(b))
             ----------------------------- ("axiom-l")
-            (prove_normalize_via(decls, env, assumptions, Relation::Equals(a, b), goal) => Constrained(b, c))
+            (prove_normalize_via(decls, env, assumptions, Predicate::Equals(a, b), goal) => Constrained(b, c))
         )
 
         (
@@ -104,7 +104,7 @@ judgment_fn! {
             (prove_syntactically_eq(decls, env, assumptions, a, goal) => c)
             (let b = c.substitution().apply(b))
             ----------------------------- ("axiom-r")
-            (prove_normalize_via(decls, env, assumptions, Relation::Equals(b, a), goal) => Constrained(b, c))
+            (prove_normalize_via(decls, env, assumptions, Predicate::Equals(b, a), goal) => Constrained(b, c))
         )
 
         // These rules handle the the ∀ and ⇒ cases.

--- a/crates/formality-rust/src/prove/prove_outlives.rs
+++ b/crates/formality-rust/src/prove/prove_outlives.rs
@@ -1,5 +1,5 @@
 use crate::grammar::Wc;
-use crate::grammar::{Lt, Parameter, Relation, RigidTy, Wcs};
+use crate::grammar::{Lt, Parameter, Predicate, RigidTy, Wcs};
 use crate::prove::{decls::Program, prove};
 use formality_core::{judgment_fn, Set, Upcast};
 
@@ -87,7 +87,7 @@ judgment_fn! {
             (if env.allow_pending_outlives())!
             ----------------------------- ("anything can be pending")
             (prove_outlives(_decls, env, _assumptions, a, b) => Constraints::none(
-                env.with_pending(Relation::outlives(a, b))
+                env.with_pending(Predicate::outlives(a, b))
             ))
         )
     }
@@ -107,11 +107,11 @@ fn transitively_outlived_by(
     let mut worklist = vec![r1.clone()];
 
     // Take all the outlives assumptions.
-    let outlives_assumptions: Vec<Relation> = assumptions
+    let outlives_assumptions: Vec<Predicate> = assumptions
         .iter()
         .filter_map(|wc| {
-            if let Wc::Relation(Relation::Outlives(r1, r2)) = wc {
-                return Some(Relation::Outlives(r1, r2));
+            if let Wc::Predicate(Predicate::Outlives(r1, r2)) = wc {
+                return Some(Predicate::Outlives(r1, r2));
             }
             None
         })
@@ -120,7 +120,7 @@ fn transitively_outlived_by(
     // Find the set of lifetime that is transitively outlived by r1.
     while let Some(current) = worklist.pop() {
         for relation in outlives_assumptions.iter() {
-            let Relation::Outlives(r1, r2) = relation else {
+            let Predicate::Outlives(r1, r2) = relation else {
                 panic!("we should only have outlive relation here");
             };
 

--- a/crates/formality-rust/src/prove/prove_sub.rs
+++ b/crates/formality-rust/src/prove/prove_sub.rs
@@ -1,4 +1,4 @@
-use crate::grammar::{Lt, Parameter, Relation, RigidTy, Ty, Wcs};
+use crate::grammar::{Lt, Parameter, Predicate, RigidTy, Ty, Wcs};
 use crate::prove::Constrained;
 use formality_core::judgment_fn;
 
@@ -25,14 +25,14 @@ judgment_fn! {
 
         (
             (prove_normalize(decls, env, assumptions, x) => Constrained(y, c))
-            (prove_after(decls, c, assumptions, Relation::sub(y, z)) => c)
+            (prove_after(decls, c, assumptions, Predicate::sub(y, z)) => c)
             ----------------------------- ("normalize-l")
             (prove_sub(decls, env, assumptions, x, z) => c)
         )
 
         (
             (prove_normalize(decls, env, assumptions, y) => Constrained(z, c))
-            (prove_after(decls, c, assumptions, Relation::sub(x, &z)) => c)
+            (prove_after(decls, c, assumptions, Predicate::sub(x, &z)) => c)
             ----------------------------- ("normalize-r")
             (prove_sub(decls, env, assumptions, x, y) => c)
         )

--- a/crates/formality-rust/src/prove/prove_via.rs
+++ b/crates/formality-rust/src/prove/prove_via.rs
@@ -26,6 +26,7 @@ judgment_fn! {
             (let (skel_c, parameters_c) = pred_1.debone())
             // `g` = "goal, the name for something that we are trying to prove.
             (let (skel_g, parameters_g) = pred_2.debone())
+            (if !skel_c.is_relation())
             (if skel_c == skel_g)!
             (prove(decls, env, assumptions, Wcs::all_eq(parameters_c, parameters_g)) => c)
             ----------------------------- ("predicate-congruence-axiom")
@@ -35,10 +36,11 @@ judgment_fn! {
         (
             (let (skel_c, parameters_c) = rel_1.debone())
             (let (skel_g, parameters_g) = rel_2.debone())
+            (if skel_c.is_relation())
             (if skel_c == skel_g)
             (if parameters_c == parameters_g)! // for relations, we require 100% match
             ----------------------------- ("relation-axiom")
-            (prove_via(_decls, env, _assumptions, Wc::Relation(rel_1), Wc::Relation(rel_2)) => Constraints::none(env))
+            (prove_via(_decls, env, _assumptions, Wc::Predicate(rel_1), Wc::Predicate(rel_2)) => Constraints::none(env))
         )
 
         // If you have `where for<'a> T: Trait<'a>` then you can prove `T: Trait<'b>` for any `'b`.

--- a/crates/formality-rust/src/prove/prove_wc.rs
+++ b/crates/formality-rust/src/prove/prove_wc.rs
@@ -1,4 +1,4 @@
-use crate::grammar::{Predicate, Relation, Wc, Wcs};
+use crate::grammar::{Predicate, Wc, Wcs};
 use formality_core::judgment_fn;
 
 use crate::prove::{
@@ -46,14 +46,8 @@ judgment_fn! {
         (
             (a in assumptions)!
             (prove_via(decls, env, assumptions, a, goal) => c)
-            ----------------------------- ("assumption - predicate")
+            ----------------------------- ("assumption")
             (prove_wc(decls, env, assumptions, Wc::Predicate(goal)) => c)
-        )
-        (
-            (a in assumptions)!
-            (prove_via(decls, env, assumptions, a, goal) => c)
-            ----------------------------- ("assumption - relation")
-            (prove_wc(decls, env, assumptions, Wc::Relation(goal)) => c)
         )
 
 
@@ -124,13 +118,13 @@ judgment_fn! {
         (
             (prove_eq(decls, env, assumptions, a, b) => c)
             ----------------------------- ("eq")
-            (prove_wc(decls, env, assumptions, Relation::Equals(a, b)) => c)
+            (prove_wc(decls, env, assumptions, Predicate::Equals(a, b)) => c)
         )
 
         (
             (prove_sub(decls, env, assumptions, a, b) => c)
             ----------------------------- ("subtype")
-            (prove_wc(decls, env, assumptions, Wc::Relation(Relation::Sub(a, b))) => c)
+            (prove_wc(decls, env, assumptions, Predicate::Sub(a, b)) => c)
         )
 
         (
@@ -151,19 +145,19 @@ judgment_fn! {
         (
             (prove_outlives(decls, env, assumptions, a, b) => c)
             ----------------------------- ("outlives")
-            (prove_wc(decls, env, assumptions, Relation::Outlives(a, b)) => c)
+            (prove_wc(decls, env, assumptions, Predicate::Outlives(a, b)) => c)
         )
 
 
         (
             (prove_wf(decls, env, assumptions, p) => c)
             ----------------------------- ("parameter well formed")
-            (prove_wc(decls, env, assumptions, Relation::WellFormed(p)) => c)
+            (prove_wc(decls, env, assumptions, Predicate::WellFormed(p)) => c)
         )
 
         (
             (prove_const_has_type(decls, env, assumptions, constant) => (ty_constant, c))
-            (prove_after(decls, c, assumptions, Relation::equals(ty_constant, ty)) => c)
+            (prove_after(decls, c, assumptions, Predicate::equals(ty_constant, ty)) => c)
             ----------------------------- ("const has ty")
             (prove_wc(decls, env, assumptions, Predicate::ConstHasType(constant, ty)) => c)
         )

--- a/crates/formality-rust/src/prove/prove_wf.rs
+++ b/crates/formality-rust/src/prove/prove_wf.rs
@@ -1,5 +1,5 @@
 use crate::grammar::{
-    AliasName, AliasTy, Const, Lt, Parameter, Parameters, Relation, RigidName, RigidTy, Ty,
+    AliasName, AliasTy, Const, Lt, Parameter, Parameters, Predicate, RigidName, RigidTy, Ty,
     UniversalVar, Wcs,
 };
 use formality_core::{judgment_fn, Downcast, ProvenSet, Upcast};
@@ -32,7 +32,7 @@ judgment_fn! {
             // `&'a T` is well-formed if `T: 'a`
             (let (lt, ty) = parameters.downcast_err::<(Lt, Ty)>()?)
             (prove_wf_recursive(decls, env, assumptions, ty) => c)
-            (prove_after(decls, c, assumptions, Relation::outlives(ty, lt)) => c)
+            (prove_after(decls, c, assumptions, Predicate::outlives(ty, lt)) => c)
             --- ("references")
             (prove_wf(decls, env, assumptions, RigidTy { name: RigidName::Ref(_), parameters }) => c)
         )
@@ -101,5 +101,5 @@ pub fn prove_wf_recursive(
     assumptions: impl Upcast<Wcs>,
     param: impl Upcast<Parameter>,
 ) -> ProvenSet<Constraints> {
-    prove(program, env, assumptions, Relation::well_formed(param))
+    prove(program, env, assumptions, Predicate::well_formed(param))
 }

--- a/crates/formality-rust/src/prove/test/adt_wf.rs
+++ b/crates/formality-rust/src/prove/test/adt_wf.rs
@@ -1,4 +1,4 @@
-use crate::grammar::{Parameter, Relation, Wcs};
+use crate::grammar::{Parameter, Predicate, Wcs};
 use crate::rust::term;
 use expect_test::expect;
 use formality_core::test;
@@ -25,7 +25,7 @@ fn well_formed_adt() {
         decls(),
         Env::default(),
         assumptions,
-        Relation::WellFormed(goal),
+        Predicate::WellFormed(goal),
     );
     constraints.assert_ok(
     expect!["{Constraints { env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false }, known_true: true, substitution: {} }}"]);
@@ -39,7 +39,7 @@ fn not_well_formed_adt() {
         decls(),
         Env::default(),
         assumptions,
-        Relation::WellFormed(goal),
+        Predicate::WellFormed(goal),
     )
     .assert_err(expect![[r#"
         crates/formality-rust/src/prove/prove_via.rs:8:1: no applicable rules for prove_via { goal: u64 = u32, via: Foo(u64), assumptions: {Foo(u64)}, env: Env { variables: [], bias: Soundness, pending: [], allow_pending_outlives: false } }


### PR DESCRIPTION
## What does this PR do?

Part of #417. Merges `Relation` into `Predicate` so there is a single atomic-goal type.

* `Predicate` gains `Equals` / `Sub` / `Outlives` / `WellFormed`, declared **before** the existing variants.
* `Relation`, its `debone()`, and the (unused) `Debone` trait + `debone_impl!` macro are deleted.
* Adds `Skeleton::is_relation()`, and drops the dead `Skeleton::IsInt` variant.
* `prove_wc`'s two byte-identical `"assumption - predicate"` / `"assumption - relation"` rules collapse into a single `"assumption"` rule.

`WhereClause` still lowers into `Wc`, and this PR does not touch that layer. Wc` survives, so the next PR in this series is a rename rather than a merge.

Also noticed while working in `grammar/formulas.rs`, and deliberately **not** fixed here: `Coinductive` is dead code (only its own definition plus a `BitAnd` impl, no other references anywhere in the workspace). Pre-existing and unrelated to this refactor, happy to remove it in a separate PR if you want it gone.

## How does it work, what questions do you have?

The merge is safe because `Skeleton`/`debone()` already lumped relations and predicates together before this PR, and nothing else in the grammar has a `Predicate` or `Relation` field, so folding the two enums into one doesn't touch anyone else's terms, but `prove_via` still needs to distinguish them, since `predicate-congruence-axiom` proves parameters equal while `relation-axiom` needs them literally identical (doing congruence on `Equals` would be circular), so now that both rules match `Wc::Predicate` instead of separate `Wc::Relation`/`Wc::Predicate` patterns, the split is handled by a `Skeleton::is_relation()` guard placed before the `!` in each rule, which keeps the same silent-skip behavior as before since `!` is the commit point for `push_rules!` failures; and finally, variant order still matters because `#[term]` derives `Ord` and `Wcs` is a sorted set so putting relations first inside `Predicate` reproduces the old `Relation | Predicate` ordering so set order and proof search order don't shift.

## AI disclosure

* I used an AI to author the main logic of the code