### PR TITLE
Wait for cargo fmt

### DIFF
--- a/crates/formality-rust/src/to_rust/mod.rs
+++ b/crates/formality-rust/src/to_rust/mod.rs
@@ -94,7 +94,7 @@ pub fn create_workspace(crates: &Crates, root_directory: &std::path::Path) -> Fa
 
     std::process::Command::new("cargo")
         .args(["fmt", "--all", "--manifest-path", location])
-        .spawn()?;
+        .status()?;
 
     Ok(location.to_string())
 }


### PR DESCRIPTION
## What does this PR do?

I have been seeing CI failures on another PR of mine: https://github.com/rust-lang/a-mir-formality/actions/runs/31603415405, which seem to be caused by deferred formatting. We used to spawn `fmt`, so it would run in the background, but now we wait for `fmt` to finish before doing anything else.

## How does it work, what questions do you have?

<!-- In your own words (**no LLM usage here**), explain the main idea of why it's correct. It's ok if you're not sure! Please include any questions you have. If you wish to use an LLM for translation, include the original as well as the translated version. Thanks! -->

## AI disclosure

<!-- Remove the items that do not apply -->

* I did not use any AI tools

